### PR TITLE
Wpotter 2022 08 12 colophon doxology label ingest

### DIFF
--- a/data/tei/1.xml
+++ b/data/tei/1.xml
@@ -166,6 +166,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p1addition1" syriaca-tags="doxology scribal-colophon">
+                    <label>Doxology</label>
                     <locus from="107b" to="107b"/>
                     <p>The doxology,</p>
                     <p>
@@ -176,6 +177,7 @@
                     </p>
                   </item>
                   <item n="2" xml:id="p1addition2" syriaca-tags="ownership-inscription">
+                    <label>Colophon</label>
                     <locus from="108a" to="108a"/>
                     <p>A note on fol.<locus>108a</locus>, states that the manuscript was written for the monks of the<placeName>convent of Nātphā</placeName>,  near<placeName>Māridīn</placeName>, at the expense of the priest<listPerson>
                         <person>
@@ -404,6 +406,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p2addition1" syriacatags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="169b" to="169b"/>
                     <p>On fol. 169b we have the following colophon:</p>
                     <!-- Mixture of production note and final rubric. -->
@@ -485,50 +488,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/10.xml
+++ b/data/tei/10.xml
@@ -560,6 +560,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                  <label>Colophon</label>
                   <locus from="310b" to="311a"/>
                   <p>On foll. 310 b and 311 a we find a series of notes, written by the same hand as
                     the rest of the book. The first three inform us that this books was written by <!--missing diacritics on the first a -->
@@ -583,6 +584,7 @@
                   </p>
                 </item>
                 <item xml:id="addition5" n="5">
+                  <label>Colophon</label>
                   <locus from="310b" to="311a"/>
                   <p>On foll. 310 b and 311 a we find a series of notes, written by the same hand as
                     the rest of the book. The second note reads:</p>
@@ -592,6 +594,7 @@
                   </p>
                 </item>
                 <item xml:id="addition6" n="6">
+                  <label>Doxology</label>
                   <locus from="310b" to="311a"/>
                   <p>On foll. 310 b and 311 a we find a series of notes, written by the same hand as
                     the rest of the book. The third note reads:</p>
@@ -602,6 +605,7 @@
                   </p>
                 </item>
                 <item xml:id="addition7" n="7">
+                  <label>Colophon</label>
                   <locus from="310b" to="311a"/>
                   <p>The next two notes state that the book was written for one <persName>Dodon of
                         <placeName>Dūra</placeName>
@@ -624,6 +628,7 @@
                   </p>
                 </item>
                 <item xml:id="addition9" n="9">
+                  <label>Colophon</label>
                   <locus from="311"/>
                   <p>Then follow the words, "<persName ref="http://syriaca.org/person/2245">Lord</persName>, let not be withhold the reward of the five pairs (of
                     fingers) that have laboured, and of the two (eyes) that have exerted themselves,
@@ -635,6 +640,7 @@
                   </p>
                 </item>
                 <item xml:id="addition10" n="10">
+                  <label>Colophon</label>
                   <locus from="311"/>
                   <p>And, "Of a truth, O reader, just as the pilot rejoices when his ship reaches
                     (the harbour and is safe) from the storms and waves of the, sea, so too the

--- a/data/tei/100.xml
+++ b/data/tei/100.xml
@@ -504,50 +504,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1002.xml
+++ b/data/tei/1002.xml
@@ -185,50 +185,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1003.xml
+++ b/data/tei/1003.xml
@@ -243,50 +243,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1004.xml
+++ b/data/tei/1004.xml
@@ -242,6 +242,7 @@
                   <p>Numerous lession, altogether 150 in number, are rubricated in the text.</p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="150b" to="150b"/>
                   <p>On fol. 150 b there is a note, stating that this manuscript was written A. Gr.<origDate when="1565" calendar="Seleucid">1565</origDate>, A.D.<origDate when="1254" calendar="Gregorian">1254</origDate>, in<origPlace>the convent of Abbā Yuhannān Zĕ'ūrā, or John the less</origPlace>, in the desert of<placeName>Scete</placeName>, by a Persian monk from<placeName>Sigistān</placeName>, named<persName>Behnām</persName>.</p>
                   <p>
@@ -249,6 +250,7 @@
                   </p>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="150b" to="150b"/>
                   <p>Another note on the same page tells us that the said<persName>Behnām</persName>presented it to<placeName>the convent of S. Mary Deipara</placeName>.</p>
                   <p>
@@ -256,6 +258,7 @@
                   </p>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="151a" to="151a"/>
                   <p>A note on fol. 151 a further informs us, that at this time<persName>Rabban Yeshua’ of<placeName>Zargol Castra</placeName>
                     </persName>, near<placeName>Hisn Kīfā</placeName>, was abbat of<placeName>the convent of S. Mary Deipara</placeName>; and that<persName>Athanasius</persName>was patriarch of<placeName>Alexandria</placeName>. See<bibl>Renaudot, Hist. part. Alexandr. Jacob., p. 599</bibl>;<bibl>Le Quien, Oriens Christ., t. ii. col. 493</bibl>.  But, the name of the occupant, of the see of<placeName>Antioch</placeName>is left blank, perhaps because of the contention between<persName>Dionysius VII</persName>and<persName>John bar Ma'dān</persName>.  See<bibl>Assemani, Bibl. Orient., t. ii. p. 376 etc</bibl>.</p>
@@ -338,50 +341,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1005.xml
+++ b/data/tei/1005.xml
@@ -382,50 +382,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1014.xml
+++ b/data/tei/1014.xml
@@ -419,6 +419,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The colophon states that this book was written <date datingMethod="Seleucid" when-custom="1795">A. Gr.
                               1795</date>, <date calendar="Gregorian" when="1484">A.D. 1484</date>, in the <placeName ref="http://syriaca.org/place/360">convent of
@@ -432,6 +433,7 @@
                            </p>
                         </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The former portion was written by one <persName>Jacob</persName>, as
                               appears from the subscription on fol. 24 b.</p>

--- a/data/tei/1015.xml
+++ b/data/tei/1015.xml
@@ -362,6 +362,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>Then follows a long note, fol. 495 b, in which the scribe, by name
                       <persName>Denhā, or Ma’rūf, bar Yūhannān Abū Sa'īd bar Abu 'l-Khair bar Abu

--- a/data/tei/1021.xml
+++ b/data/tei/1021.xml
@@ -380,6 +380,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="242a"/>
                   <p>The colophon on fol. 242 a and the following note
                     state that this book was written, <date datingMethod="Seleucid" when-custom="1595">A.Gr. 1595</date>, <date calendar="Gregorian" when="1284">A.D. 1284</date>, in the <placeName ref="http://syriaca.org/place/360">convent of S. Mary Deipara</placeName> on <placeName>the river <foreign xml:lang="ar">(كفتون)</foreign>
@@ -397,6 +398,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="242b"/>
                   <p>This, the first of the Arabic notes on fol. 242 b, offers similar details as the colophon above.</p>
                   <p>

--- a/data/tei/1027.xml
+++ b/data/tei/1027.xml
@@ -307,6 +307,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The name of the scribe was <persName>John</persName>, as appears from
                               the subscriptions on foll. 41 a and 94 a.</p>

--- a/data/tei/1028.xml
+++ b/data/tei/1028.xml
@@ -245,50 +245,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/103.xml
+++ b/data/tei/103.xml
@@ -264,50 +264,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1032.xml
+++ b/data/tei/1032.xml
@@ -239,6 +239,7 @@
                 <p/>
                 <list>
                   <item xml:id="p1addition1" n="1">
+                    <label>Colophon</label>
                     <locus/>
                     <p>The name of the scribe <persName>Yeshūa' (bar Phetion)</persName> appears on fol. 125 a and fol.
                       142a</p>

--- a/data/tei/104.xml
+++ b/data/tei/104.xml
@@ -289,50 +289,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1040.xml
+++ b/data/tei/1040.xml
@@ -229,6 +229,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>The writer of the prayers on the flyleaves seems to have been the same
                       <persName>Rabban Samuel bar Mẹ̆khīr</persName>, whose name appears on the

--- a/data/tei/105.xml
+++ b/data/tei/105.xml
@@ -225,50 +225,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1053.xml
+++ b/data/tei/1053.xml
@@ -1675,50 +1675,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/106.xml
+++ b/data/tei/106.xml
@@ -559,50 +559,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1074.xml
+++ b/data/tei/1074.xml
@@ -556,50 +556,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/1085.xml
+++ b/data/tei/1085.xml
@@ -291,6 +291,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p2addition1">
+                    <label>Colophon</label>
                     <locus from="12"/>
                     <p>The subscription mentions the name of the scribe,<persName>Basil</persName>:</p>
                     <p>
@@ -738,6 +739,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p5addition1">
+                    <label>Colophon</label>
                     <locus from="42b"/>
                     <p>On the upper margin of fol. 42b we read the words:</p>
                     <p>
@@ -976,50 +978,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/109.xml
+++ b/data/tei/109.xml
@@ -601,6 +601,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p4addition1">
+                    <label>Doxology</label>
                     <locus from="144a" to="144a"/>
                     <p>On fol. 144a the final rubric is followed by the usual doxology.</p>
                   </item>
@@ -670,50 +671,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1093.xml
+++ b/data/tei/1093.xml
@@ -231,12 +231,16 @@
                 <msItem n="3" xml:id="p2b2" defective="false">
                   <locus from="41b" to="42"/>
                   <author ref="http://syriaca.org/person/51">Severus</author>
-                  <title type="supplied"><persName>S. Simeon the Aged</persName></title>
+                  <title type="supplied">
+                    <persName>S. Simeon the Aged</persName>
+                  </title>
                 </msItem>
                 <msItem n="4" xml:id="p2b3" defective="true">
                   <locus from="42b" to="43b">foll. 42b-43b</locus>
                   <author ref="http://syriaca.org/person/51">Severus</author>
-                  <title type="supplied"><placeName>Cana of Galilee</placeName></title>
+                  <title type="supplied">
+                    <placeName>Cana of Galilee</placeName>
+                  </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܩܛܢܐ<locus from="42b" to="42b"/>
                   </rubric>
                 </msItem>
@@ -573,50 +577,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1098.xml
+++ b/data/tei/1098.xml
@@ -210,50 +210,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1099.xml
+++ b/data/tei/1099.xml
@@ -446,50 +446,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/11.xml
+++ b/data/tei/11.xml
@@ -697,6 +697,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <p>At the end are the following rubric and epigraph, stating that this volume was
                     compiled by <persName ref="http://syriaca.org/person/186">Athanasius, patriarch of Antioch</persName>, and written by his disciple
                     <persName>Romanus</persName> in the year <origDate datingMethod="Seleucid" when-custom="1311">1311</origDate>, <origDate calendar="Gregorian" when="1000">A.D. 1000</origDate>.</p>
@@ -712,7 +713,8 @@
                     </quote>
                   </p>
                 </item>
-                <item xml:id="addition2" n="2">                  
+                <item xml:id="addition2" n="2">
+                  <label>Colophon</label>                  
                   <locus from="139a"/>
                   <p>On fol. 139 a, there is the following note in Estrangela characters:</p>                  
                   <p>

--- a/data/tei/1100.xml
+++ b/data/tei/1100.xml
@@ -154,6 +154,7 @@
                             <additions>
                                 <list>
                                     <item n="1" xml:id="p1addition1">
+                    <label>Colophon</label>
                                         <locus from="29" to="29"/>
                                         <p>The colophon states that it was written for one rabban Bar-saumā</p>
                                         <p>
@@ -907,50 +908,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/1108.xml
+++ b/data/tei/1108.xml
@@ -321,6 +321,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Doxology</label>
                   <locus from="109a"/>
                   <p>Colophon</p>
                   <p>

--- a/data/tei/1110.xml
+++ b/data/tei/1110.xml
@@ -181,6 +181,7 @@
                   <p>The short marginal notes seem all to refer to the punctuation and reading of the text.</p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="196a" to="196a"/>
                   <p>The colophon, fol. 196 a, states that this manuscript was written by one<persName>Moses</persName>, in the year<ref target="#handNote1">above mentioned</ref>, in a convent, the name of which has been erased.</p>
                   <p>
@@ -249,50 +250,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1111.xml
+++ b/data/tei/1111.xml
@@ -1091,6 +1091,7 @@
             <additions>
               <list>
                 <item>
+                  <label>Colophon</label>
                   <locus from="172a"/>
                   <p>The colophon, fol. 172 a, states that this manuscript was written at <placeName>Mosul</placeName>, in <placeName>the convent of Hormisdas or Hormuzd</placeName>, by one <persName>'Ebed-yeshūa'</persName>, for <persName>the priest Mārī</persName>. Owing to a rent in the leaf, the date has been rendered in part illegible, but the words <foreign xml:lang="syr">ܐܬܟܬ[ܒ]. . . ܬܠܬܡܐ[ܐ] . . . ܘܚܡܫ</foreign> are still quite clear. The date ust therefore lie between <date>A. Gr. 1325—95</date>, <date>A.D. 1014—84</date>. From some faint traces of letters it appears to be most probably <date>A. Gr. 1385</date>, <date>A. D. 1074</date>.</p>
                   <p>

--- a/data/tei/1112.xml
+++ b/data/tei/1112.xml
@@ -204,6 +204,7 @@
                   <p>On fol. 1 a there are notes in Syriac, Arabic, and Karshūnī, but all more or less stained and effaced.</p>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="316a" to="316a"/>
                   <p>On fol. 316 a there is a note, stating that this volume was written<origDate when-custom="1719" datingMethod="Seleucid">A. Gr. 1719</origDate>(<origDate when="1438" calendar="Gregorian">A.D. 1438</origDate>), in the<placeName>village of ‘Akūrtā</placeName>on<placeName>Mount Lebanon</placeName>, by a priest named<persName>Theodore</persName>, for the archdeacon<persName>Abraham bar Theodore</persName>.</p>
                   <p>
@@ -211,6 +212,7 @@
                   </p>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="316b" to="316b"/>
                   <p>There is a note, written by the<ref target="#handNote1">above mentioned Theodore</ref>, in which he says that all<ref target="#decoNote1">these ornaments</ref>were the work of the priest<persName>Kamar</persName>from the village of<placeName>Dair Balī</placeName>.</p>
                   <p>
@@ -292,50 +294,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1113.xml
+++ b/data/tei/1113.xml
@@ -256,6 +256,7 @@
               <p>The colophon,<locus>fol. 137a</locus>, gives the date of the composition of the work, A. Gr. 1590, A.D. 1279 ; and states that this manuscript was written by<persName>Behnam bar Simeon</persName>, metropolitan of<placeName ref="http://syriaca.org/place/995">Antioch</placeName>, at the<placeName ref="http://syriaca.org/place/335">convent of Mar Abhai</placeName>, called " of the Ladder," A. Gr. 1911, A.D. 1603.</p>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="137a" to="137a"/>
                   <p>
                     <quote xml:lang="syr">ܫܠ̣ܡ ܟܬܒܐ ܕܐܝ̣ܬܝܩܘܢ ܕܥܠ ܡܝܬܪܘܼܬܐ ܕܕܘܼܒܪ̈ܐ ܙܢ̈ܢܝܐ ܕܢܦܫܐ ܘܕܦܓܪܐ ܡ̣ܢ ܣܝ̈ܡܐ ܕܐܒܘܢ ܡܪܝ ܓܪܝܓܘܪܝܘܣ ܡܦܪܝܢܐ ܡܢ̇ܚ ܢܦܫܐ ܐܒܘ ܐܠܦܪܓ ܒܪ ܐܗܪܘܢ ܐܣ̇ܝܐ ܡܝܠܝܛܝܢܝܐ̣. ܕܛܟܣ̣ܗ ܒܫܢܬ݀ ܐ܏ܢܨ ܝܲܘܢܝܬܐ̣. ܒܐܝ̣̈ܕܝ ܡܚܝ̣ܠܐ ܘܬܚܘܼܒܐ ܐܢܫ ܕܡܬ݂ܟܢܐ ܡ̇ܢ ܒܫܡܐ ܡܝܛܪ܏ܘܦܘ ܕܟܘܪܣܝܐ ܕܫܠ̣ܝܚܐ ܝܲܥܩܘܿܒ ܐܚܘܼܗܝ ܕܡܪܢ̣. ܒܗܢܐܡ ܒܪ ܫܡܥܘܢ ܡܢ̇ܚܐ ܟܕ ܡܬ݂ܬܟܣܢܢ ܗ̇ܘܝܬ ܒܥܘܼܡܪܐ ܟܗܢܝܐ ܕܡܪܝ ܐܒܚܝ ܕܕܣܒܠܬܐ ܡܬ݂ܟܲܢܐ. ܘܒܗ ܒܥܘܡܪܐ ܗܘ̣ܐ ܫܘܼܪܝܗ ܘܫܘܠܡܗ ܒܫܢܬ݀ ܏ܐܨܝܕ܀ ܕܩ̇ܪܐ ܢܨ̇ܠܐ ܥܠܝ ܘܥܠ ܐܒܗ̈ܝ܀</quote>
@@ -321,50 +322,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1115.xml
+++ b/data/tei/1115.xml
@@ -565,6 +565,7 @@
                   </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="133a"/>
                   <p>A note on fol. 133 a states that <ref>the lessons for Passion
                     Week</ref> were compiled by <persName>Daniel the blind,
@@ -631,6 +632,7 @@
                                     </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="193"/>
                   <p>The second of two notes concerning the manuscript's origin (see <ref>above</ref>), written on fol. 193, reads:</p>
                   <p>

--- a/data/tei/1115.xml
+++ b/data/tei/1115.xml
@@ -582,6 +582,7 @@
                   </p>
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="193b"/>
                   <p>Colophon</p>
                   <p>
@@ -591,6 +592,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="192b"/>
                   <p>The notes on foll. 192 b and 193 a state that this manuscript
                                         was written in the year <date>1525</date> (<date>A.D.

--- a/data/tei/1116.xml
+++ b/data/tei/1116.xml
@@ -322,6 +322,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="155b" to="155b"/>
                   <ref target="#addition2 #a4 #handNote2"/>
                   <p>This manuscript seems, as stated above, to be of the xiith cent. However, on fol.<locus>155b</locus>, at the end of the Lamentations of Jeremiah, there is added, in a much later hand, the date A. Gr.<date>1097</date>, A.D.<date>786</date>(!):<quote xml:lang="syr">ܫܢ̣ܬ݀ ܐܠܦ ܘܰܫܒ̣ܥ ܘܬܫܥܝܢ ܕܝܘܢ̈ܝܐ: ܨܠ̇ܘ ܥܠ ܟܬܘܒܐ  ܡܚܝܼܠܐ</quote>
@@ -334,6 +335,7 @@
                   </p>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="colophon-incertus">
+                  <label>Colophon</label>
                   <locus from="39a" to="39a"/>
                   <p>The name of the scribe appears to have been<persName resp="scribe">Bar-saumā</persName>. At least, on the lower margin of fol. 39a, there is written in the same ink as the text:</p>
                   <p>
@@ -440,50 +442,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1118.xml
+++ b/data/tei/1118.xml
@@ -253,50 +253,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1120.xml
+++ b/data/tei/1120.xml
@@ -873,50 +873,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/1123.xml
+++ b/data/tei/1123.xml
@@ -371,50 +371,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1125.xml
+++ b/data/tei/1125.xml
@@ -969,50 +969,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/1126.xml
+++ b/data/tei/1126.xml
@@ -226,50 +226,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1134.xml
+++ b/data/tei/1134.xml
@@ -252,6 +252,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Doxology</label>
                            <locus/>
                            <p>The colophon, fol. 17 a, states that the volume originally comprised
                               219 poems and 166 letters of <persName ref="http://syriaca.org/person/511">Gregory Theologus</persName>.</p>

--- a/data/tei/1135.xml
+++ b/data/tei/1135.xml
@@ -217,6 +217,7 @@
               <p/>
               <list>
                 <item xml:id="p1addition1" n="1">
+                    <label>Colophon</label>
                            <locus from="110b"/>
                            <p>A note on fol. 110 b gives the date and the name of the scribe,
                                  <persName>Joseph bar 'Antar</persName>; but the name of his village

--- a/data/tei/1136.xml
+++ b/data/tei/1136.xml
@@ -504,6 +504,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="33a"/>
                   <p>In the subscription to the discourse "On the Massacre of the Innocents", fol. 33 a, the scribe gives his name,
                     <persName>Zaina</persName>
@@ -513,6 +514,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="132a"/>
                   <p>Subscription for the discourse "On the Invention of the Cross", in which the scribe mentions his name, <persName>Abu 'l-Khair</persName>
                   </p>
@@ -524,6 +526,7 @@
                   </p>
                 </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                   <locus from="184a"/>
                   <p>In the subscription of the discourse "On the Ordination of Bishops, Priests, and Deacons", fol. 184 a, the scribe gives his name, <persName>George</persName>:</p>
                   <p>
@@ -531,6 +534,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                  <label>Colophon</label>
                   <locus from="197a"/>
                   <p>In the subscription for the discourse "On the Consecration of the Chrism", fol. 197 a, the scribe again mentions his name, <persName>George</persName>, and the
                     date, <origDate datingMethod="Seleucid" when-custom="1553">A. Gr. 1553</origDate>, <origDate calendar="Gregorian" when="1242">A.D. 1242</origDate>.</p>
@@ -540,6 +544,7 @@
                   </p>
                 </item>
                 <item xml:id="addition5" n="5">
+                  <label>Colophon</label>
                   <locus from="199a"/>
                   <p>The subscription for the discourse by Rabban Daniel, fol. 199 a, informs us that the manuscript was written in <placeName ref="http://syriaca.org/place/2107">the
                     church of S. Thomas the Apostle</placeName> at <placeName ref="https://www.syriaca.org/place/139">Mosul</placeName>, for the monk <persName>Abu 'l-Khair</persName>, a priest of
@@ -719,6 +724,7 @@
                   </p>
                 </item>
                 <item xml:id="addition22" n="22">
+                  <label>Colophon</label>
                   <locus from="134a"/>
                   <p>A note, partially effaced, written by a monk of <placeName ref="http://syriaca.org/place/5">Adarbaijan</placeName>, named <persName>Gregory</persName>.</p>
                   <p>

--- a/data/tei/1137.xml
+++ b/data/tei/1137.xml
@@ -176,6 +176,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The colophon, fol. 42 b, states that the manuscript was written by one
                               <persName>Murad</persName>, in <placeName>the village of Azikh</placeName>, <date datingMethod="Seleucid" when-custom="2142">A. Gr. 2142</date>, <date calendar="Gregorian" when="1831">A.D. 1831</date>, when

--- a/data/tei/1138.xml
+++ b/data/tei/1138.xml
@@ -408,50 +408,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/114.xml
+++ b/data/tei/114.xml
@@ -343,50 +343,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1140.xml
+++ b/data/tei/1140.xml
@@ -198,6 +198,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="26b" to="26b"/>
                   <p>The subscription,<locus from="26b">fol. 26 b</locus>, gives the name of the scribe,<persName>Mubārak</persName>
                   </p>
@@ -283,50 +284,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1141.xml
+++ b/data/tei/1141.xml
@@ -287,6 +287,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>The colophon, fol. 422 b, states that the volume was written by the priest
                       <persName>Sulaimān ibn Mūsā al-Kaiyāl</persName>, <date when-custom="2031" calendar="Seleucid">A. Gr. 2031</date>, <date calendar="Gregorian" when="1720">A.D. 1720</date>, when <persName>Mār Ignatius [Ignatius XXVI</persName>.
@@ -311,6 +312,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>There is a similar note on fol. 303 b, at the end of the book of
                                  <persName>Daniel</persName>.</p>

--- a/data/tei/1143.xml
+++ b/data/tei/1143.xml
@@ -173,6 +173,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>The subscription, fol. 49 a, sates that this manuscript was written by the
                     deacon <persName>Michael</persName>, son of the metropolitan <persName>Basil, of

--- a/data/tei/1144.xml
+++ b/data/tei/1144.xml
@@ -355,6 +355,7 @@
                   </p>
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="361a"/>
                   <p>The colophon, <locus>fol 361a</locus>, is similar to the previous ones</p>
                   <p>

--- a/data/tei/1144.xml
+++ b/data/tei/1144.xml
@@ -309,6 +309,7 @@
               <p/>
               <list>
                 <item>
+                  <label>Colophon</label>
                   <locus from="81a"/>
                   <p>The subscription to <title>An extract regarding Nebuchadnezzar from a discourse of
                     John Chrysostom on the Fast of Daniel and his Companions</title>, <locus>fol. 81 a</locus>, states that the book
@@ -321,6 +322,7 @@
                   </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="157b"/>
                   <p>The subscription to <title>The Bee, compiled by Solomon, metropolitan of Pĕrath #Maishān or al-Baṣra</title>, <locus>fol. 157 b</locus>, states that the book
                     was written by the same scribe as <ref>no. 7</ref>, at the expense of the priest
@@ -338,6 +340,7 @@
                   </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="232a"/>
                   <p>The colophon to <title/>, <locus>fol. 232 a</locus>, states that the
                     work was written by the same scribe as the previous ones, in the year <date calendar="Seleucid">2020</date>, <date>A.D.

--- a/data/tei/1145.xml
+++ b/data/tei/1145.xml
@@ -479,6 +479,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                                     <locus from="307a"/>
                                     <p>The colophon, fol. 307 a, states that <title>the last tract</title> was
                                         written by the deacon <persName>Homo</persName>, A. Gr.

--- a/data/tei/1145.xml
+++ b/data/tei/1145.xml
@@ -461,6 +461,7 @@
                   </p>
                                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="290b"/>
                   <p>On <locus>fol. 290 b</locus> we find the name of the scribe, the <persName>deacon Marauge</persName>
                   </p>
@@ -469,6 +470,7 @@
                   </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="290b"/>
                   <p>Beneath the scribe's name we find part of the colophon</p>
                   <p>

--- a/data/tei/1146.xml
+++ b/data/tei/1146.xml
@@ -128,6 +128,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The colophon, fol. 86 b. states that the manuscript was written in the
                               year above mentioned by one <persName>Hurmiz of

--- a/data/tei/1151.xml
+++ b/data/tei/1151.xml
@@ -847,6 +847,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="186a"/>
                   <p>The colophon, fol. 186 a, is very much mutilated. It informs
                                         us that this Lectionary was drawn up according to the use of

--- a/data/tei/1152.xml
+++ b/data/tei/1152.xml
@@ -191,6 +191,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The colophon, fol. 31 a, states that the book was written, <date calendar="Gregorian" when="1683">A.D. 1683</date>,
                               by the (Roman Catholic) <persName ref="http://syriaca.org/person/812">patriarch Joseph I</persName>., <note>See

--- a/data/tei/1153.xml
+++ b/data/tei/1153.xml
@@ -501,6 +501,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <label/>
                   <locus from="47b">Fol. 47b</locus>
                   <quote xml:lang="syr">
@@ -510,6 +511,7 @@
                                         ܕܡܪܕܐ ܐܘܟܝܬ ܡܐܪܕܝܢ ܡܕܝܢܬܐ.</quote>
                 </item>
                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                   <label/>
                   <locus from="77a">Fol. 77a</locus>
                   <quote xml:lang="syr">
@@ -520,11 +522,13 @@
                                         ܕܝܿܠܕܬ݀ ܐܠܗܐ ܡܪܝܡ ܕܡܬܟܲܢܐ ܕܒܝܬ ܡܪܩܘܣ..</quote>
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <label/>
                   <p>
                     <ref target="#Abr_b_Yesh"/>See also<locus from="165b">Foll. 165b</locus>and<locus from="320a">320a</locus>.</p>
                 </item>
                 <item n="4" xml:id="addition4">
+                  <label>Colophon</label>
                   <label/>
                   <locus from="199-200">Foll. 199-200</locus>
                   <quote xml:lang="syr">
@@ -625,50 +629,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/1155.xml
+++ b/data/tei/1155.xml
@@ -202,6 +202,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>A note on fol. 174 b informs us that the book was written by
                       <persName>Moses</persName>, <note>Apparently the well known <persName>Moses
@@ -232,6 +233,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The name of the writer and the date are repeated in the ornamental
                               device on fol. 178 a,where we read: i.e. <date datingMethod="Seleucid" when-custom="1860">A. Gr. 1860</date>,

--- a/data/tei/1157.xml
+++ b/data/tei/1157.xml
@@ -215,6 +215,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>At the end of the first part of the volume, on fol. 105 a, there is a
                               note, which states that it was written by <persName>Maryam (Mary)</persName>, the
@@ -242,6 +243,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>Similarly, on fol. 85 a.</p>
                            <p>
@@ -251,6 +253,7 @@
                            </p>
                         </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                            <locus/>
                            <p>At the end of the second part, fol. 171 a, is the following note,
                               giving the date <date calendar="Gregorian" when="1702">A.D. 1702</date>. </p>

--- a/data/tei/117.xml
+++ b/data/tei/117.xml
@@ -154,6 +154,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p1addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="3a"/>
                     <p>A note on the margin of fol. 3a states that<ref target="#a1">this index</ref>was drawn up by one<persName>Severus</persName>, with the aid of the priest<persName>John</persName>and the deacon and steward<persName>Romanus</persName>:</p>
                     <p>
@@ -314,6 +315,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p2addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="48a"/>
                     <p>On fol. 48a there is the following note, in the handwriting of the scribe, saying that the manuscript was written in the year<origDate when-custom="0843" datingMethod="Seleucid">843</origDate>,<origDate when="0532" calendar="Gregorian">A.D. 532</origDate>, and collated with care in the<origPlace>convent of the Orientals (at Edessa?)</origPlace>. Part of it has been intentionally erased.</p>
                     <p>
@@ -389,50 +391,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/118.xml
+++ b/data/tei/118.xml
@@ -230,50 +230,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/119.xml
+++ b/data/tei/119.xml
@@ -243,50 +243,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/12.xml
+++ b/data/tei/12.xml
@@ -316,50 +316,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/120.xml
+++ b/data/tei/120.xml
@@ -266,6 +266,7 @@
                     </bibl>.</p>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="209b" to="209b"/>
                   <p>The date, about which there is a slight difficulty, is given as follows:</p>
                   <p>
@@ -335,50 +336,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/121.xml
+++ b/data/tei/121.xml
@@ -273,50 +273,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/122.xml
+++ b/data/tei/122.xml
@@ -296,50 +296,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/126.xml
+++ b/data/tei/126.xml
@@ -225,50 +225,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/127.xml
+++ b/data/tei/127.xml
@@ -264,50 +264,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/128.xml
+++ b/data/tei/128.xml
@@ -289,50 +289,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/129.xml
+++ b/data/tei/129.xml
@@ -525,50 +525,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/13.xml
+++ b/data/tei/13.xml
@@ -640,50 +640,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/130.xml
+++ b/data/tei/130.xml
@@ -363,6 +363,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p2addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="200b" to="200b"/>
                     <p>On fol. 200 b, at the end of<ref target="#p2a1">the Gospel of S. John</ref>, there is a note, unfortunately mutilated, stating that these two leaves were written by one<persName>Gabriel of Edessa</persName>:</p>
                     <p>
@@ -431,50 +432,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/131.xml
+++ b/data/tei/131.xml
@@ -202,6 +202,7 @@
                   <p>Foll.<locus from="154b" to="154b">154 b</locus>and<locus from="156a" to="156a">156 a</locus>have been retouched at a later date, and one half of<locus from="155" to="155">fol. 155</locus>has been supplied on<material>paper</material>about the end of the<date notBefore="1000" notAfter="1100">11th century</date>.</p>
                 </item>
                 <item n="5" xml:id="addition5" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="157b" to="157b"/>
                   <p>On fol. 157 b there is a note, in the handwriting of the scribe, stating that this book was collated by<persName>Kashīsh</persName>, the Arab, priest of the district called<placeName>Nahrā dě-Kastra</placeName>, along with his syncelli<persName ref="syr">John bar Daniel</persName>, the Arab, and<persName>John</persName>, the deacon, of<placeName xml:lang="syr">ܐܘܢܡܪܐ</placeName>, who was also of Arab race.</p>
                   <p>
@@ -209,6 +210,7 @@
                   </p>
                 </item>
                 <item n="6" xml:id="addition6" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="157b" to="157b"/>
                   <p>The name of the scribe appears to have been<persName>David</persName>, for under<ref target="#addition5">the above note</ref>we read:</p>
                   <p>
@@ -278,50 +280,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/132.xml
+++ b/data/tei/132.xml
@@ -554,6 +554,8 @@
                     <p>Fol. 74 is a palimpsest leaf of the<date notBefore="0800" notAfter="1000">9th or 10th century</date>, the more ancient text being that of<ref target="#Part4">S. Matthew</ref>.</p>
                   </item>
                   <item n="4" xml:id="p4addition4" syriaca-tags="doxology scribal-colophon">
+                    <label>Colophon</label>
+                    <label>Doxology</label>
                     <locus from="169b" to="169b"/>
                     <p>On fol. 169 b we have the ordinary doxology; and under it, at some distance below<ref target="#p3decoNote2">the coloured ornament</ref>, there is a note, much injured and effaced, containing the date:</p>
                     <p>
@@ -848,50 +850,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/135.xml
+++ b/data/tei/135.xml
@@ -196,6 +196,7 @@
                   <p>Several pages have been re-touched by a modern hand, especially<locus from="29a" to="29a">fol. 29 a</locus>.</p>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="doxology scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="104a" to="104a"/>
                   <p>Under the doxology, there stands a note, partially effaced and torn, which states that the volume was written at<placeName>Tel-Dīnawar</placeName>in the<placeName>district of Beth-Nūhadrā</placeName>, [See<bibl>Assemani, Bibl. Orient., t. iii. Pars 2, pag. DCCXLIII., art. Dinur</bibl>, and<bibl>pag. DCCLXIX., art. Nuhadra</bibl>. He is mistaken in his identification of the latter with Nehardea]<origDate when-custom="0911" datingMethod="Seleucid">A. Gr. 911</origDate>,<origDate when="0600" calendar="Gregorian">A.D. 600</origDate>, in the tenth year of the reign of<listPerson>
                       <person>
@@ -279,50 +280,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/136.xml
+++ b/data/tei/136.xml
@@ -180,6 +180,7 @@
                     <p>On fol. 107b, between the subscription of the Gospel of S. Mark and the doxology, there was a rubric of two lines, which has been carefully erased.</p>
                   </item>
                   <item n="3" xml:id="p1addition3">
+                    <label>Colophon</label>
                     <locus from="1a" to="1a"/>
                     <p>Of the writing on fol. 1a but little is now distinctly legible, which is to be regretted, as it seems to be a nearly contemporary notice of the taking of<placeName>Damascus</placeName>by the Arabs,<date from="0634" to="0635" calendar="Gregorian">A.D. 634-5</date>. The two most important passages read as follows.</p>
                     <p>Line 8—12:</p>
@@ -414,50 +415,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/139.xml
+++ b/data/tei/139.xml
@@ -186,6 +186,7 @@
                   <p>Fol. 8 is a comparatively modern<material>paper</material>leaf.</p>
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="68a" to="68a"/>
                   <p>At the foot of fol. 68a, after the doxology, stand the words</p>
                   <p>
@@ -259,50 +260,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/14.xml
+++ b/data/tei/14.xml
@@ -633,50 +633,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/140.xml
+++ b/data/tei/140.xml
@@ -262,50 +262,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/141.xml
+++ b/data/tei/141.xml
@@ -182,6 +182,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="63a" to="63a"/>
                   <p>On fol. 63a, between the last line of the text and the subscription, the scribe<persName>Constantine</persName>has recorded his name:</p>
                   <p>
@@ -311,50 +312,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/142.xml
+++ b/data/tei/142.xml
@@ -228,50 +228,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/143.xml
+++ b/data/tei/143.xml
@@ -399,6 +399,7 @@
                             <additions>
                                 <list>
                                     <item n="1" xml:id="p3addition1">
+                    <label>Colophon</label>
                                         <locus from="42b" to="42b"/>
                                         <p>The subscription was followed by a note, now erased, the first line of which contained a date, as is clear from the single legible word</p>
                                         <p>
@@ -673,50 +674,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/1472.xml
+++ b/data/tei/1472.xml
@@ -194,6 +194,7 @@
                   <p>The word <foreign xml:lang="syr">ܡܡܠܠ</foreign> in <ref>the above addition</ref> is a still later addition.</p>
                 </item>
                 <item n="1" xml:id="p1addition1">
+                    <label>Doxology</label>
                   <locus from="185a"/>
                   <p>Colophpon</p>
                   <p>
@@ -202,6 +203,8 @@
                     </p>
                 </item>
                 <item n="2" xml:id="p1addition2">
+                    <label>Colophon</label>
+                    <label>Colophon</label>
                   <locus from="185b"/>
                   <p>Then follows, on the same page as <ref>the colophon</ref>, a note, stating that this book was written at
                     <placeName ref="http://syriaca.org/place/78">Edessa</placeName>, <date datingMethod="Seleucid" when-custom="1128">A. Gr. 1128</date> (<date calendar="Gregorian" when="0817">A.D. 817</date>), by a professional scribe named

--- a/data/tei/148.xml
+++ b/data/tei/148.xml
@@ -221,50 +221,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/149.xml
+++ b/data/tei/149.xml
@@ -365,50 +365,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/152.xml
+++ b/data/tei/152.xml
@@ -193,6 +193,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="doxology">
+                  <label>Doxology</label>
                   <locus from="205" to="205"/>
                   <p>At the end of the<ref target="#b8">Gospel of S. John</ref>, after the subscription, stands the following doxology:</p>
                   <p>
@@ -204,6 +205,7 @@
                   </p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="205"/>
                   <p>Below<ref target="#addition1">this</ref>, in the same handwriting, there is a note, informing us that this volume was written in the<placeName>desert of Scete</placeName>,<origDate when-custom="1247" datingMethod="Seleucid">A. Gr. 1247</origDate>(<origDate when="0936" calendar="Gregorian">A.D. 936</origDate>), by a priest named<persName>John</persName>, for the abbat<persName ref="http://syriaca.org/person/647">Moses of Nisibis</persName>.</p>
                   <quote xml:lang="syr">ܫܩ̣ܠ ܕܝܢ ܫ̇ܘܠܡܐ ܟܬܒܐ ܗܢܐ ܫ̣ܢܬ ܐܠܦܐ ܘܡ̈ܐܬܝܢ ܘܐܪ̈ܒܥܝܢ ܘܫܒܥ ܒܕܝܘ̈ܢܝܐ ܐܬܟܬܒ ܕܝܢ ܒܕܝܪܐ ܕܣܘܪ̈ܝܝܐ ܒܡܕܒܪܐ ܕܐܣܩܝܛܐ ܟܬܒܗ ܕܝܢ ܝܘܚܢܢ ܐܟܣܢܝܐ ܘܒܫܡܐ ܕܝܪܝܐ ܘܒܕܪܓܐ ܬܘܒ ܩܫܝܫܐ ܟܕ ܫ̇ܘܐ ܟܬܒܗ ܕܝܢ ܠܡܘܫܐ ܪܝܫܕܝܪܐ ܕܝܠܗ̇ ܕܕܘܟܬܐ ܕܡܬܝܕܥ ܢܨܝܒܝܢܐ܇ ܟܠ ܕܝܢ ܕܩ̇ܪܐ ܒܗ ܒܟܬܒܐ ܗܢܐ ܕܐܘܢܓܠܝܘܢ ܩܕܝܫܐ ܢܨ̇ܠܐ ܥܠ ܚܛܝܐ ܕܣܪܛ ܕܢܬܚܢܢ ܗ̣ܘ ܘܥܢ̈ܝܕܘܗܝ ܘܟܠܗ ܝܠ̣ܕܐ ܕܥܕܬܐ ܩܕܝܫܬܐ ܐܝܟ ܓܝ̇ܣܐ ܕܡܢ ܝܡܝܢ ܘܟܠ ܕܝܢ ܕܗܘ̣ܐ ܠܗ ܒܗ ܫܘܬܦܘܬܐ ܐܢ ܒܡܠܬܐ ܘܐܢ ܒܥ̇ܒܕܐ ܐܘ ܒܥܠ̣ܬܐ ܐ̇ܝܕܐ ܕܗܝ ܐܝܢ ܘܐܡܝܢ܀</quote>
@@ -267,50 +269,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/153.xml
+++ b/data/tei/153.xml
@@ -356,50 +356,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/154.xml
+++ b/data/tei/154.xml
@@ -214,6 +214,7 @@
                   </p>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="108a" to="108a"/>
                   <p>The second column of fol. 108 a contains a note, which states that the volume was written in the twenty-fifth year of the reign of<persName>Khusrau the son of<persName>Hurmuz</persName>, king of<placeName>Persia</placeName>
                     </persName>(i.e.<origDate when-custom="0926" datingMethod="Seleucid">A. Gr. 926</origDate>,<origDate when="0615" calendar="Gregorian">A.D. 615</origDate>), when<persName>Mār Basha</persName>was metropolitan of<placeName>Nisibis</placeName>,<persName>Mār Matthew</persName>head of the college,<persName>Mār Aha</persName>lecturer, and<persName>Mār Bar-Sahde</persName>teacher. It belonged to, and was collated by,<persName>Gabriel Katrāyā (or the Bactrian)</persName>.</p>
@@ -295,50 +296,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/155.xml
+++ b/data/tei/155.xml
@@ -337,50 +337,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/156.xml
+++ b/data/tei/156.xml
@@ -216,6 +216,7 @@
                     <p>On fol. 1 a, at the foot of the page, there are some lines of Greek writing, in slanting uncials, now too much effaced to be legible.</p>
                   </item>
                   <item n="5" xml:id="p1addition5">
+                    <label>Doxology</label>
                     <locus from="108" to="108"/>
                     <p>
                       <ref target="#p1a1">The Acts</ref>is followed by the short doxology:</p>
@@ -365,6 +366,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p2addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="148" to="148"/>
                     <p>A note at the end states that these leaves were written by a person named<persName>Lazarus</persName>:</p>
                     <p>
@@ -448,50 +450,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/159.xml
+++ b/data/tei/159.xml
@@ -410,50 +410,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/160.xml
+++ b/data/tei/160.xml
@@ -253,6 +253,7 @@
                   <p>Other lessons are marked by a later reader, who evidently drew up an index (<foreign xml:lang="syr">ܦܘܪܫ ܩܪ̈ܝܢܐ</foreign>), which is now lost, and also indicated certain chapters or sections by the word<foreign xml:lang="syr">ܦܣܘܩܐ</foreign>(e.g. foll.<locus from="16a" to="16a">16 a</locus>,<locus from="32a" to="32a">32 a</locus>,<locus from="37b" to="37b">37 b</locus>,<locus from="41a" to="41a">41 a</locus>,<locus from="53a" to="53a">53 a</locus>, etc.</p>
                 </item>
                 <item n="8" xml:id="addition8">
+                  <label>Colophon</label>
                   <locus from="208b" to="208b"/>
                   <p>The more recent portions of the manuscript were written by a scribe named<persName>John</persName>, as appears from a note on fol. 208 b, at the foot of the second column:</p>
                   <p>
@@ -344,50 +345,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/161.xml
+++ b/data/tei/161.xml
@@ -320,50 +320,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/162.xml
+++ b/data/tei/162.xml
@@ -345,50 +345,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/163.xml
+++ b/data/tei/163.xml
@@ -273,6 +273,7 @@
                   <p>Some lessons are indicated in the margins with a later hand.</p>
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="143a" to="143a"/>
                   <p>On fol. 143 there is a note, stating that this manuscript was written for one<persName>John bar Sergius</persName>, from the<placeName>village of Halūgā</placeName>in the<placeName>district of Sĕrūg</placeName>, in the<origDate when-custom="0933" datingMethod="Seleucid">year of the Greeks 933</origDate>,<origDate when-custom="0622" datingMethod="Gregorian">A.D. 622</origDate>, and that he paid for it the sum of 14 carats:</p>
                   <p>
@@ -363,50 +364,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/164.xml
+++ b/data/tei/164.xml
@@ -248,6 +248,7 @@
                   <p>A few Greek vowels have been added by another reader.</p>
                 </item>
                 <item n="6" xml:id="addition6" syriaca-tags="doxology">
+                  <label>Doxology</label>
                   <locus from="101b"/>
                   <p>Doxology:</p>
                   <p>
@@ -255,6 +256,7 @@
                   </p>
                 </item>
                 <item n="7" xml:id="addition7" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="101b" to="101b"/>
                   <p>After the<ref target="#addition6">doxology</ref>, there stands a note, portions of which have been designedly erased, stating that this manuscript was written at the expense of a person from the village of<placeName>Bĕ-'Aital</placeName>, in<placeName>the district of Hims or Emesa</placeName>, for the library of<placeName>a certain convent, at Edessa</placeName>, in the year<origDate when-custom="0845" datingMethod="Seleucid">845</origDate>,<origDate when="0534" calendar="Gregorian">A.D. 534</origDate>:</p>
                   <p>
@@ -329,50 +331,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/165.xml
+++ b/data/tei/165.xml
@@ -585,50 +585,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/166.xml
+++ b/data/tei/166.xml
@@ -279,50 +279,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/168.xml
+++ b/data/tei/168.xml
@@ -216,50 +216,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/169.xml
+++ b/data/tei/169.xml
@@ -888,50 +888,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/175.xml
+++ b/data/tei/175.xml
@@ -728,6 +728,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="68b" to="68b"/>
                   <p>The colophon, fol. 68 b, informs us that this lectionary was finished in the year 1135 (A.D. 824) in the church of Achudemes (at<placeName>Harrrān</placeName>), at the expense of the congregation, under the direction of<persName>Mihr-Shabūr</persName>the son of<persName>Elias</persName>(the name of<persName>Dūmā</persName>is a later alteration; see Add. 14,486 and 14,487).</p>
                   <p>
@@ -801,50 +802,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/176.xml
+++ b/data/tei/176.xml
@@ -349,6 +349,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                    <label>Colophon</label>
                   <locus/>
                   <p>After the doxology there is a note, stating that the book was bound by the monk
                       <persName>Isaac</persName> in the, year 1135, <date>A.D. 824</date> (see <bibl>Add. 14,485<ptr target="http://syriaca.org/manuscript/175"/>
@@ -360,6 +361,7 @@
                   </p>
                 </item>
                 <item xml:id="addition3" n="3">
+                    <label>Colophon</label>
                   <locus/>
                   <p>The same hand has written below in Greek uncials: ΟΘΕ ΦΟΥΛΑⲜΗⲤ ΤΟⲚ ⲌΕⲚΟC ΤΟⲚ
                     ΗⲤΑΚ ΕΡΓΟⲚ ΑΜΗⲚ, probably meaning: "O God, preserve the stranger Isaac, (who
@@ -369,6 +371,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                    <label>Colophon</label>
                   <locus from="81a"/>
                   <p>A note in the same handwriting, on fol. 81 a, states that this lectionary was
                     written for<placeName> the church of Achudemes</placeName>, in the monastery

--- a/data/tei/177.xml
+++ b/data/tei/177.xml
@@ -309,6 +309,7 @@
               <p/>
               <list>
                 <item xml:id="p1addition1" n="1">
+                    <label>Colophon</label>
                   <locus from="71a"/>
                   <p>In the second column of the same page are the following notes, all by the same
                     hand, informing us that this lectionary was written for the Church of Achudemes,

--- a/data/tei/178.xml
+++ b/data/tei/178.xml
@@ -872,6 +872,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus/>
                   <p>At the end of the lesson on the Feast of Nativity are written the words,
                       "<persName ref="http://syriaca.org/person/2245">Lord</persName>, remember the
@@ -898,6 +899,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                  <label>Doxology</label>
                   <locus/>
                   <p>On fol. 162 a, at the foot of the second column, we read these words.</p>
                   <p>
@@ -906,6 +908,7 @@
                   </p>
                 </item>
                 <item xml:id="addition5" n="5">
+                  <label>Colophon</label>
                   <locus/>
                   <p>On foll. 162 b and 163 a there is a succession of notes, all in the same
                     handwriting, informing us that this lectionary was written in the

--- a/data/tei/179.xml
+++ b/data/tei/179.xml
@@ -429,6 +429,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="187a"/>
                   <p>A note informs us that this Lectionary was written in the year 1357, A.D. 1046,
                     in the convent of Elias, on the Black Mountain called the <placeName>Boar's

--- a/data/tei/18.xml
+++ b/data/tei/18.xml
@@ -176,6 +176,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="464b" to="464b"/>
                   <p>On<locus>fol. 464b</locus>there is a note, stating that this manuscript was written in<date when-custom="1540" datingMethod="Seleucid">the year of the Greeks 1540</date>,<date when="1229" calendar="Gregorian">A.D. 1229</date>, by one<persName>
                       <choice>
@@ -263,50 +264,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/180.xml
+++ b/data/tei/180.xml
@@ -558,6 +558,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p1addition1">
+                    <label>Colophon</label>
                     <locus from="275a" to="276b"/>
                     <p>On<locus from="275a" to="275a">fol. 275 a</locus>, after the doxology, there is the following note, informing us that this lectionary was written and bound, in the year<date calendar="Alexandrian">1400</date>(<date calendar="Gregorian">A.D. 1089</date>), at<placeName ref="http://syriaca.org/place/360">the convent of S. Mary Deipara near Alexandria</placeName>, by a recluse and stylite named<persName>Samuel bar Cyriacus bar Abraham</persName>, from a place in the East called<placeName>Nirabā</placeName>(<foreign xml:lang="syr">ܢܪܒܐ</foreign>,<!-- ARABIC GOES HERE -->), in<placeName>the district of Ma'dān</placeName>(<foreign xml:lang="syr">ܡ̇ܥܕܢ</foreign>, see<bibl>Assemani, Bibl. Or., t. ii., Dissert. de Monopliys., art. ix., Maadan</bibl>).</p>
                     <p>
@@ -805,50 +806,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/181.xml
+++ b/data/tei/181.xml
@@ -623,50 +623,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/182.xml
+++ b/data/tei/182.xml
@@ -329,6 +329,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="104a"/>
                   <p>On <locus from="104a">fol. 104a</locus> there is a note, informing us that this
                     lectionary was written in the year <date>1173</date> (<date>A. D. 862</date>),

--- a/data/tei/19.xml
+++ b/data/tei/19.xml
@@ -554,6 +554,8 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="233b"/>
                   <p>After the colophon follows the doxology, after which the compiler,
                       <persName ref="http://syriaca.org/person/164">Severus</persName>, proceeds thus:</p>
@@ -613,6 +615,7 @@
                   </p>
                 </item>                  
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="233b"/>
                   <p>After the compiler <persName ref="http://syriaca.org/person/164">Severus</persName>' note, we read:</p>
                   <p>

--- a/data/tei/193.xml
+++ b/data/tei/193.xml
@@ -820,6 +820,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="178b"/>
                   <p>The colophon, fol. 178 b, informs us that the latter portion
                                         of the manuscript was written, and the whole of it repaired

--- a/data/tei/196.xml
+++ b/data/tei/196.xml
@@ -529,6 +529,7 @@
                             <additions>
                                 <list>
                                     <item n="1" xml:id="p3addition1">
+                    <label>Colophon</label>
                                         <locus from="97a" to="97a"/>
                                         <p>On<locus from="97a">fol. 97 a</locus>there is a note by the scribe,<persName>John bar Mārūthā, a Tagritan</persName>, from the city of<placeName>Dolūk</placeName>(<foreign xml:lang="syr">ܕܠܝܟ</foreign>or<foreign xml:lang="syr">ܕܠܘܟ</foreign>; see<bibl>Assemani, Bibl. Orient., t. ii., Dissert, de Monophys., art. ix., Dolucha</bibl>), residing at<placeName ref="http://syriaca.org/place/78">Edessa</placeName>.</p>
                                         <p>
@@ -1110,6 +1111,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p6addition1">
+                    <label>Colophon</label>
                                         <locus from="235a" to="235a"/>
                                         <p>On fol. 235 a there is a note, stating that this manuscript was written by a monk named<persName>John</persName>, at the expense of a person whose name has been erased.</p>
                                         <p>
@@ -1211,50 +1213,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/20.xml
+++ b/data/tei/20.xml
@@ -732,6 +732,7 @@
                     </p>
                   </item>
                   <item n="3" xml:id="p1addition3">
+                    <label>Colophon</label>
                     <locus from="189b"/>
                     <p>On fol. 189 b there are two notes, in the same handwriting as that of the last nine leaves. The second states that the last quire was written by the priest <persName>Jacob</persName>, <date>A.G. 1345</date>, <date>A.D. 1034</date>.</p>
                     <p>

--- a/data/tei/204.xml
+++ b/data/tei/204.xml
@@ -187,6 +187,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="272b"/>
                   <p>A note on fol. 272b informs us that this manuscript was written at the expense
                     of a monk named <persName>Abba Simon</persName>, the son of <persName>Abraham</persName>, from <placeName>Maipherkat or Maiyāfārikin</placeName>
@@ -198,6 +199,7 @@
                     </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="273a"/>
                   <p>Another note, on fol. 273a, states that it was written in the year <date datingMethod="Seleucid" when-custom="1367">1367</date>, <date calendar="Gregorian" when="1056">A.D.
                     1056</date>, in the <placeName>monastery of Elias</placeName>, on the <placeName ref="http://syriaca.org/place/317">Black mountain (near <placeName>Antioch</placeName>)</placeName>, by the priest <persName>Peter</persName>,

--- a/data/tei/206.xml
+++ b/data/tei/206.xml
@@ -632,50 +632,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/207.xml
+++ b/data/tei/207.xml
@@ -288,50 +288,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/208.xml
+++ b/data/tei/208.xml
@@ -728,6 +728,7 @@
                           <p/>
                           <list>
                             <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                               <locus from="83b"/>
                               <p>On fol. 83 b the scribe has recorded his name, <persName>Epiphanius</persName>:</p>
                               <p>
@@ -735,6 +736,7 @@
                               </p>
                                             </item>
                             <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                               <locus from="93b"/>
                               <p>On fol. 93 b we find another name, perhaps that of the person for whom the book was written</p>
                               <p>

--- a/data/tei/209.xml
+++ b/data/tei/209.xml
@@ -758,6 +758,7 @@
                                     </p>
                                 </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                                     <locus from="311b"/>
                                     <p>Another note on the same page, compared with that at the end
                                         of <bibl>Add. 17,190</bibl>, shows us that this manuscript was written in

--- a/data/tei/21.xml
+++ b/data/tei/21.xml
@@ -655,6 +655,7 @@ to the metre in which they are composed.</note>
                   </p>
                 </item>
                   <item>
+                    <label>Colophon</label>
                     <locus from="234b"/>
                     <p>The <ref>above words</ref> are followed by
                               an epigraph in heptasyllabic metre, naming <persName>the scribe

--- a/data/tei/212.xml
+++ b/data/tei/212.xml
@@ -268,50 +268,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/213.xml
+++ b/data/tei/213.xml
@@ -534,6 +534,7 @@
                   </p>
                 </item>
                 <item xml:id="addition7" n="7">
+                  <label>Colophon</label>
                   <locus from="176b"/>
                   <p>
                     On fol. 176 b, after the doxology, there stands the following note,

--- a/data/tei/215.xml
+++ b/data/tei/215.xml
@@ -266,50 +266,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/216.xml
+++ b/data/tei/216.xml
@@ -832,50 +832,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/22.xml
+++ b/data/tei/22.xml
@@ -771,6 +771,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="299b"/>
                   <p>On fol. 299 b there is the following note in heptasyllabic metre, mentioning the names of<persName>the scribe Yeshūa'</persName>and of<persName>Abū 'Alī Zakarīyā</persName>, at whose expense the manuscript was written.</p>
                   <p>
@@ -781,6 +782,7 @@
                   </p>
                 </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                   <locus from="75a"/>
                   <p>The scribe has also recorded his own name and that of his patron in
                               several other places; e.g. foll. 75 a.</p>
@@ -789,6 +791,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                  <label>Colophon</label>
                   <p>The scribe has also recorded his own name and that of his patron in
                               several other places; e.g. foll. 99 a, 117 a, 166 b, 188 b, 250 b, 281
                               a, and 357 b</p>
@@ -797,6 +800,7 @@
                   </p>
                 </item>
                 <item xml:id="addition5" n="5">
+                  <label>Colophon</label>
                   <locus from="68b"/>
                   <p>To a marginal addition on fol. 68 b are appended the words: "written
                               by<persName>Rabban Athanasius (or #Theōnas?), the disciple of our

--- a/data/tei/221.xml
+++ b/data/tei/221.xml
@@ -206,50 +206,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/222.xml
+++ b/data/tei/222.xml
@@ -1297,50 +1297,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/23.xml
+++ b/data/tei/23.xml
@@ -237,12 +237,14 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="233b"/>
                   <p>At the end of the last order, fol. 233 b, after the words
                    <foreign xml:lang="syr">ܫܠܡ̣ܬ݁ ܦܠܓܘܬܐ ܩܕܡܝܬܐ ܕܟܪܘܟܝܐ. ܒܟܠܗ̈ܝܢ ܕܝܠܗ̇</foreign>, we find the same metrical colophon as in <bibl>Add. 12,146<ptr target="http://syriaca.org/manuscript/21"/>
                     </bibl>.</p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="233b"/>
                   <p>Then comes the following note:</p>                  
                   <p>

--- a/data/tei/233.xml
+++ b/data/tei/233.xml
@@ -1002,50 +1002,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/24.xml
+++ b/data/tei/24.xml
@@ -181,6 +181,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="84a"/>
                   <p>Fol. 84 a contains the following note, similar to that in <bibl>Add. 12,148<ptr target="http://syriaca.org/manuscript/23"/>,
                               <citedRange unit="locus">fol. 233 b</citedRange>

--- a/data/tei/25.xml
+++ b/data/tei/25.xml
@@ -358,6 +358,8 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon doxology">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="254a"/>
                   <p>On fol. 254a, 3rd col., we read the colophon, written with green paint (see also fol.<locus from="227b">227b</locus>):</p>
                   <p>
@@ -481,50 +483,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/252.xml
+++ b/data/tei/252.xml
@@ -341,52 +341,112 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against
-              Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical
-              Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against
+              Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical
+              Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/257.xml
+++ b/data/tei/257.xml
@@ -464,6 +464,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="108a" to="108b"/>
                   <p>On fol. 108 a and b is a long note, written in a small cursive character, in
                     parts almost illegible, stating that this book was transcribed in the year <origDate datingMethod="Seleucid" when-custom="0846">846</origDate>,

--- a/data/tei/258.xml
+++ b/data/tei/258.xml
@@ -406,50 +406,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/26.xml
+++ b/data/tei/26.xml
@@ -286,6 +286,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="172b"/>
                   <p>At the end of the last epistle, fol. 172b, after a doxology and table of contents, we read the following note, giving the date of the manuscript and the name of the scribe,<persName>George</persName>the deacon.</p>
                   <p>
@@ -300,6 +301,7 @@
                   </p>
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="176b"/>
                   <p>On fol. 176b is a note in the handwriting of the scribe<persName>George</persName>, from which it appears that this volume was written for<persName>John</persName>and<persName>Elisha</persName>, the sons of one<persName>Mahīr of<placeName ref="http://syriaca.org/place/193">Tagrīt</placeName>
                     </persName>, at the expense of their father.</p>
@@ -391,50 +393,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/264.xml
+++ b/data/tei/264.xml
@@ -212,50 +212,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/266.xml
+++ b/data/tei/266.xml
@@ -234,50 +234,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/267.xml
+++ b/data/tei/267.xml
@@ -276,50 +276,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/268.xml
+++ b/data/tei/268.xml
@@ -895,6 +895,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p7addition1">
+                    <label>Colophon</label>
                     <locus from="49" to="49"/>
                     <p>After the doxology, there stands a note, now much mutilated, from which it appears that the name of the scribe was Thomas.</p>
                     <p>
@@ -1233,50 +1234,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/27.xml
+++ b/data/tei/27.xml
@@ -213,6 +213,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="193b"/>
                   <p>On fol. 193 b, after the short index of contents, there is a note,
                               stating that this manuscript was written by the<persName>deacon Addai, from <placeName>Amid</placeName>
@@ -225,6 +226,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="194a" to="194"/>
                   <p>On fol. 194 a there is a long note, from which we learn that this manuscript, with the works of<persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> in two volumes, was written for a monk named <persName>George</persName>, a native of <placeName>the village called Kěphar-Hūn</placeName>, near <placeName ref="http://syriaca.org/place/78">Edessa</placeName>. These books were transcribed in the year of the Greeks <date>1148</date>, <date>A.D. 837</date>, at <placeName>the village of Tūrlāhā</placeName>, in<placeName ref="http://syriaca.org/place/995">the province of Antioch</placeName>, in <placeName>the district of Beth-Maiyā</placeName>, near <placeName ref="http://syriaca.org/place/373">the convent of Pěsīltā (or the Quarry)</placeName>, during the time when <persName>Dionysius</persName> was patriarch of<placeName ref="http://syriaca.org/place/10">Antioch</placeName> (That is, <persName>Dionysius I. Tell-mahrāyā</persName>. See <bibl>
                       <persName>Assemani</persName>, Bibl. Orient., t. ii., p. 344</bibl>; <bibl>

--- a/data/tei/273.xml
+++ b/data/tei/273.xml
@@ -177,6 +177,7 @@
                   <p>"Let not be unjustly withheld the reward of the five pairs of twins" (the ten fingers), "whose husband¬man was the king of the members" (the head), " and the ploughshare with which they ploughed (<foreign xml:lang="syr">ܕܕܒܪ̈ܝ</foreign>=<foreign xml:lang="syr">ܕܕܒܪ</foreign>), the quill of a bird; who toiled (<foreign xml:lang="syr">ܠܐ̈ܝ</foreign>=<foreign xml:lang="syr">ܠܐܝ</foreign>), in reliance on Thee, under the yoke of Thy doctrine. Amen."</p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="94a"/>
                   <p>A long note, in a more cursive character, on fol. 94a, informs us that the manuscript was written in the year<origDate when-custom="0820" datingMethod="Seleucid">820</origDate>(A.D.<origDate when="0509" calendar="Gregorian">509</origDate>), in the (Arabian)<placeName>convent of<foreign xml:lang="syr">ܦܥܢܘܪ</foreign>
                     </placeName>, when<persName>Thomas</persName>was abbat, at the expense of the deacon and oeconomus<persName>Simeon</persName>.</p>
@@ -185,6 +186,7 @@
                   </p>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="94a"/>
                   <p>Another note on the same page, in minute cursive characters (see<bibl>Land, Anecd. Syr., t. i. tab. v., no. 11</bibl>), states that the name of the scribe was<persName>Jacob of Amid</persName>(?), and offers up prayers for<persName>Malchus</persName>,<persName>Leontius</persName>, from a place called<foreign xml:lang="syr">ܚܖܬܐ</foreign>(?) on Mount Lebanon, and<choice>
                       <corr resp="http://syriaca.org/documentation/editors.xml#wwright">
@@ -294,50 +296,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/274.xml
+++ b/data/tei/274.xml
@@ -429,50 +429,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/275.xml
+++ b/data/tei/275.xml
@@ -248,50 +248,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/276.xml
+++ b/data/tei/276.xml
@@ -218,50 +218,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/277.xml
+++ b/data/tei/277.xml
@@ -348,50 +348,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/278.xml
+++ b/data/tei/278.xml
@@ -509,6 +509,7 @@
                     </choice>.</p>
                 </item>
                 <item n="3" xml:id="addition3" syriacatags="colophon-incertus">
+                  <label>Colophon</label>
                   <locus from="236a"/>
                   <p>Under the final rubric we read:</p>
                   <p>
@@ -609,50 +610,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/279.xml
+++ b/data/tei/279.xml
@@ -354,6 +354,7 @@
                   <p>The margins of this manuscript are even more thickly studded with notes of various kinds than these of Add.<ref target="http://syriaca.org/manuscript/28">12,153</ref>and Add.<ref target="http://syriaca.org/manuscript/278">14,547</ref>.</p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="187b"/>
                   <p>At the top of fol. 187b we read the words:</p>
                   <p>
@@ -468,50 +469,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/28.xml
+++ b/data/tei/28.xml
@@ -560,6 +560,7 @@
                             <p/>
                             <list>
                                 <item n="1" xml:id="addition1" syriaca-tags="doxology scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                                     <locus from="205b"/>
                                     <p>On fol. 205b, after the doxology, there is a long colophon, stating that the greater part of this volume was written by one<persName>Ephraim</persName>, a stylite, of<placeName>Kĕphar-Taurĕthā</placeName>, near<placeName>Zeugma</placeName>()in the year<origDate when-custom="1156" datingMethod="Seleucid">1156</origDate>, A.D.<origDate when="0845" calendar="Gregorian">845</origDate>, when<persName ref="http://syriaca.org/person/155">Dionysius I of Tel-mahar,</persName>who died on the 22nd of August in this same year, was patriarch of<placeName>Antioch</placeName>, and<persName>David</persName>bishop of<placeName>Urem Castra</placeName>, for the use of one<persName>George</persName>, a monk of the<placeName>convent of<persName>Job</persName>at<foreign xml:lang="syr">ܫܪܟܝܫ</foreign>
                                         </placeName>(<!-- Need Arabic here -->?). On Zeugma and Urem Castra, see<bibl>Assemani, Bibl, Orient., t. ii., dissert, de monophys., art. IX</bibl>. On Dionysius I, see<bibl>Assemani, Bibl. Orient., t. ii., p. 344; Le Quien, Or. Christ,, t. ii., col, 1372</bibl>.</p>
@@ -654,50 +655,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/280.xml
+++ b/data/tei/280.xml
@@ -872,6 +872,7 @@
                             <p/>
                             <list>
                                 <item n="1" xml:id="addition1" syriaca-tags="doxology scribal-colophon">
+                  <label>Colophon</label>
                                     <locus from="226b"/>
                                     <p>After the usual doxology, fol. 226b, we find the name of the scribe,<persName>Abraham of Beth-Sūrāyā</persName>:</p>
                                     <p>
@@ -961,50 +962,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/281.xml
+++ b/data/tei/281.xml
@@ -367,50 +367,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/282.xml
+++ b/data/tei/282.xml
@@ -172,6 +172,8 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="137b" to="138"/>
                   <p>Beneath<ref target="#a1">the final rubric</ref>, are the words<quote xml:lang="syr">ܒܪܝܟ ܐܠܗܐ ܠܥܠܡ̣. ܘܡܫܒܚ ܫܡܗ̣ ܠܕܪܕܪܝܢ</quote>, followed by the doxology.</p>
                   <p>A long note, filling up the whole of the second column of<locus from="137b">this page</locus>, has been most carefully effaced. At the beginning of its second paragraph, we can just decipher the words<quote xml:lang="syr">ܐܝܬܘܗܝ ܟܬܒܐ ܗܢܐ ܕܬܠܡ̈ܝܕܘܗܝ ܕܚܣܝܐ ܐܒܘܢ ܡܪܝ ܓܐܘܪܓܝ : ܐܠܐ</quote>,<quote>This book belongs to the disciples of the bishop, our father<persName>Mar George</persName>; but—</quote>.</p>
@@ -249,50 +251,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/283.xml
+++ b/data/tei/283.xml
@@ -256,50 +256,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/284.xml
+++ b/data/tei/284.xml
@@ -268,52 +268,112 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against
-              Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical
-              Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against
+              Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical
+              Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/285.xml
+++ b/data/tei/285.xml
@@ -220,50 +220,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/286.xml
+++ b/data/tei/286.xml
@@ -223,6 +223,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p1addition1">
+                    <label>Colophon</label>
                     <locus from="42b"/>
                     <p>From the first few lines of the colophon, fol. 42b, col. b, we learn that the name of the scribe was<persName>Theodore</persName>.</p>
                     <p>
@@ -408,50 +409,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/287.xml
+++ b/data/tei/287.xml
@@ -225,50 +225,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/288.xml
+++ b/data/tei/288.xml
@@ -441,50 +441,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/289.xml
+++ b/data/tei/289.xml
@@ -175,11 +175,13 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="171a"/>
                   <p>After the doxology, fol. 171a,<quote xml:lang="syr">ܫܘܒܚܐ ܠܬܠܝܬܝܘܬܐ ܡܪܝܡܬܐ ܡܢ ܟܠ ܦܘܡ̈ܝܢ: ܕܫ̇ܡ̈ܝܢܐ ܕܐܪ̈ܥܢܐ: ܗܫܐ̣ ܘܒܟܠܙܒܢ: ܘܠܥܠܡ̇ ܥܠܡܝܢ ܐܡܝܢ</quote>, we find the name of the scribe,<quote xml:lang="syr">ܐܢܐ ܝܘܚܢܢ ܟܬܒܐ</quote>; under which, in smaller characters, are the words:<quote xml:lang="syr">ܢܗܘܘܢ ܪ̈ܚܡ̣ܘܗܝ ܕܡܪܢ ܥܠ ܗ̇ܘ ܕܟܬ݂ܒ ܒܬܪ̈ܝܗܘܢ ܥ̈ܠܡܐ ܐܝܢ ܘܐܡܝܢ܀</quote>
                   </p>
                 </item>
                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                   <locus from="171b"/>
                   <p>On fol. 171b, there is a long note in cursive characters, part of which has been erased, giving the date of the manuscript, and stating that it was written for a certain convent, in the days of the abbat<persName>Elias</persName>and the priest<persName>Nětirā</persName>(?):</p>
                   <p>
@@ -270,50 +272,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/290.xml
+++ b/data/tei/290.xml
@@ -183,6 +183,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="107b"/>
                   <p>A note on fol. 107b informs us that the manuscript belonged to<placeName>the monastery of Nātphā of Zagal</placeName>, near<placeName ref="http://syriaca.org/place/153">
                       <choice>
@@ -291,50 +292,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/291.xml
+++ b/data/tei/291.xml
@@ -234,50 +234,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/292.xml
+++ b/data/tei/292.xml
@@ -158,6 +158,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Doxology</label>
                   <locus from="161a"/>
                   <p>This is followed by the usual doxology, under which there is a note, in a more cursive character, of which the first two lines have been erased. The remainder contains one of the ordinary anathemas:</p>
                   <p>
@@ -232,50 +233,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/293.xml
+++ b/data/tei/293.xml
@@ -176,6 +176,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="140b"/>
                   <p>The original colophon on fol. 140b has been purposely erased, but enough is still legible to let us see that the manuscript was written by one<persName>Abraham</persName>, from<placeName>the convent of Eusebius</placeName>at<placeName xml:lang="syr">ܟܦܪܐ ܕܒܪܬܐ</placeName>.</p>
                   <p>
@@ -270,50 +271,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/294.xml
+++ b/data/tei/294.xml
@@ -218,50 +218,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/295.xml
+++ b/data/tei/295.xml
@@ -190,6 +190,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="194a"/>
                   <p>After the doxology, on the same page, there is a note, in a smaller Estrangělā, giving the name of the scribe,<persName>
                       <sic>Peter bar 'Anākā</sic>
@@ -273,50 +274,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/296.xml
+++ b/data/tei/296.xml
@@ -267,50 +267,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/297.xml
+++ b/data/tei/297.xml
@@ -451,52 +451,112 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against
-              Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical
-              Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against
+              Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical
+              Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/300.xml
+++ b/data/tei/300.xml
@@ -350,50 +350,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/301.xml
+++ b/data/tei/301.xml
@@ -177,6 +177,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="50b" to="50b"/>
                   <p>On fol. 50 b there is a note, which, besides being stained and torn, has twice suffered alteration and erasure. Of the original writing we can read, in the first and second lines, the words:</p>
                   <p>
@@ -270,50 +271,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/302.xml
+++ b/data/tei/302.xml
@@ -255,50 +255,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/303.xml
+++ b/data/tei/303.xml
@@ -251,50 +251,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/304.xml
+++ b/data/tei/304.xml
@@ -751,6 +751,7 @@
                             <p/>
                             <list>
                                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                                     <locus from="114a"/>
                                     <p>The colophon, fol. 114a, states that this manuscript belonged to one<persName>Simeon</persName>, a priest, and was written by an Edessene scribe named<persName>Julian</persName>, in the year<origDate when-custom="0830" datingMethod="Seleucid">830</origDate>of the era of<placeName>Apamea</placeName>, which is identical with the Seleucian era (see<bibl>Bickell, Carm. Nisib., preface, p. 3, note</bibl>), A.D.<origDate when="0519" calendar="Gregorian">519</origDate>.</p>
                                     <p>
@@ -827,50 +828,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/305.xml
+++ b/data/tei/305.xml
@@ -240,50 +240,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/306.xml
+++ b/data/tei/306.xml
@@ -304,50 +304,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/307.xml
+++ b/data/tei/307.xml
@@ -578,6 +578,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p2addition1">
+                    <label>Colophon</label>
                                         <locus from="33b"/>
                                         <ref target="p2handNote1"/>
                                         <p>The colophon follows the subscription, with an index to the contents of the volume, of which the commencement is unfortunately torn away.</p>
@@ -742,6 +743,8 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p3addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
+                    <label>Doxology</label>
                                         <locus from="40b"/>
                                         <p>The<ref target="#p3b4">index</ref>is followed by the doxology, after which the scribe has recorded his name,<persName>
                                                 <choice>
@@ -830,50 +833,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/31.xml
+++ b/data/tei/31.xml
@@ -1858,6 +1858,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="136b"/>
                   <p>After the doxology there is a note giving the name of the scribe, <persName>Talyā of
                     Edessa</persName>.</p>

--- a/data/tei/311.xml
+++ b/data/tei/311.xml
@@ -445,50 +445,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/312.xml
+++ b/data/tei/312.xml
@@ -431,6 +431,7 @@
                             <p/>
                             <list>
                                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                                     <locus from="84a"/>
                                     <p>After the usual doxology, the scribe<persName>Agathon</persName>has recorded his name in these words, written in cursive characters:</p>
                                     <p>
@@ -442,6 +443,7 @@
                                     </p>
                                 </item>
                                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                                     <locus from="84b"/>
                                     <p>Of the notes on fol. 84b, the most ancient appears to be the following:</p>
                                     <p>
@@ -555,50 +557,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/315.xml
+++ b/data/tei/315.xml
@@ -367,7 +367,8 @@
             </decoDesc>
             <additions>
               <list>
-                <item xml:id="addition1" n="1">                  
+                <item xml:id="addition1" n="1">
+                  <label>Colophon</label>                  
                   <locus from="190a"/>
                   <p>The colophon, fol. 190 a, gives the date, <origDate datingMethod="Seleucid" when-custom="1224">A. Gr. 1224</origDate>, <origDate calendar="Gregorian" when="0913">A.D. 913</origDate>, and the name
                     of the scribe, <persName>Ḥasan</persName>, the son of <persName>Thomas</persName>, from the village of <placeName xml:lang="syr">ܛܫܝܬܘܢܝܬܐ</placeName> near
@@ -385,6 +386,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="190b"/>
                   <p>A note on fol. 190 b, in the same handwriting, states that the book was written
                     at the expense of the deacon and stylite <persName>Isaac bar Maron</persName>, from the village of

--- a/data/tei/316.xml
+++ b/data/tei/316.xml
@@ -301,6 +301,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="149a"/>
                   <p>The colophon, fol. 149 a, states that the volume was written at <placeName ref="http://syriaca.org/place/2605">Edessa</placeName>, <origDate datingMethod="Seleucid" when-custom="1177">A. Gr. 1177</origDate>,
                    <origDate calendar="Gregorian" when="0866">A.D. 866</origDate>. The name of the scribe is not mentioned, whilst that of the

--- a/data/tei/318.xml
+++ b/data/tei/318.xml
@@ -616,6 +616,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="261b"/>
                   <p>A note on fol. 261 b informs us that the volume was written at the expense of
                       <persName>Matthew</persName> and <persName>Abraham</persName>, two monks of

--- a/data/tei/319.xml
+++ b/data/tei/319.xml
@@ -321,6 +321,8 @@
               <p/>
               <list>
                 <item>
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="179b"/>
                   <p>The colophon, but imperfect:</p>
                   <p>

--- a/data/tei/320.xml
+++ b/data/tei/320.xml
@@ -360,6 +360,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                     <locus from="166b"/>
                     <p>The colophon, fol. 166 b, belongs to the time when the manuscript was repaired, and foll. 106 and 166 added to it. It states that the book was the property of certain persons, whose names have been erased (that of <persName>Hannān of <placeName ref="http://syriaca.org/place/193">Tagrīt</placeName>
                     </persName> being substituted), and that it was bound by one <persName>Iyār</persName>.</p>

--- a/data/tei/321.xml
+++ b/data/tei/321.xml
@@ -302,50 +302,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/322.xml
+++ b/data/tei/322.xml
@@ -224,50 +224,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/323.xml
+++ b/data/tei/323.xml
@@ -739,6 +739,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                     <locus from="136a"/>
                     <p>A note on fol. 136 a states that the volume was written in the year <date calendar="Seleucid" when="0914">914</date>, <date calendar="Gregorian" when="0603">A.D. 603</date>, for certain persons, whose names have been erased, that of <persName>Joseph of <placeName ref="http://syriaca.org/place/67">Dārā</placeName>
                     </persName> being substituted</p>

--- a/data/tei/327.xml
+++ b/data/tei/327.xml
@@ -646,6 +646,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="150b" to="151a"/>
                   <p>Two notes, the one in black, the other in red ink, foll. 150b and 151a, inform
                     us that this manuscript was written at the expense of the priest

--- a/data/tei/33.xml
+++ b/data/tei/33.xml
@@ -180,6 +180,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="127b" to="128"/>
                   <p>At the foot of fol. 127 b, a later hand has written over an
                       erasure these words: "This book was finished in the convent of <placeName>. . . . </placeName>, in <date>the year 899</date> (<date>A.D. 588</date>),
@@ -208,6 +209,7 @@
                   </p>
                 </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                   <locus from="1a"/>
                   <p>The cross line on fol. 1 a reads, "<persName>John</persName> wrote (this), and gave (this book), and gave (it) of his own free
                     will. May God grant him forgiveness. Amen."</p>

--- a/data/tei/333.xml
+++ b/data/tei/333.xml
@@ -366,6 +366,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                     <locus from="139a"/>
                   <!-- Missing Arabic names of places in the following text -->
                     <p>On fol. 139 a there is a note, stating that the manuscript was written in the year <date calendar="Seleucid" when="0880">880</date>, <date calendar="Gregorian" when="0569">A.D. 569</date>, in the <placeName ref="http://syriaca.org/place/410">village of Sarmin (<foreign xml:lang="syr">ܣܪܡܝܢ </foreign>, %)</placeName>, for the <placeName>convent of S. John at Nairab (<foreign xml:lang="syr">ܢܐܪܒ</foreign>, %)</placeName> , when <persName>Mār George</persName> was abbat, and that it was collated by the deacons <persName>Theodore</persName> and <persName>Thomas</persName>.</p>

--- a/data/tei/335.xml
+++ b/data/tei/335.xml
@@ -320,6 +320,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                     <locus from="194b"/>
                     <p>After the doxology, there follows a note, informing us that the manuscript was written by one <persName>Anastasius</persName>, at the expense of the <persName>priest Stephen</persName>, in the year <date calendar="seleucid" when="0880">880</date>, corresponding to the year 617 of the era of Antioch (<date calendar="gregorian" when="0569">A.D. 569</date>), when <persName>Sergius</persName> was abbat of a convent, the name of which has been erased and that of <persName>Silas</persName> substituted.</p>
                     <p>

--- a/data/tei/336.xml
+++ b/data/tei/336.xml
@@ -656,50 +656,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/337.xml
+++ b/data/tei/337.xml
@@ -637,6 +637,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="182b"/>
                   <p>On fol. 182 b there is a long note, with an ornament at the top and a coloured
                     border, informing us that the manuscript was written at the expense of a lady,

--- a/data/tei/339.xml
+++ b/data/tei/339.xml
@@ -254,50 +254,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/34.xml
+++ b/data/tei/34.xml
@@ -1182,6 +1182,7 @@
               </p>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="313a" to="313"/>
                   <p>A note, now much mutilated, gives the name of the scribe, the priest<persName>Addai</persName>,<quote xml:lang="syr">ܐܕܝ ܚܛܝܐ ܘܐܟܣܢܝܐ̇. ܩܫܝܫܐ ܟܝܬ ܘܕܡܢ ܐܡܕ [ܡܕܝܢܬܐ</quote>.</p>
                   <p>The next three lines, containing the date, are likewise much mutilated and effaced, but enough can be deciphered to fix the year in which the manuscript was written:<quote xml:lang="syr">... ܥܝܢ ܘܬܫ̈ܥ ܒܕܝܘ̈ܢܝܐ. ܐܬܟܬܒ ܟܬܒܐ [ܗܢܐ: ܒܝܘ̈ܡܘܗܝ] ܕܝܘ݊ܚܢܢ ܦܐܛܪܝܐܪܟܐ̇. ܗ̇ܘ ܕܡܢ . . . ܒܬܪ ܥܘܗܕܢܗ ܕܡܪܝ ܕܝܘܢܘܣܝܘܣ</quote>.<persName>John III</persName>., patriarch of<placeName>Antioch</placeName>, the successor of<persName>Dionysius Tel-mahrāyā</persName>, sat from<date>A. Gr. 1158 to A. Gr. 1185</date>.</p>
@@ -1248,6 +1249,7 @@
                   </p>
                 </item>
                 <item n="10" xml:id="addition10">
+                  <label>Colophon</label>
                   <locus from="313" to="313"/>
                   <p>Of the note that follows, precisely the most important part is nearly illegible. It appears, however, that the volume was written at the expense of the<persName>deacon George, son of the<persName>deacon John</persName>
                     </persName>, from a village in the district of Antioch, for the convent of<foreign xml:lang="syr">ܐܒܘ ܠܡܘܬ</foreign>; and that it was collated and corrected by<persName>Bar-had-běshabbā</persName>, from<placeName>the convent of S. Matthew</placeName>
@@ -1257,6 +1259,7 @@
                   </p>
                 </item>
                 <item n="11" xml:id="addition11">
+                  <label>Colophon</label>
                   <locus from="97a" to="97a"/>
                   <p>The scribe<persName>Addai</persName>has also inserted his name in the subscriptions to the first and second parts of the volume,<locus from="97a">foll. 97 a</locus>and<locus from="197b">197 b</locus>. In both places a later hand has drawn a circle and partly coloured it with red paint, verses being written in the uncoloured spaces in praise of<persName>Severus</persName>and to the Holy Cross.</p>
                   <p>
@@ -1264,6 +1267,7 @@
                   </p>
                 </item>
                 <item n="12" xml:id="addition12">
+                  <label>Colophon</label>
                   <locus from="197b" to="197b"/>
                   <p>The scribe<persName>Addai</persName>has also inserted his name in the subscriptions to the first and second parts of the volume,<locus from="97a">foll. 97 a</locus>and<locus from="197b">197 b</locus>. In both places a later hand has drawn a circle and partly coloured it with red paint, verses being written in the uncoloured spaces in praise of<persName>Severus</persName>and to the Holy Cross.</p>
                   <p>
@@ -1339,50 +1343,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/342.xml
+++ b/data/tei/342.xml
@@ -353,6 +353,8 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="addition1">
+                    <label>Colophon</label>
+                    <label>Doxology</label>
                     <locus from="146b" to="146b">Fol. 146b</locus>
                     <p>The doxology, fol. 146 b, is followed by six lines of writing in the alphabet of <persName>Bardesanes</persName>, which have, however, been in great part effaced. So far as they can be deciphered, they run as follows:</p>
                     <p>

--- a/data/tei/344.xml
+++ b/data/tei/344.xml
@@ -665,50 +665,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -429,6 +429,7 @@
                   </p>
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="187b"/>
                   <p>On fol. 187 b there is a note, in the handwriting of the scribe, of which but
                     little is now legible. The volume seems to have been written, with several

--- a/data/tei/35.xml
+++ b/data/tei/35.xml
@@ -188,6 +188,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p1addition1" syriacatags="scribal-colophon">
+                    <label>Colophon</label>
                     <locus from="107a"/>
                     <p>The first note on fol. 107a gives us the name of the scribe, the deacon<persName ref="http://syriaca.org/person/795">Thomas of Edessa</persName>:</p>
                     <p>
@@ -195,6 +196,7 @@
                     </p>
                   </item>
                   <item n="2" xml:id="p1addition2" syriacatags="scribal-colophon ownership-inscription">
+                    <label>Colophon</label>
                     <p>Another note informs us that the book was written in the year<origDate when-custom="0895" datingMethod="Seleucid">895</origDate>,<origDate when="0584" calendar="Gregorian">A.D. 584</origDate>, in the convent of<choice>
                         <reg resp="http://syriaca.org/documentation/editors.xml#wwright">Gubbā Barrāyā</reg>
                         <orig xml:lang="syr">ܓܘܒܐ ܒܪܝܐ</orig>
@@ -647,50 +649,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/350.xml
+++ b/data/tei/350.xml
@@ -1025,50 +1025,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/352.xml
+++ b/data/tei/352.xml
@@ -823,50 +823,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/357.xml
+++ b/data/tei/357.xml
@@ -353,6 +353,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="114b"/>
                   <p>A note on fol. 114 b shows that the name of the scribe was <persName>John</persName>
                   </p>

--- a/data/tei/359.xml
+++ b/data/tei/359.xml
@@ -397,6 +397,7 @@
                   </p>
                 </item>
                 <item n="4" xml:id="addition4">
+                  <label>Colophon</label>
                   <locus from="109a"/>
                   <p>This<ref target="#c14">discourse</ref>is dated,<locus from="109a" to="109a">fol. 109 a</locus>,<date when="0655" calendar="Seleucid">A. Gr. 655</date>,<date when="0344" calendar="Gregorian">A.D. 344</date>.</p>
                   <p>
@@ -463,50 +464,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/361.xml
+++ b/data/tei/361.xml
@@ -560,6 +560,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="171b"/>
                   <p>After the doxology, fol. 171 b, we find the following note, which gives the
                     name of the scribe, <persName>George</persName>, and the date of the manuscript, <origDate datingMethod="Seleucid" when-custom="1113">A. Gr. 1113</origDate>, <origDate calendar="Gregorian" when="0802">A.D.
@@ -571,6 +572,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="172a"/>
                   <p>A note on fol. 172 a, in the handwriting of the scribe, mentioned the names of
                     certain monks of <placeName ref="http://syriaca.org/place/78">Edessa</placeName> for whom the volume was written; but the names of

--- a/data/tei/365.xml
+++ b/data/tei/365.xml
@@ -256,50 +256,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/366.xml
+++ b/data/tei/366.xml
@@ -206,50 +206,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/367.xml
+++ b/data/tei/367.xml
@@ -347,50 +347,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/374.xml
+++ b/data/tei/374.xml
@@ -423,6 +423,7 @@
               <additions>
                 <list>
                   <item n="1" xml:id="p3addition1">
+                    <label>Colophon</label>
                     <locus from="41b" to="41b"/>
                     <p>A note at the end, in the handwriting of the scribe, states that the manuscript was written for the monk<persName>Joseph</persName>, of the place called "<placeName>little Baddāyā</placeName>,"<foreign xml:lang="syr">ܒ̇ܕܝܐ ܙܥܘܪܬܐ</foreign>, near<placeName ref="http://syriaca.org/place/216">Harrān</placeName>
                     </p>
@@ -492,50 +493,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/38.xml
+++ b/data/tei/38.xml
@@ -162,6 +162,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="184a"/>
                   <p>Of the note written by the scribe on <locus from="184a">fol.
                               184 a</locus> the greater part has been erased, but from what

--- a/data/tei/382.xml
+++ b/data/tei/382.xml
@@ -453,50 +453,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/383.xml
+++ b/data/tei/383.xml
@@ -508,50 +508,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/384.xml
+++ b/data/tei/384.xml
@@ -614,50 +614,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/389.xml
+++ b/data/tei/389.xml
@@ -373,6 +373,7 @@
                                     </item>
                   <!-- A special shape of cross needs to replace the one which ends this quote. -->
                                     <item n="2" xml:id="p2addition2">
+                    <label>Colophon</label>
                                         <locus from="5a"/>
                                         <p>Underneath this, the same<persName>John</persName>has written in Coptic:</p>
                                         <p>
@@ -556,6 +557,8 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p3addition1">
+                    <label>Colophon</label>
+                    <label>Doxology</label>
                                         <locus from="18a"/>
                                         <ref target="#p3handNote1"/>
                                         <p>The first column of fol. 18a has been cut away. The second contains the conclusion of the colophon:</p>
@@ -894,50 +897,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/4.xml
+++ b/data/tei/4.xml
@@ -228,6 +228,8 @@
                     the same hand that wrote the text; for all which see the edition of Ceriani</p>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon doxology">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="132b" to="132b"/>
                   <quote xml:lang="syr">ܫ̣ܠܡ ܟܬܒܐ ܕܡܦܩܢܐ̣ ܐܝܟ ܡܫܠܡܢܘܬܐ ܕܫܒܥܝܢ. . . ܨܚ̇ܚܐ ܕܝܢ ܗܿܘ
                     ܕܡܢܗ ܐܬ̇ܦܫܩ ܠܠܫܢܐ ܣܘܪܝܝܐ̣. ܪܘܫܡܐ̇ ܐܝܬ ܒܗ̣ ܗܢܐ. ܐܬܢܣ̣ܒ ܡܢ ܫ̈ܬܝܬܝ ܦܨ̈ܐ ܕܐܝܟ
@@ -346,50 +348,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/40.xml
+++ b/data/tei/40.xml
@@ -248,6 +248,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p1addition1">
+                    <label>Doxology</label>
                                         <locus from="126a"/>
                                         <p>The final rubric is followed by the doxology, after which there stood three or four lines of arithmetical figures, now erased, with the exception of the first, which is<!-- Need arithmetical figures here -->, i.e.<foreign xml:lang="syr">ܝܘܚܢܢ</foreign>,<persName>John</persName>.</p>
                                     </item>
@@ -427,6 +428,7 @@
                                         </p>
                                     </item>
                                     <item n="7" xml:id="p2addition7">
+                    <label>Colophon</label>
                                         <locus from="235a"/>
                                         <locus from="247b"/>
                                         <p>The writer of the third part,<locus from="225" to="304">foll. 225- 304</locus>, has recorded his name,<persName>Sergius of Amid</persName>, on fol. 235a:</p>
@@ -911,6 +913,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p4addition1">
+                    <label>Colophon</label>
                                         <locus from="235a"/>
                                         <locus from="247b"/>
                                         <p>The writer of the third part,<locus from="225" to="304">foll. 225- 304</locus>, has recorded his name,<persName>Sergius of Amid</persName>, on fol. 235a:</p>
@@ -1099,50 +1102,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/403.xml
+++ b/data/tei/403.xml
@@ -192,6 +192,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus to="130b">fol. 130b</locus>
                   <p>A note on states that the volume was written by one<persName>Elias</persName>.</p>
                   <quote xml:lang="syr">ܟܠ ܕܩ̇ܪܐ ܡܛܠ ܡܪܢ ܒܟܬܒܐ ܗܢܐ ܢܨܠܐ ܥܠ ܕܘܝܐ ܘܚܠܫܐ ܘܬܚܘܒܐ ܕܟܠܗܘܢ ܒܢܝ̈ܢܫܐ ܐܠܝܐ ܕܟܬ̣ܒ ܟܬܒܐ ܗܢܐ. ܕܐܝܬܘܗܝ ܝܘܬܪܢܐ ܠܟܠ ܕܦ݁ܓܥ ܒܗ. ܘܟܠ ܕܩ̇ܪܐ ܒܗ ܢܐܡܪ݂. ܐܠܗܐ ܗܒ ܕܚܠܬܟ ܒܠܒܗ. ܘܡܢ ܝܘܠܦܢܟ ܡܠܝܘܗܝ ܘܚ̇ܟܡܝܗܝ ܕܢܕܥܟ ܘܚܘܢܝܗܝ ܐܝܟ ܕܠܓܝ̇ܣܐ ܒܙܩܝܦܐ̣. ܐܝܢ̇ ܐܡܝܢ.܀.</quote>
@@ -269,50 +270,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/405.xml
+++ b/data/tei/405.xml
@@ -372,50 +372,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/407.xml
+++ b/data/tei/407.xml
@@ -211,6 +211,7 @@
                                     </p>
                                 </item>
                                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                                     <locus from="60b" to="60b"/>
                                     <p>The note on <locus from="60b" to="60b">fol. 60 b</locus>, in the handwriting of the scribe, once contained the name of the original possessor; but a later owner erased it, and substituted his own (John), which has in its turn been almost completely effaced.</p>
                                     <p>
@@ -277,50 +278,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/409.xml
+++ b/data/tei/409.xml
@@ -558,6 +558,7 @@
                   </p>                 
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="430b"/>
                   <p>On fol. 430 b there is a note stating that the manuscript was written in <placeName>the
                     convent of the Syrians</placeName> in <placeName>the desert of Scete</placeName>, <date>A. Gr. 1247</date>, <date>A.D. 936</date>, when

--- a/data/tei/410.xml
+++ b/data/tei/410.xml
@@ -591,50 +591,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/413.xml
+++ b/data/tei/413.xml
@@ -734,6 +734,8 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <locus from="171b"/>
                   <p>After the doxology, fol. 171 b, stand the following notes, which mention the
                     name of the scribe, <persName>Sergūnā</persName>, and the date of the

--- a/data/tei/418.xml
+++ b/data/tei/418.xml
@@ -646,6 +646,7 @@
                   </p>
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                                     <locus from="235a"/>
                                     <p>On fol. 235 a, after <ref>the doxology</ref>, there is a note, stating
                                         that the later portions of this manuscript were written in

--- a/data/tei/419.xml
+++ b/data/tei/419.xml
@@ -310,6 +310,7 @@
               <p/>
               <list>
                 <item xml:id="p1addition2" n="2">
+                    <label>Colophon</label>
                   <locus from="214b"/>
                   <p>A note on fol. 214 b informs us that the manuscript was written in the year
                     <date datingMethod="Seleucid" when-custom="1161">1161</date>, <date calendar="Gregorian" when="0850">A.D. 850</date>, and that it belonged to the priest <persName>Job</persName> and <persName>another man, whose

--- a/data/tei/421.xml
+++ b/data/tei/421.xml
@@ -293,6 +293,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                                     <locus from="93a"/>
                                     <p>The colophon on fol. 93 a gives the name of the scribe,
                                             <persName>Sālībā</persName>. </p>

--- a/data/tei/426.xml
+++ b/data/tei/426.xml
@@ -617,50 +617,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/427.xml
+++ b/data/tei/427.xml
@@ -254,6 +254,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="32a" to="32a"/>
                   <p>The name of the scribe was Theodosius, as appears from a note (written with green paint) on fol. 32 a</p>
                   <p>
@@ -261,6 +262,7 @@
                   </p>
                 </item>
                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                   <locus from="33a" to="33a"/>
                   <p>The name of the scribe appears again on fol. 33a</p>
                   <p>
@@ -268,6 +270,7 @@
                   </p>
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="55b" to="55b"/>
                   <p>The name of the scribe appears again on fol. 55b</p>
                   <p>
@@ -334,50 +337,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/428.xml
+++ b/data/tei/428.xml
@@ -263,6 +263,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Doxology</label>
                   <locus from="81a"/>
                   <p>Colophon, fol. 81 a</p>
                   <p>

--- a/data/tei/432.xml
+++ b/data/tei/432.xml
@@ -749,50 +749,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/445.xml
+++ b/data/tei/445.xml
@@ -1837,50 +1837,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -1201,6 +1201,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="355a"/>
                   <p>On fol. 355 a there is a note, some parts of which are either wholly effaced or
                     barely legible. From it we learn that this volume was written by one
@@ -1275,6 +1276,8 @@
                   <!--WLP: Check the ? marks in the PDF. Check the order of the Syriac here. -->
                 </item>
                 <item xml:id="addition6" n="6">
+                  <label>Colophon</label>
+                  <label>Doxology</label>
                   <p>The colophon follows the last subscription, consisting of the doxology, and the following lines, expressing the gratification of the transcriber at reaching the end of his task:</p>
                   <p>
                     <quote xml:lang="syr">ܐܝܟ ܐܠܦ̣ܐ ܕܪܕ̇ܝܐ

--- a/data/tei/46.xml
+++ b/data/tei/46.xml
@@ -464,6 +464,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p1addition1" syriacatags="ownership-inscription scribal-colophon">
+                    <label>Colophon</label>
                                         <locus from="154b"/>
                                         <p>The note that originally followed the doxology has been erased, but enough remains to show that this volume was written at the expense of certain monks.</p>
                                         <p>
@@ -606,6 +607,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p2addition1" syriacatags="scribal-colophon ownership-inscription">
+                    <label>Colophon</label>
                                         <locus from="258a"/>
                                         <p>On fol. 258a, after the doxology, we read the following note, giving the date and stating that the volume was written at<placeName ref="http://syriaca.org/place/78">Edessa</placeName>, at the expense of the deacon<persName>Thomas of<placeName>Zěmārtā Castra</placeName>
                                             </persName>.</p>
@@ -694,50 +696,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/483.xml
+++ b/data/tei/483.xml
@@ -1515,50 +1515,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/49.xml
+++ b/data/tei/49.xml
@@ -717,6 +717,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="298"/>
                            <p>After the doxology, fol. 298 the scribe has given the date of the
                               manuscript, <origDate when-custom="1187" calendar="Seleucid">A. Gr., 1187</origDate>, <origDate when="876" calendar="Gregorian">A.D. 876</origDate>.</p>
@@ -726,6 +727,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus from="299a"/>
                            <p>On fol. 299 a there is a note, in the hand of the scribe, stating that
                               it was written for <persName>a monk named John</persName>.</p>

--- a/data/tei/496.xml
+++ b/data/tei/496.xml
@@ -1573,50 +1573,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/5.xml
+++ b/data/tei/5.xml
@@ -453,50 +453,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -598,6 +598,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="255a"/>
                   <p>The scribe <persName>Thomas</persName> mentions his name in
                                         the concluding words:</p>

--- a/data/tei/51.xml
+++ b/data/tei/51.xml
@@ -519,50 +519,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/510.xml
+++ b/data/tei/510.xml
@@ -1440,50 +1440,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/523.xml
+++ b/data/tei/523.xml
@@ -245,50 +245,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/526.xml
+++ b/data/tei/526.xml
@@ -327,50 +327,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/529.xml
+++ b/data/tei/529.xml
@@ -527,50 +527,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/530.xml
+++ b/data/tei/530.xml
@@ -300,50 +300,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/534.xml
+++ b/data/tei/534.xml
@@ -147,6 +147,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="83"/>
                   <p>On fol. 83 there is a mutilated note, which states that this Psalter was
                     written <date datingMethod="Seleucid" when-custom="1548">A. Gr. 1548</date>,
@@ -169,6 +170,7 @@
                     576</bibl>; <bibl>Le Quien, Oriens Christ., t. ii., col. 491</bibl>.</note>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="84a"/>
                   <p>There is a note, written in very large letters, recording the name of one
                       <persName>Bar-saumā</persName>, who not improbably bore part of the expense of

--- a/data/tei/535.xml
+++ b/data/tei/535.xml
@@ -155,6 +155,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="192b" to="192b"/>
                   <p>Then follows a note, fol. 192b, stating that the manuscript was transcribed by<persName>Samuel bar Cyriacus</persName>, a priest and stylite,<origDate when-custom="1413" datingMethod="Seleucid">A.Gr. 1413</origDate>, (<origDate when="1102" calendar="Gregorian">A.D. 1102</origDate>), at a place called<origPlace xml:lang="syr">ܢܝܩܝܘܣ</origPlace>(<origPlace xml:lang="grc">Νικίου</origPlace>), not far from the desert of<placeName>Scete</placeName>and from<placeName>Cairo</placeName>and<placeName>Alexandria</placeName>.</p>
                   <p>
@@ -222,50 +223,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/536.xml
+++ b/data/tei/536.xml
@@ -284,50 +284,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/537.xml
+++ b/data/tei/537.xml
@@ -326,50 +326,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/538.xml
+++ b/data/tei/538.xml
@@ -282,50 +282,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/539.xml
+++ b/data/tei/539.xml
@@ -206,6 +206,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p1addition1">
+                    <label>Colophon</label>
                     <locus from="92b"/>
                     <p>On fol. 92b there is a note, stating that this part of the manuscript was written by<persName>Harith bar Sisin of<placeName>Sanbat</placeName>
                       </persName>(see<ref target="http://syriaca.org/manuscript/538">Add. 14,682</ref>):</p>
@@ -364,6 +365,7 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p2addition1">
+                    <label>Colophon</label>
                     <locus from="138b"/>
                     <p>After the doxology, we find a note, fol. 138 b, written by one<choice>
                         <corr>
@@ -378,6 +380,7 @@
                     </p>
                   </item>
                   <item n="2" xml:id="p2addition2">
+                    <label>Colophon</label>
                     <locus from="140b"/>
                     <p>On fol. 140b there is a note by the scribe,<choice>
                         <corr>
@@ -390,6 +393,7 @@
                     </p>
                   </item>
                   <item n="3" xml:id="p2addition3">
+                    <label>Colophon</label>
                     <locus from="141a"/>
                     <p>Another note, on fol. 141a, gives the date<date when-custom="1356" datingMethod="Seleucid">A. Gr. 1356</date>,<date when="1045" calendar="Gregorian">A.D. 1045</date>, but the name of the writer has been erased:</p>
                     <p>
@@ -460,50 +464,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/54.xml
+++ b/data/tei/54.xml
@@ -547,6 +547,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p1addition1">
+                    <label>Colophon</label>
                                         <locus from="135a"/>
                                         <p>A note on fol. 135a, in a more cursive character, states that this manuscript was written for the recluse<persName>Sha'dūn</persName>, residing near the village of<placeName xml:lang="syr">ܡܬܢ</placeName>, in the province of<placeName>Bostra</placeName>,<origDate when-custom="0915" datingMethod="Seleucid">A. Gr. 915</origDate>=<origDate when="0604" calendar="Gregorian">A.D. 604</origDate>, who gave for it the sum of<quote>4 dīnārs, minus 3 carats.</quote>
                                         </p>
@@ -1351,50 +1352,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/543.xml
+++ b/data/tei/543.xml
@@ -242,50 +242,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/544.xml
+++ b/data/tei/544.xml
@@ -449,6 +449,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="205b"/>
                   <p>On fol. 205 b there is a note, stating that this volume and its companion were
                     written in the year <date datingMethod="Seleucid" when="1566">1566</date>, <date calendar="Gregorian" when="1255">A.D. 1255</date>, in <placeName ref="http://syriaca.org/place/360">the convent of S. Mary Deipara</placeName>, by a

--- a/data/tei/545.xml
+++ b/data/tei/545.xml
@@ -291,6 +291,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="198a" to="198a"/>
                   <p>On<locus from="198a">fol. 198a</locus>there is a note, differing only in the date from that in<listBibl>
                       <bibl>
@@ -380,50 +381,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/547.xml
+++ b/data/tei/547.xml
@@ -535,6 +535,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="185" to="186"/>
                   <p>There is a note, now much stained and torn, from which it appears that this
                     manuscript was written in the year <origDate datingMethod="Seleucid" when-custom="1532">1532</origDate>
@@ -590,6 +591,7 @@
                   </p>
                 </item>
                 <item xml:id="addition7" n="7">
+                  <label>Colophon</label>
                   <locus from="187a"/>
                   <p>A the scribe <persName>Yeshūa'</persName> has again recorded his name and that
                     of his village, <foreign xml:lang="syr">ܗܪܣܝܣ</foreign>. This note is written

--- a/data/tei/548.xml
+++ b/data/tei/548.xml
@@ -394,6 +394,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="178a"/>
                   <p>After the doxology, on fol. 178 a, there is a note, giving the name of the
                     scribe, <persName>Simeon</persName>.</p>
@@ -417,6 +418,7 @@
                   </p>
                 </item>
                 <item xml:id="addition3" n="3">
+                  <label>Colophon</label>
                   <locus/>
                   <p>The second note informs us that this volume was written in the convent of Mār
                     Simeon, of <placeName>Kartamīn</placeName>, <date>A. Gr. 1493</date> (<date>A.D.

--- a/data/tei/549.xml
+++ b/data/tei/549.xml
@@ -454,50 +454,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/565.xml
+++ b/data/tei/565.xml
@@ -192,6 +192,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="136a"/>
                   <p>On fol. 136 a there is a note, informing us that it was written in the year
                       <origDate when-custom="1603" datingMethod="Seleucid">1603</origDate>, <origDate when="1292" calendar="Gregorian">A.D. 1292,</origDate> by one

--- a/data/tei/566.xml
+++ b/data/tei/566.xml
@@ -149,6 +149,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="119b"/>
                   <p>On <locus from="119b">fol. 119 b</locus> there is a note to the same effect as
                     that in <bibl>Add. 14,699<ptr target="http://syriaca.org/manuscript/565"/>

--- a/data/tei/567.xml
+++ b/data/tei/567.xml
@@ -408,8 +408,8 @@
                   </p>
                 </item>
                 <item>
+                  <label>Colophon</label>
                   <locus from="245a"/>
-                  <p>Colophon:</p>
                   <p>
                     <quote xml:lang="syr">ܫܠܡܬ ܡܓܡܥܢܝܬܐ ܐܝܟ ܡܨܝܢܘܬܗ ܕܟܬܘܒܐ ܡܚܝܠܐ</quote>
                   </p>

--- a/data/tei/568.xml
+++ b/data/tei/568.xml
@@ -168,6 +168,7 @@
                   </p>
                   </item>
                   <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                     <locus from="53a"/>
                     <p>The colophon,<locus>fol. 53 a</locus>, gives the name of the second scribe, <persName>Moses of <placeName>Mount Lebanon</placeName>
                     </persName>, who wrote in the year <date>1800</date> (<date>A.D. 1489</date>), in the convent of <placeName ref="http://syriaca.org/place/360">S. Mary Deipara</placeName>.</p>

--- a/data/tei/582.xml
+++ b/data/tei/582.xml
@@ -173,6 +173,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="227a"/>
                   <p>The last of these is followed by a note, fol. 227 a, giving the date and the
                     name of the scribe, <persName>Ma'mar, a priest of <placeName ref="http://syriaca.org/place/161">Kārā</placeName>

--- a/data/tei/583.xml
+++ b/data/tei/583.xml
@@ -265,6 +265,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="220b"/>
                   <p>On fol. 220 b there is a note, giving the date and the name of the scribe,
                       <persName>Peter</persName>, the son of <persName>Mark</persName>, from the town of

--- a/data/tei/584.xml
+++ b/data/tei/584.xml
@@ -206,6 +206,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="27a"/>
                   <locus from="66a"/>
                   <locus from="51a"/>

--- a/data/tei/586.xml
+++ b/data/tei/586.xml
@@ -270,6 +270,7 @@
                   </p>
                 </item>
                 <item xml:id="addition4" n="4">
+                  <label>Colophon</label>
                   <locus from="138a"/>
                   <p>The colophon, fol. 138 a, states that the first part of this book (foll. 1—110)
                     was written in the year 1386 (A.D. 1075) by one Benjamin, and the remainder by one

--- a/data/tei/599.xml
+++ b/data/tei/599.xml
@@ -275,6 +275,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="92b"/>
                   <p>On fol. 92 b there is a note, stating that this manuscript
                                         was written, in the year <date>1495</date> (<date>A.D.

--- a/data/tei/61.xml
+++ b/data/tei/61.xml
@@ -2357,50 +2357,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/638.xml
+++ b/data/tei/638.xml
@@ -398,6 +398,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="105a"/>
                   <p>The name of the scribe, as appears from the concluding words of the title of no. II. (item 23), was <persName>
                       <choice>

--- a/data/tei/643.xml
+++ b/data/tei/643.xml
@@ -261,50 +261,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/652.xml
+++ b/data/tei/652.xml
@@ -1138,6 +1138,7 @@
                 <p/>
                 <list>
                   <item xml:id="p12addition1" n="1">
+                    <label>Colophon</label>
                     <locus from="52a"/>
                     <p>Colophon: </p>
                     <p>
@@ -1751,6 +1752,7 @@
                 <p/>
                 <list>
                   <item xml:id="p19addition1" n="1">
+                    <label>Colophon</label>
                     <locus from="64b" to="65a"/>
                     <p>A long note, foll. 64 b and 65 a, stating that this manuscript was written, in
                       <placeName>the convent of S. Mary Deipara</placeName>, for the
@@ -1954,50 +1956,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/69.xml
+++ b/data/tei/69.xml
@@ -200,6 +200,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="58b"/>
                            <p>Although this work, Histories of the Solitary Brethren of the Egyptian
                               Desert, is ascribed in the title to <persName ref="http://syriaca.org/person/668">Palladius</persName>, yet the
@@ -211,6 +212,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus from="117b"/>
                            <p>And again, <persName ref="http://syriaca.org/person/857">Hieronymus</persName> is mentioned as the author at the end of
                               Histories of the Solitary Brethren of the Egyptian Desert.</p>

--- a/data/tei/693.xml
+++ b/data/tei/693.xml
@@ -3205,50 +3205,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/70.xml
+++ b/data/tei/70.xml
@@ -1203,50 +1203,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/71.xml
+++ b/data/tei/71.xml
@@ -1301,6 +1301,7 @@
                             <additions>
                                 <list>
                                     <item n="1" xml:id="p3addition1" syriaca-tags="scribal-colophon">
+                    <label>Colophon</label>
                                         <locus from="254b"/>
                                         <p>Following the<ref target="#a8">index</ref>is a note containing the date, which runs nearly as follows:</p>
                                         <p>
@@ -1404,50 +1405,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/728.xml
+++ b/data/tei/728.xml
@@ -205,6 +205,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>
                     <locus>Foll. 295</locus> and <locus>296</locus> contain a note in

--- a/data/tei/729.xml
+++ b/data/tei/729.xml
@@ -188,6 +188,7 @@
                   <p>Quires are now numbered with letters.</p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="60a" to="60a"/>
                   <p>Long note stating that this manuscript was written in the year<origDate when-custom="0910" datingMethod="Seleucid">910</origDate>, and collated with another copy of the school of the Armenians. The names of the man at whose expense it was transcribed, and of the convent to which he gave it, were altered by the hand of a person from the village of<placeName>Kěphar-Darīn</placeName>, who added a few lines, informing us that the manuscript was incorporated with the library of the<placeName>convent of Mār Daniel at<placeName>Kěphar-Bīl</placeName>
                     </placeName>
@@ -312,50 +313,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/730.xml
+++ b/data/tei/730.xml
@@ -205,6 +205,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="70b" to="70b"/>
                   <p>Colophon :</p>
                   <p>
@@ -284,50 +285,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/731.xml
+++ b/data/tei/731.xml
@@ -267,50 +267,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/732.xml
+++ b/data/tei/732.xml
@@ -400,50 +400,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/733.xml
+++ b/data/tei/733.xml
@@ -319,50 +319,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/736.xml
+++ b/data/tei/736.xml
@@ -159,6 +159,7 @@
                   <quote xml:lang="syr">ܩܕܡܝܬܐ ܕܚܙܩܝܐܝܠ ܥܠ ܚܝܠܗ ܕܝܫܘܥ ܡـ[ܪܢ ܘ] ܐܠܗܢ ܟܘܪܣܐ   ܒܨܘ . .</quote>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="68b" to="68b"/>
                   <p>On<locus>fol. 68 b</locus>, we find the following note, in a current hand, stating that this volume was written at<origPlace>Edessa</origPlace>,<date calendar="Seleucid">A. Gr. 852</date>, and purchased by<persName>Sergius</persName>and<persName>Abraham</persName>, the sons of<persName>Malkā</persName>, from the town of<placeName>Hadathā</placeName>for the use of the convent to which they belonged.</p>
                   <quote xml:lang="syr">ܢܗܘܐ ܕܘܟܪܢܐ ܛܒܐ ܩܕܡ ܐܠܗܐ ܠܣܪܓܝܣ ܘܐܒܪܗܡ ܒܢ̈ܝ ܡܠܟܐ ܡܢ ܚܕܬܐ ܕܪ̈ܗܘܡܝܐ ܕܐܠܗܐ ܗܘ ܕܡܛܠ ܫܡܗ ܐܬܚܦܛܘ ܘܙܒܢܘ ܟܬܒܐ ܗܢܐ ܠܥܘܡܪܐ ܕܝܠܗܘܢ ܕܢܩܪܘܢ ܒܗܘܢ (<foreign>sic</foreign>) ܘܢܬܗܓܘܢ ܒܗܘܢ (<foreign>sic</foreign>) ܗܢܘܢ ܘܝܪ̈ܬܝܗܘܢ ܢܩܪܐ ܘܢܩܝܡ ܐܢܘܢ ܡܢ ܝܡܝܢܗ ܠܗܘܢ ܘܠܥܢܝܕܝܗܘܢ ܒܡܠܟܘܬܐ ܕܫܡܝܐ ܠܥܠܡ ܥܠܡܝܢ ܐܡܝܢ
@@ -241,50 +242,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/737.xml
+++ b/data/tei/737.xml
@@ -197,50 +197,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/738.xml
+++ b/data/tei/738.xml
@@ -333,6 +333,7 @@
                       </p>
                   </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="147a"/>
                   <p>The colophon, fol. 147 a, informs us that this manuscript was
                                         written at <placeName>Edessa</placeName>, <date>A. H .

--- a/data/tei/740.xml
+++ b/data/tei/740.xml
@@ -172,6 +172,7 @@
                     <foreign xml:lang="syr">ܫܘܒ̈ܚܐ</foreign>.</p>
                 </item>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="86a"/>
                   <p>From the subscription, fol. 86 a, in which the contents are enumerated, it
                     appears that this volume was written in <placeName>the convent of S. Mary Deipara</placeName> in <placeName>the

--- a/data/tei/742.xml
+++ b/data/tei/742.xml
@@ -248,50 +248,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/743.xml
+++ b/data/tei/743.xml
@@ -240,50 +240,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/744.xml
+++ b/data/tei/744.xml
@@ -240,50 +240,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/745.xml
+++ b/data/tei/745.xml
@@ -251,50 +251,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/746.xml
+++ b/data/tei/746.xml
@@ -229,50 +229,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/747.xml
+++ b/data/tei/747.xml
@@ -231,50 +231,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/748.xml
+++ b/data/tei/748.xml
@@ -166,6 +166,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="83b"/>
                   <p>According to the notes on the same page, this manuscript was written by a person named<persName>George</persName>, and belonged to the<placeName>convent of Silvanus</placeName>, near<placeName>Damascus</placeName>, having been purchased for it by the abbat.</p>
                   <p>
@@ -228,50 +229,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/749.xml
+++ b/data/tei/749.xml
@@ -300,50 +300,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/75.xml
+++ b/data/tei/75.xml
@@ -279,50 +279,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/750.xml
+++ b/data/tei/750.xml
@@ -291,50 +291,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/751.xml
+++ b/data/tei/751.xml
@@ -326,50 +326,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/752.xml
+++ b/data/tei/752.xml
@@ -241,50 +241,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/753.xml
+++ b/data/tei/753.xml
@@ -254,6 +254,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="172b" to="172b"/>
                   <p>A note at the foot of fol. 172 b gives the name of the scribe,<persName>Isaac</persName>:</p>
                   <p>
@@ -261,6 +262,7 @@
                   </p>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="173a" to="173a"/>
                   <p>Two notes on fol. 173 a inform us that this manuscript was written for a monk named<persName>Theodore</persName>(the name is almost completely erased), in<placeName>the monastery of Nātphā</placeName>, situated above<placeName>the monastery of Hananyā or Ananias</placeName>, to the east of the city of<placeName>Māridīn</placeName>, in the year<origDate when-custom="1545" datingMethod="Seleucid">1545</origDate>(<origDate when="1234" calendar="Gregorian">A.D. 1234</origDate>), when<listPerson>
                       <person>
@@ -364,50 +366,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/755.xml
+++ b/data/tei/755.xml
@@ -167,6 +167,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="38b" to="38b"/>
                   <p>After the final rubric follows a note, stating that this volume was written at<origPlace>Mabūg</origPlace>in the year<origDate when="0511" calendar="Gregorian">511 A.D.</origDate>
                     <origDate when-custom="0822" datingMethod="Seleucid">A. Gr., 822</origDate>, consequently some years before the death of the author (see<bibl>Assemani, Bibl. Or., t. ii., p. 19</bibl>).</p>
@@ -236,50 +237,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/759.xml
+++ b/data/tei/759.xml
@@ -281,6 +281,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="86a"/>
                   <p>On <locus>fol. 86 a</locus> there is a note, stating that this manuscript was written for the <placeName ref="http://syriaca.org/place/360">convent of S. Mary Deipara</placeName>, at the expense of one <persName>Simeon</persName>, from <placeName ref="http://syriaca.org/place/361">the convent of Mār Solomon</placeName> near <placeName ref="http://syriaca.org/place/75">Dolūk (ܕܠܝܟ or ܕܠܘܟ, %)</placeName>, in the year <date calendar="Seleucid" when-custom="1188">1188</date>, <date when="0877">A.D. 877</date>. The name of the scribe is not mentioned.</p>
                   <p>

--- a/data/tei/76.xml
+++ b/data/tei/76.xml
@@ -206,6 +206,7 @@
                   </p>
                 </item>
                 <item n="5" xml:id="addition5">
+                  <label>Colophon</label>
                   <locus from="290b" to="290b"/>
                   <p>A note on fol. 290 b, informs us that this manuscript was written<origDate when-custom="1500" datingMethod="Seleucid">A. Gr. 1500</origDate>,<origDate when="1189" calendar="Gregorian">A.D. 1189</origDate>, in<placeName>the convent of Mār Sergius</placeName>on the<placeName>Tūrā Sahyā, or Dry Mountain</placeName>, [See<bibl>Assemani, Bibl. Or., t. ii.p. 127,</bibl>and<bibl>the Dissert, de Monophysitis, art. ix., Monast. S. Sergii</bibl>, in the same volume.] when<persName>Michael the Great was patriarch of<placeName>Antioch</placeName>
                     </persName>, [See<bibl>Assemani, Bibl. Or.,t. ii.p. 363</bibl>;<bibl>Le Quien, Oriens Christ., t. ii. col. 1389</bibl>.]<persName>Gregory metropolitan of<placeName>Tagrīt</placeName>and<placeName>Mosul</placeName>
@@ -322,50 +323,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/763.xml
+++ b/data/tei/763.xml
@@ -2422,50 +2422,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/771.xml
+++ b/data/tei/771.xml
@@ -222,50 +222,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/772.xml
+++ b/data/tei/772.xml
@@ -274,50 +274,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/773.xml
+++ b/data/tei/773.xml
@@ -600,50 +600,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/774.xml
+++ b/data/tei/774.xml
@@ -253,50 +253,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/775.xml
+++ b/data/tei/775.xml
@@ -336,50 +336,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/777.xml
+++ b/data/tei/777.xml
@@ -175,6 +175,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <p>After the doxology, there is a shorter note, in a more cursive character,
                     giving the name of the scribe, <persName>John</persName>.</p>
                   <p>
@@ -183,6 +184,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="78a"/>
                   <p>Of the note in the second column of fol. 78 a, part has been torn away, and
                     much of the remainder erased. Enough, however, remains to show that the

--- a/data/tei/778.xml
+++ b/data/tei/778.xml
@@ -328,50 +328,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/779.xml
+++ b/data/tei/779.xml
@@ -227,50 +227,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/78.xml
+++ b/data/tei/78.xml
@@ -422,6 +422,7 @@
                   </p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="243"/>
                   <p>Owing to fol. 243 being torn, the precise date of this manuscript can no longer
                     be given. All that can now be read of the subscription (fol. 243 b, first

--- a/data/tei/780.xml
+++ b/data/tei/780.xml
@@ -264,50 +264,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/781.xml
+++ b/data/tei/781.xml
@@ -179,6 +179,7 @@
               <p/>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="119b" to="119b"/>
                   <p>There is a note, written by the scribe,<listPerson>
                       <persName xml:lang="eng">John of Edessa</persName>
@@ -273,50 +274,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/782.xml
+++ b/data/tei/782.xml
@@ -255,50 +255,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/783.xml
+++ b/data/tei/783.xml
@@ -286,50 +286,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/784.xml
+++ b/data/tei/784.xml
@@ -332,50 +332,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/789.xml
+++ b/data/tei/789.xml
@@ -238,6 +238,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1">
+                  <label>Colophon</label>
                   <locus from="117b" to="117b"/>
                   <p>The second column of the same page contains the following note, which informs us that this volume was written at<placeName>Edessa</placeName>, in the<date>year 876 (A.D. 565)</date>, and belonged to the priest<persName>Theodore</persName>, from the district of<placeName>Apamea</placeName>.</p>
                   <p>
@@ -328,50 +329,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/79.xml
+++ b/data/tei/79.xml
@@ -238,50 +238,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/797.xml
+++ b/data/tei/797.xml
@@ -802,50 +802,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/8.xml
+++ b/data/tei/8.xml
@@ -211,6 +211,7 @@
                   <quote xml:lang="syr">ܕܡܪܝ ܐܬܢܣܝܘܣ ܡܛܠ ܡܬܒܪܢܫܘܬܐ</quote>
                 </item>
                 <item n="5" xml:id="addition5">
+                  <label>Doxology</label>
                   <locus from="100b" to="100b"/>
                   <ref target="#a2"/>
                   <p>
@@ -289,50 +290,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/80.xml
+++ b/data/tei/80.xml
@@ -969,6 +969,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>A subsequent note, in the handwriting of the scribe, informs us that
                               this volume was written for <persName ref="http://syriaca.org/person/2640">Elisha, metropolitan of

--- a/data/tei/804.xml
+++ b/data/tei/804.xml
@@ -335,50 +335,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/808.xml
+++ b/data/tei/808.xml
@@ -531,50 +531,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/81.xml
+++ b/data/tei/81.xml
@@ -248,6 +248,7 @@
                   <!-- Vowels missing -->
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="115b" to="115b"/>
                   <p>On fol.<locus>115b</locus>, after the subscription of the book of<ref target="#a2">Exodus</ref>and the usual doxology, there is a note, part of which has been erased, and the rest retouched by a later hand, as it would seem, not always correctly. It runs as follows.</p>
                   <p>
@@ -258,6 +259,7 @@
                   </p>
                 </item>
                 <item n="4" xml:id="addition4">
+                  <label>Colophon</label>
                   <locus from="115b" to="115b"/>
                   <p>Then follows the date, the letters of which have also been slightly retouched.</p>
                   <p>
@@ -273,6 +275,7 @@
                     </bibl>.</p>
                 </item>
                 <item n="5" xml:id="addition5">
+                  <label>Colophon</label>
                   <locus from="115b" to="115b"/>
                   <p>The next note gives the name of<ref target="#handNote1">the scribe who wrote the first half of the manuscript</ref>, viz. the deacon<persName>John</persName>. The last line is in part no longer legible.</p>
                   <p>
@@ -376,50 +379,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/812.xml
+++ b/data/tei/812.xml
@@ -407,50 +407,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/813.xml
+++ b/data/tei/813.xml
@@ -572,50 +572,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/814.xml
+++ b/data/tei/814.xml
@@ -365,6 +365,7 @@
                   <p>The <ref>extract from a discourse on the Baptism of our Lord</ref>, written on foll. 144 b and 145 a, is in a more recent, current hand.</p>
                 </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                   <locus from="145b"/>
                   <p>On fol. 145 b there is a note. The date given, <date>A. Gr. 760</date>,
                     <date>A.D. 449</date>, is evidently erroneous, and perhaps <foreign xml:lang="syr">ܫܒܥܡܐܐ</foreign> may be a mistake for

--- a/data/tei/819.xml
+++ b/data/tei/819.xml
@@ -299,6 +299,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="126a"/>
                   <p>On fol. 126 a, after <ref>the doxology</ref>, there is a long note, which states that this
                     manuscript was written by one <persName>Sergius</persName>, for the <persName>deacon

--- a/data/tei/82.xml
+++ b/data/tei/82.xml
@@ -261,50 +261,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/820.xml
+++ b/data/tei/820.xml
@@ -357,6 +357,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="88a"/>
                            <p>Colophon:</p>
                            <p>
@@ -365,6 +366,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus from="88a"/>
                            <p>In the second column of the same page as <ref>the colophon</ref>, there is an imperfect note,
                               stating that this book was written at <placeName ref="http://syriaca.org/place/78">Edessa</placeName>, <date datingMethod="Hijri-qamari" when-custom="0158">A.H. 158</date>

--- a/data/tei/820.xml
+++ b/data/tei/820.xml
@@ -388,6 +388,7 @@
                            </p>
                         </item>
                 <item>
+                  <label>Doxology</label>
                   <locus from="88a"/>
                   <p>The doxology and the first part of <ref>the above note</ref>, at the foot of the
                     first column, have been erased, with the exception of the following words:</p>

--- a/data/tei/821.xml
+++ b/data/tei/821.xml
@@ -402,50 +402,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/824.xml
+++ b/data/tei/824.xml
@@ -405,6 +405,7 @@
                            </p>
                         </item>
                 <item xml:id="addition4" n="4">
+                  <label>Colophon</label>
                   <locus/>
                   <p>The Colophon is followed by a note, giving the name of the scribe,
                       <persName>the priest Theodosius</persName>.</p>
@@ -414,6 +415,7 @@
                   </p>
                 </item>
                 <item xml:id="addition5" n="5">
+                  <label>Colophon</label>
                            <locus from="281b"/>
                            <p>On fol. 281 b is a note, stating that this manuscript was written by
                               the said <persName>Theodosius</persName>, for the Tagritan monks

--- a/data/tei/825.xml
+++ b/data/tei/825.xml
@@ -415,6 +415,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="42b"/>
                            <p/>
                            <p>
@@ -426,6 +427,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>The colophon on fol. 146 b is so much stained and effaced that hardly
                               a single line of it is now completely legible. It does not appear,

--- a/data/tei/828.xml
+++ b/data/tei/828.xml
@@ -145,6 +145,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="97b"/>
                            <p>After the doxology, on fol. 97 b, we find a note, informing us that
                               the manuscript was written by one <persName>Elias</persName>, in the

--- a/data/tei/83.xml
+++ b/data/tei/83.xml
@@ -207,50 +207,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/834.xml
+++ b/data/tei/834.xml
@@ -279,6 +279,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p1addition1" syriaca-tags="scribal-colophon ownership-inscription">
+                    <label>Colophon</label>
                                         <locus from="99b" to="99b"/>
                                         <p>On fol. 99b, there is a note, written by the scribe in a more cursive character, which states that this book was purchased by<persName>
                                                 <foreign xml:lang="syr">ܡܪܝ ܡܢܝܡ</foreign>(<foreign xml:lang="grk">Μόνιμος</foreign>?)</persName>, priest of the church in the village of<foreign xml:lang="syr">ܚܪܝܫܬܐ</foreign>(perhaps<placeName>
@@ -570,6 +571,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p2addition1">
+                    <label>Colophon</label>
                                         <locus from="174b" to="174b"/>
                                         <ref target="#p2handNote1"/>
                                         <p>On fol. 174 b there is a long note written by the scribe in a more cursive character. See<bibl>Land, Aneed. Syr., t. i., plate v., no. 12</bibl>. It contained the date A. Gr.<origDate when-custom="0823" datingMethod="Seleucid">823</origDate>, A.D.<origDate when="0512" calendar="Gregorian">512</origDate>, as well as the name of the owner of the manuscript and of his convent; but these latter particulars have been erased.</p>
@@ -769,50 +771,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/84.xml
+++ b/data/tei/84.xml
@@ -168,6 +168,7 @@
             <additions>
               <list>
                 <item n="2" xml:id="addition2">
+                  <label>Colophon</label>
                   <locus from="89a" to="89a"/>
                   <ref target="#a1 #handNote1"/>
                   <p>Note following doxology and in smaller
@@ -186,6 +187,7 @@
                   <!-- Question about dots in the Syriac -->
                 </item>
                 <item n="3" xml:id="addition3">
+                  <label>Colophon</label>
                   <locus from="89b" to="89b"/>
                   <ref target="#handNote3"/>
                   <p>First note stating:</p>
@@ -317,50 +319,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/840.xml
+++ b/data/tei/840.xml
@@ -303,50 +303,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/841.xml
+++ b/data/tei/841.xml
@@ -209,50 +209,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/843.xml
+++ b/data/tei/843.xml
@@ -401,50 +401,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/846.xml
+++ b/data/tei/846.xml
@@ -370,6 +370,7 @@
               <p/>
               <list>
                                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus from="1a"/>
                            <p>Fol. 1 a exhibits an index to the discourses contained in the volume.
                               A note at the end of this index gives the name of the scribe,
@@ -380,6 +381,7 @@
                            </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus from="123b"/>
                            <p>On fol. 123 b, there is a note, similar to that in <bibl>Add. 14,515<ptr target="http://syriaca.org/manuscript/209"/>,<citedRange unit="locus">311b</citedRange>
                               </bibl>.</p>

--- a/data/tei/848.xml
+++ b/data/tei/848.xml
@@ -404,6 +404,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>A note on fol. 310 b, after the doxology, informs us that the scribe's
                               name was <persName>Jonas</persName>. The name of the owner has been

--- a/data/tei/849.xml
+++ b/data/tei/849.xml
@@ -1789,6 +1789,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="1a"/>
                   <p>
                     Above the coloured figure, we read the words: <quote xml:lang="syr">ܨ̣ܪ ܕܝܢ ܩܛܪܘܢܐ

--- a/data/tei/85.xml
+++ b/data/tei/85.xml
@@ -241,6 +241,7 @@
                   <p>There are a considerable number of various readings and notes, some of the latter being taken from the works of<persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>(foll.<locus from="36a" to="36a">36 a</locus>,<locus from="100a" to="100a">100 a</locus>).</p>
                 </item>
                 <item n="5" xml:id="addition5" syriaca-tags="colophon-incertus">
+                  <label>Colophon</label>
                   <locus from="1a" to="1a"/>
                   <quote xml:lang="syr">ܫܢܬ ܏ܐܠ ܏ܒܝ ܒܢܝܣܢ ܫ̇ܪܝ ܒܟܬܒܐ ܗܢܐ ܠܥܙܪ ܘܥܐܕܝ ܒ. .</quote>
                   <quote>"in the year<date when-custom="1030" datingMethod="Seleucid">1030</date>(<date when="0719" calendar="Gregorian">A.D. 719</date>), on the tenth of Nīsān,<persName>Lazarus</persName>and<persName>‘Adī</persName>began in this book . . . ."</quote>
@@ -336,50 +337,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/850.xml
+++ b/data/tei/850.xml
@@ -272,6 +272,7 @@
             <additions>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                   <locus from="82a"/>
                   <p>The colophon, fol. 82 a, informs us that the manuscript was written by one
                       <persName>Ignatius of Mabug</persName>, <date datingMethod="Seleucid" when-custom="1197">A. Gr. 1197</date>, 

--- a/data/tei/853.xml
+++ b/data/tei/853.xml
@@ -375,50 +375,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/857.xml
+++ b/data/tei/857.xml
@@ -213,50 +213,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/859.xml
+++ b/data/tei/859.xml
@@ -601,50 +601,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/86.xml
+++ b/data/tei/86.xml
@@ -176,17 +176,20 @@
             <additions>
               <list>
                 <item n="1" xml:id="addition1" syriaca-tags="scribal-colophon">
+                  <label>Colophon</label>
                   <locus from="73a" to="73a"/>
                   <desc>On fol. 73a, after the subscription, stands the following note, giving the name of the scribe, with his usual boast that he "never made a blotted tau.”</desc>
                   <quote xml:lang="syr">ܟܠ ܕܩ̇ܪܐ ܒܟܬܒܐ ܗܠܝܼܢ. ܢܨ̇ܠܐ ܥܠ ܚ̇ܛܝܐ ܘܕܘܝܐ ܡܪܣܒܐ ܫܡܫܐ ܟܬܘܒܐ ܪܝܫܥܝܢܝܐ ܕܟ̣ܬܒ ܐܝܟ ܚܝܠܗ܇ ܘܬܘ ܛܡܝܡܐ ܒܗܘܢ ܠܐ ܥܒܕ. ܘܢܐܡܪ̣ . ܐܠܗܐ̣ ܚܘܢܝܗܝ ܠܚ̇ܛܝܐ ܒܨܠܘܬ ܝܠܕܬܟ ܐܡܝܢ.</quote>
                 </item>
                 <item n="2" xml:id="addition2" syriaca-tags="scribal-colophon doxology">
+                  <label>Doxology</label>
                   <locus from="73a" to="73a"/>
                   <desc>
                     <ref target="#addition1">This</ref>is followed by the doxology:</desc>
                   <quote xml:lang="syr">ܫܘܒܚܐ ܠܬܠܝܬܝܘܬܐ ܕܠܐ ܦܘܠܓ ܐܡܝܢ ܘܐܡܝܢ</quote>
                 </item>
                 <item n="3" xml:id="addition3" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="73b" to="73b"/>
                   <desc>On fol. 73b are three notes, the first of which states that this copy of the biblical books was written at the expense of the bishop<persName>Constantine of<placeName>Māridīn</placeName>
                     </persName>(see<bibl>Add. 12,135,<citedRange unit="pp">fol. 42 b</citedRange>
@@ -196,6 +199,7 @@
                   <quote xml:lang="syr">ܠܐܝܩܪܐ ܘܠܬܫܒܘܚܬܐ ܕܐܒܐ ܘܒܪܐ ܘܪܘܚܐ ܩܕܝܫܐ: ܘܠܒܢܝܢܐ ܘܩܘܝ̇ܡܐ ܘܝܘܬܪܢܐ ܪܘܚܢܐ ܕܐܝܠܝܢ ܕܦܓܥܝܢ: ܐܬܚ̇ܦܛ ܘܣܡ ܣܝܡܬܐ ܗܕܐ ܪܘܚܢܝܬܐ ܕܟܬܒ̈ܐ ܗܠܝܢ ܒܥܘܡܪܐ ܕܝܠܗ ܣܦܩܠܝܣ ܕܪܝܫܥܝܢܐ̣. ܚܣܝܐ ܡܪܝ ܩܘܣܛܢܛܝܢܐ ܐܦܝܣܩܦܐ ܡܢܗ ܕܥܘܡܪܐ. ܚܠܦ ܦܘܪܩܢܐ ܕܪܘܚܗ ܘܕܘܟܪܢܐ ܛ̇ܒܐ ܕܥܢܝ̈ܕܘܗܝ. ܕܐܠܗܐ ܗ̇ܘ ܕܡܛܠ ܫܡܗ ܩܕܝܫܐ ܐܬܚܦܛ ܘܠܐܝ̣. ܗ̣ܘ ܢܬܠ ܠܗ ܐܓܪܐ ܘܦܘܪܥܢܐ ܒܡܠܟܘܬܐ ܕܫܡܝܐ ܥܡ ܩ̈ܕܝܫܐ ܕܪܚܡܘܗܝ ܐܝܢ ܘܐܡܝܢ</quote>
                 </item>
                 <item n="4" xml:id="addition4" syriaca-tags="scribal-colophon ownership-inscription">
+                  <label>Colophon</label>
                   <locus from="73b" to="73b"/>
                   <desc>The second note informs us that the expense was borne in part by the deacon<persName>Sarai of<placeName>Tel-Beshmai</placeName>
                     </persName>in the year<origDate when-custom="1035" datingMethod="Seleucid">1035</origDate>,<origDate when="0724" calendar="Gregorian">A.D. 724</origDate>, at the time when<persName>Simeon</persName>was abbat of the convent,<persName>Theodosius</persName>and<persName>Sarrai</persName>the stewards, and the<persName>deacon Anastasius</persName>the sacristan or warden. See<bibl>Assemani, loc. Cit., Tel-Besme</bibl>.</desc>
@@ -281,50 +285,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/865.xml
+++ b/data/tei/865.xml
@@ -132,6 +132,7 @@
                   </p>
                         </item>
                 <item xml:id="addition2" n="2">
+                  <label>Colophon</label>
                            <locus/>
                            <p>Again, on fol. 16 b, there is a second colophon.</p>
                            <p>

--- a/data/tei/87.xml
+++ b/data/tei/87.xml
@@ -175,6 +175,7 @@
             <additions>
               <list>
                 <item n="1" xml:id="additon1" syriaca-tags="scribal-colophon doxology">
+                  <label>Colophon</label>
                   <locus from="157a" to="157a"/>
                   <p>On fol.<locus>157a</locus>after the doxology, there, is a note, mentioning the name of the, scribe<persName>Sergūnā</persName>:</p>
                   <p>
@@ -275,50 +276,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/874.xml
+++ b/data/tei/874.xml
@@ -2257,50 +2257,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/88.xml
+++ b/data/tei/88.xml
@@ -369,50 +369,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/89.xml
+++ b/data/tei/89.xml
@@ -177,6 +177,7 @@
                     <p>A later hand has added a marginal division of <ref>the Psalms</ref> into <foreign xml:lang="syr">ܡܪ̈ܡܝܬܐ</foreign> and <foreign xml:lang="syr">ܫܘܒ̈ܚܐ</foreign>.</p>
                 </item>
                   <item>
+                      <label>Doxology</label>
                       <locus from="207b"/>
                       <p>On fol. 207 b, after <ref>the doxology</ref>, stands the following prayer, from which we learn that the name of the scribe was <persName>Mārūthā</persName>.</p>
                       <p>

--- a/data/tei/895.xml
+++ b/data/tei/895.xml
@@ -278,6 +278,7 @@
                                 <p/>
                                 <list>
                                     <item n="1" xml:id="p2addition1">
+                    <label>Colophon</label>
                                         <locus from="5a" to="5a"/>
                                         <p>On<locus from="5a" to="5a">fol. 5 a</locus>there is a note, stating that the manuscript was written, at the date above mentioned, by<persName>Arabi</persName>, a monk of the<placeName ref="http://syriaca.org/place/229">convent of Karkaphta</placeName>, or "the Skull," for the deacon<persName>Ishai bar Habib</persName>, of the village of<placeName>Ramin</placeName>near<placeName ref="http://syriaca.org/place/130">Maridin</placeName>.</p>
                                         <p>
@@ -1904,6 +1905,7 @@
                             <additions>
                                 <list>
                                     <item n="1" xml:id="p16addition1">
+                    <label>Colophon</label>
                                         <locus from="48b" to="48b"/>
                                         <p>
                                             <quote>ܫܠܡ ܠܡܟܬܒ ܟܬܒܐ ܗܢܐ ܥܡ ܟܠܗܘܢ ܫܪ̈ܒܘܗܝ ܦܩܘܕܘܢ ܡܛܠ ܡܪܢ ܘܨܠܘ ܥܠ ܡܪ̈ܘܗܝ ܡܛܠ ܚܘܒܐ.</quote>
@@ -2160,50 +2162,110 @@
                         <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
                     </bibl>
                     <category xml:id="biblical-manuscripts">
-                        <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-                        <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-                        <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-                        <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+                        <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+                        <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+                        <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+                        <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
                     </category>
                     <category xml:id="service-books">
-                        <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-                        <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-                        <category xml:id="missals"><catDesc>Missals</catDesc></category>
-                        <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-                        <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-                        <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-                        <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-                        <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+                        <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+                        <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+                        <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+                        <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+                        <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+                        <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+                        <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+                        <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
                     </category>
                     <category xml:id="theology">
-                        <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-                        <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-                        <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-                        <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-                        <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+                        <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+                        <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+                        <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+                        <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+                        <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-history">
-                        <category xml:id="history"><catDesc>History</catDesc></category>
+                        <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
                     </category>
                     <category xml:id="lives">
-                        <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-                        <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+                        <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+                        <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
                     </category>
                     <category xml:id="scientific-lit">
-                        <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-                        <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-                        <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-                        <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-                        <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-                        <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-                        <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+                        <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+                        <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+                        <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+                        <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+                        <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+                        <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+                        <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
                     </category>
                     <category xml:id="wright-fly-leaves">
-                        <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+                        <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
                     </category>
                     <category xml:id="appendices">
-                        <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-                        <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+                        <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+                        <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
                     </category>
                 </taxonomy>
             </classDecl>

--- a/data/tei/9.xml
+++ b/data/tei/9.xml
@@ -560,6 +560,7 @@
                     <p>A later hand has placed<foreign xml:lang="syr">ܕ̄</foreign>on the margin, opposite<foreign xml:lang="syr">ܬܠܬܐ</foreign>, and added<foreign xml:lang="syr">ܘܐܦ ܡܪܩܘܣ</foreign>.</p>
                   </item>
                   <item n="3" xml:id="p4addition3">
+                    <label>Colophon</label>
                     <locus from="213a" to="213a"/>
                     <p>After the usual doxology, there follow two notes, but both have been erased, so as to be now almost illegible. The first begins:</p>
                     <p>
@@ -771,50 +772,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/90.xml
+++ b/data/tei/90.xml
@@ -529,6 +529,7 @@
                     <quote/>
                   </item>
                   <item n="5" xml:id="p2addition5">
+                    <label>Colophon</label>
                     <ref target="#p2handNote6"/>
                     <desc>This manuscript was written by a scribe from the<placeName>city of Amid</placeName>, whose name appears to have been<persName>Simeon</persName>:</desc>
                     <quote xml:lang="syr">[ܐ̇ܢܐ ܫܡܥ]ܘܢ ܩܫܝܫܐ ܡܢ ܐܡܕ ܡܕܝܢܬܐ [ܟܬ̇ܒ]ܬ ܐܝܟ ܚܝܠܝ. ܟܠ ܕܩ̇ܪܐ ܢܨܠܐ ܥܠܝ ܡܛܠ ܡܪܢ̇ ܕܐ̇ܬܚܢܢ ܐܝܟ ܓܝܿܣܐ ܕܡܢ ܝܡܝܢܐ ܐܡܝܢ ܘܐܡܝܢ܀</quote>
@@ -597,50 +598,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/911.xml
+++ b/data/tei/911.xml
@@ -1913,50 +1913,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/929.xml
+++ b/data/tei/929.xml
@@ -2798,50 +2798,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/956.xml
+++ b/data/tei/956.xml
@@ -2584,50 +2584,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/97.xml
+++ b/data/tei/97.xml
@@ -392,6 +392,8 @@
                     <p>One annotation from<persName>Epiphanius</persName>(de Mensuris, fol. 102a).</p>
                   </item>
                   <item n="5" xml:id="p2addition5" syriaca-tags="scribal-colophon doxology">
+                    <label>Colophon</label>
+                    <label>Doxology</label>
                     <locus from="122a" to="122a"/>
                     <p>The usual doxology, after which we have the following note of the translator,<persName ref="http://syriaca.org/person/82">Paul of Tellā</persName>:</p>
                     <p>
@@ -552,12 +554,14 @@
                 <p/>
                 <list>
                   <item n="1" xml:id="p3addition1">
+                    <label>Colophon</label>
                     <locus from="123b" to="123b"/>
                     <p>Fol. 123 was the last leaf of the book, containing on the recto a note, giving the date and the name of the scribe<persName>Romanus</persName>:</p>
                     <p>
                       <quote xml:lang="syr">ܝܪܚ ܬܫܪܝܢ. . . ܝܘܡ ܥܪܘܒܬ[ܐ]. . . ܐܠܦ. . . ܘܣ. . . ܟܘܪܐ [ܕܚܡܨ؟] ܟܠ ܕܩܪܐ̣. ܢܨܠܐ ܥܠ ܚܛܝܐ ܪܘܡܢܐ ܕܥܡ̣ܠ ܘܟ̣ܬܒ. ܠܝܘܬܪܢܐ ܕܪ̈ܚܡܝ ܝܘܠܦܢܐ ܕܥܘܡܪܗ. ܐܠܐ ܟܠ ܕܩ̇ܪܐ ܘܝ̇ܬܪ܆ ܢܨܠܐ ܥܠܘܗܝ. ܘ܏ܫ</quote>.</p>
                   </item>
                   <item n="2" xml:id="p3addition2">
+                    <label>Colophon</label>
                     <locus from="124b" to="124b"/>
                     <p>On the verso there is another note, giving the date<date when-custom="1014" datingMethod="Seleucid">A. Gr. 1014</date>,<date when="0703" calendar="Gregorian">A.D. 703</date>, and mentioning that the sum of 5 1/2 dīnārs was paid for the writing:</p>
                     <p>
@@ -622,50 +626,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>

--- a/data/tei/981.xml
+++ b/data/tei/981.xml
@@ -261,6 +261,7 @@
               <p/>
               <list>
                 <item xml:id="p2addition1" n="1">
+                    <label>Colophon</label>
                            <locus from="186a"/>
                            <p>The colophon, fol. 186 a, states that the volume belonged to one
                                  <persName>Rabban Abraham</persName>.</p>

--- a/data/tei/982.xml
+++ b/data/tei/982.xml
@@ -225,6 +225,7 @@
               <p/>
               <list>
                 <item xml:id="addition1" n="1">
+                  <label>Colophon</label>
                            <locus/>
                            <p>On fol. 105 a, the scribe has recorded his name,
                                  <persName>Domitius</persName>.</p>

--- a/data/tei/985.xml
+++ b/data/tei/985.xml
@@ -1921,50 +1921,110 @@
             <ptr target="http://syriaca.org/documentation/Wright-BL-Taxonomy.html"/>
           </bibl>
           <category xml:id="biblical-manuscripts">
-            <category xml:id="bible-ot"><catDesc>Old Testament</catDesc></category>
-            <category xml:id="bible-nt"><catDesc>New Testament</catDesc></category>
-            <category xml:id="bible-apocrypha"><catDesc>Apocrypha</catDesc></category>
-            <category xml:id="bible-punctuation"><catDesc>Punctuation</catDesc></category>
+            <category xml:id="bible-ot">
+              <catDesc>Old Testament</catDesc>
+            </category>
+            <category xml:id="bible-nt">
+              <catDesc>New Testament</catDesc>
+            </category>
+            <category xml:id="bible-apocrypha">
+              <catDesc>Apocrypha</catDesc>
+            </category>
+            <category xml:id="bible-punctuation">
+              <catDesc>Punctuation</catDesc>
+            </category>
           </category>
           <category xml:id="service-books">
-            <category xml:id="psalter"><catDesc>Psalters</catDesc></category>
-            <category xml:id="lectionaries"><catDesc>Lectionaries</catDesc></category>
-            <category xml:id="missals"><catDesc>Missals</catDesc></category>
-            <category xml:id="sacerdotals"><catDesc>Sacerdotals</catDesc></category>
-            <category xml:id="choral"><catDesc>Choral Books</catDesc></category>
-            <category xml:id="hymns"><catDesc>Hymns</catDesc></category>
-            <category xml:id="prayers"><catDesc>Prayers</catDesc></category>
-            <category xml:id="funerals"><catDesc>Funeral Services</catDesc></category>
+            <category xml:id="psalter">
+              <catDesc>Psalters</catDesc>
+            </category>
+            <category xml:id="lectionaries">
+              <catDesc>Lectionaries</catDesc>
+            </category>
+            <category xml:id="missals">
+              <catDesc>Missals</catDesc>
+            </category>
+            <category xml:id="sacerdotals">
+              <catDesc>Sacerdotals</catDesc>
+            </category>
+            <category xml:id="choral">
+              <catDesc>Choral Books</catDesc>
+            </category>
+            <category xml:id="hymns">
+              <catDesc>Hymns</catDesc>
+            </category>
+            <category xml:id="prayers">
+              <catDesc>Prayers</catDesc>
+            </category>
+            <category xml:id="funerals">
+              <catDesc>Funeral Services</catDesc>
+            </category>
           </category>
           <category xml:id="theology">
-            <category xml:id="theo-single"><catDesc>Individual Authors</catDesc></category>
-            <category xml:id="theo-collected"><catDesc>Collected Authors</catDesc></category>
-            <category xml:id="theo-catenae"><catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc></category>
-            <category xml:id="theo-anonymous"><catDesc>Anonymous Works</catDesc></category>
-            <category xml:id="theo-council"><catDesc>Councils of the Church and Ecclesiastical Canons</catDesc></category>
+            <category xml:id="theo-single">
+              <catDesc>Individual Authors</catDesc>
+            </category>
+            <category xml:id="theo-collected">
+              <catDesc>Collected Authors</catDesc>
+            </category>
+            <category xml:id="theo-catenae">
+              <catDesc>Catenae Patrum and Demonstrations against Heresies</catDesc>
+            </category>
+            <category xml:id="theo-anonymous">
+              <catDesc>Anonymous Works</catDesc>
+            </category>
+            <category xml:id="theo-council">
+              <catDesc>Councils of the Church and Ecclesiastical Canons</catDesc>
+            </category>
           </category>
           <category xml:id="wright-history">
-            <category xml:id="history"><catDesc>History</catDesc></category>
+            <category xml:id="history">
+              <catDesc>History</catDesc>
+            </category>
           </category>
           <category xml:id="lives">
-            <category xml:id="lives-collect"><catDesc>Collected Lives</catDesc></category>
-            <category xml:id="lives-single"><catDesc>Single Lives</catDesc></category>
+            <category xml:id="lives-collect">
+              <catDesc>Collected Lives</catDesc>
+            </category>
+            <category xml:id="lives-single">
+              <catDesc>Single Lives</catDesc>
+            </category>
           </category>
           <category xml:id="scientific-lit">
-            <category xml:id="sci-logic"><catDesc>Logic and Rhetoric</catDesc></category>
-            <category xml:id="sci-grammar"><catDesc>Grammar and Lexicography</catDesc></category>
-            <category xml:id="sci-ethics"><catDesc>Ethics</catDesc></category>
-            <category xml:id="sci-medicine"><catDesc>Medicine</catDesc></category>
-            <category xml:id="sci-agriculture"><catDesc>Agriculture</catDesc></category>
-            <category xml:id="sci-chemistry"><catDesc>Chemistry</catDesc></category>
-            <category xml:id="sci-natural-history"><catDesc>Natural History</catDesc></category>
+            <category xml:id="sci-logic">
+              <catDesc>Logic and Rhetoric</catDesc>
+            </category>
+            <category xml:id="sci-grammar">
+              <catDesc>Grammar and Lexicography</catDesc>
+            </category>
+            <category xml:id="sci-ethics">
+              <catDesc>Ethics</catDesc>
+            </category>
+            <category xml:id="sci-medicine">
+              <catDesc>Medicine</catDesc>
+            </category>
+            <category xml:id="sci-agriculture">
+              <catDesc>Agriculture</catDesc>
+            </category>
+            <category xml:id="sci-chemistry">
+              <catDesc>Chemistry</catDesc>
+            </category>
+            <category xml:id="sci-natural-history">
+              <catDesc>Natural History</catDesc>
+            </category>
           </category>
           <category xml:id="wright-fly-leaves">
-            <category xml:id="fly-leaves"><catDesc>Fly Leaves</catDesc></category>
+            <category xml:id="fly-leaves">
+              <catDesc>Fly Leaves</catDesc>
+            </category>
           </category>
           <category xml:id="appendices">
-            <category xml:id="appendix-a"><catDesc>Appendix A</catDesc></category>
-            <category xml:id="appendix-b"><catDesc>Appendix B</catDesc></category>
+            <category xml:id="appendix-a">
+              <catDesc>Appendix A</catDesc>
+            </category>
+            <category xml:id="appendix-b">
+              <catDesc>Appendix B</catDesc>
+            </category>
           </category>
         </taxonomy>
       </classDecl>


### PR DESCRIPTION
Ingests the data from labeling the colophon and doxology additions using the spreadsheet [here](https://docs.google.com/spreadsheets/d/183Sm8nyRtlE2Ucl5JyLg4_RvXSgTF-xB0ceacj2n3BY/edit?pli=1#gid=1612849240).

A tei:label element with keywords "Colophon" or "Doxology" was added to each matching `//additions/list/item`.

This will resolve #39 