### PR TITLE
Manage whitespace in title

### DIFF
--- a/data/tei/10.xml
+++ b/data/tei/10.xml
@@ -243,8 +243,7 @@
                   <persName xml:lang="en">Jesus the son of Sirach</persName>
                 </author>
                 <title ref="http://syriaca.org/work/9575" xml:lang="en">Ecclesiasticus, or the
-                  Wisdom of <persName>Jesus the son of <persName>Sirach</persName>
-                  </persName>
+                  Wisdom of <persName>Jesus the son of <persName>Sirach</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܼܒ݂ ܫܡܵܗܸ̈ܐ ܘܲܩܪ̈ܵܝܵܬ݂ܵܐ ܕܡ̣ܢ ܚܟ݂ܡܬ݂ܵܐ
                   ܕܒ݁ܪܣܝ̣ܪܵܐ</rubric>

--- a/data/tei/10.xml
+++ b/data/tei/10.xml
@@ -243,8 +243,7 @@
                   <persName xml:lang="en">Jesus the son of Sirach</persName>
                 </author>
                 <title ref="http://syriaca.org/work/9575" xml:lang="en">Ecclesiasticus, or the
-                  Wisdom of <persName>Jesus the son of
-                  <persName>Sirach</persName>
+                  Wisdom of <persName>Jesus the son of <persName>Sirach</persName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܼܒ݂ ܫܡܵܗܸ̈ܐ ܘܲܩܪ̈ܵܝܵܬ݂ܵܐ ܕܡ̣ܢ ܚܟ݂ܡܬ݂ܵܐ
@@ -453,8 +452,7 @@
               </msItem>
               <msItem xml:id="b38" n="43">
                 <locus from="312"/>
-                <title xml:lang="en">The prayer that <persName ref="http://syriaca.org/person/1808">S. John (the Baptist)</persName> taught <persName>his
-                  disciples</persName>.</title>
+                <title xml:lang="en">The prayer that <persName ref="http://syriaca.org/person/1808">S. John (the Baptist)</persName> taught <persName>his disciples</persName>.</title>
                 <rubric xml:lang="syr">ܬܘܒ ܨܠܘܬܐ ܕܐܠܦ ܝܘܚܢܢ ܠܬܠܡ̈ܝܕܘܗܝ ܐܒܐ ܚܘܢܝ ܒܪܟ. ܒܪܐ ܚܘܢܝ ܪܘܚܟ.
                   ܪܘܚܐ ܕܩܘܕܫܐ ܚܟܡܝܢܝ ܒܫܪܪܟ. ܘܐܝܬ ܕܐܡܪ̈ܝܢ ܕܗܕܐ ܗܝ. ܐܒܐ ܩܕܝܫܐ ܩܕܝܫܝ (ܩܕܫܝܢܝ read)
                   ܒܫܪܪܟ. ܘܐܘܕܥܝܢܝ ܫܘܒܚܐ ܕܪܒܘܬܟ ܘܚܘܢܝ ܒܪܟ ܘܡܠܝܢܝ ܡܢ ܪܘܚܟ ܕܐܬܢܗܪ ܒܝܕܥܬܟ.</rubric>

--- a/data/tei/1014.xml
+++ b/data/tei/1014.xml
@@ -234,8 +234,7 @@
               </msItem>
               <msItem xml:id="b16" n="24" defective="true">
                 <locus from="143a" to="145">Foll. 143a-145</locus>
-                <title xml:lang="en">The Commemoration of <persName>Isaiah of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">The Commemoration of <persName>Isaiah of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܡܪܝ ܐܫܥܝܐ ܚܴ̇ܠܴܒܴܝܴܐ</rubric>
               </msItem>
               <msItem xml:id="b17" n="25" defective="true">
@@ -247,15 +246,13 @@
               <msItem xml:id="b18" n="26">
                 <locus from="148b" to="151">Foll. 148b-151</locus>
                 <title xml:lang="en">Of <persName>Mār Simeon</persName> and
-                              <persName>Mār Samuel of <placeName>Kartamīn</placeName>
-                  </persName>.</title>
+                              <persName>Mār Samuel of <placeName>Kartamīn</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܣܕܪܐ ܥܠ ܡܪܝ ܫܡ̣ܥܘܢ ܘܡܪܝ ܫܡ̣ܘܐܝܠ ܕܥܘܼܡܪܐ
                            ܕܩܲܪܬܡܝܢ</rubric>
               </msItem>
               <msItem xml:id="b19" n="27">
                 <locus from="152a" to="155">Foll. 152a-155</locus>
-                <title xml:lang="en">Of <persName>Mār Gabriel of <placeName>Kartamīn</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Of <persName>Mār Gabriel of <placeName>Kartamīn</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܐܚܪܢܐ ܕܥܠ ܡܪܝ ܓܒܪܐܝܠ ܕܥܘܼܡܪܐ</rubric>
               </msItem>
               <msItem xml:id="b20" n="28">
@@ -270,8 +267,7 @@
               </msItem>
               <msItem xml:id="b22" n="30">
                 <locus from="161a" to="163">Foll. 161a-163</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
                 <rubric xml:lang="syr"> ܛܟܣ̣ܐ ܕܩ̇ܕܝܫܐ ܡܪܝ ܦܻܝܠܳܠܘܟܣܶܢܳܘܣ ܐ܏ܦܝܣ
                            ܕܡܲܰܐܒܽܘܓ.</rubric>
               </msItem>

--- a/data/tei/1014.xml
+++ b/data/tei/1014.xml
@@ -159,8 +159,7 @@
               </msItem>
               <msItem xml:id="b3" n="11" defective="true">
                 <locus from="59a" to="68">Foll. 59a-68</locus>
-                <title xml:lang="en">The Ascension of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                <title xml:lang="en">The Ascension of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕ[ܣܘܠܩܗ] ܕܡܪܢ ܠܫܡܝܐ</rubric>
               </msItem>
               <msItem xml:id="b4" n="12">
@@ -170,8 +169,7 @@
               </msItem>
               <msItem xml:id="b5" n="13">
                 <locus from="77a" to="82">Foll. 77a-82</locus>
-                <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/1607">twelve
-                           Apostles</persName>.</title>
+                <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/1607">twelve Apostles</persName>.</title>
                 <rubric xml:lang="syr">ܛܶܟܣ̣ܳܐ ܕܥܠ ܬܪܶܥܣ̣ܰܪ ܫ̈ܠܻܝ̣ܚܶܐ ܓܲܰܘܳܢܳܐܻܝܬ</rubric>
               </msItem>
               <msItem xml:id="b6" n="14">
@@ -191,21 +189,18 @@
               </msItem>
               <msItem xml:id="b8" n="16">
                 <locus from="87b" to="96">Foll. 87b-96</locus>
-                <title xml:lang="en">The Transfiguration of <persName ref="http://syriaca.org/person/2245">our
-                              Lord</persName>
+                <title xml:lang="en">The Transfiguration of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܐܕܐ ܕܡ̈ܛܠܠܐ</rubric>
               </msItem>
               <msItem xml:id="b9" n="17">
                 <locus from="96b" to="105">Foll. 96b-105</locus>
-                <title xml:lang="en">The Decease of the <persName ref="http://syriaca.org/person/624">blessed
-                              Virgin</persName>.</title>
+                <title xml:lang="en">The Decease of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܫܽܘܢܳܝܳܗ̇ ܕܝ̇ܳܠܕܰܬ݀ ܐܠܗܐ ܡܪܝܡ</rubric>
               </msItem>
               <msItem xml:id="b10" n="18" defective="true">
                 <locus from="105b" to="107">Foll. 105b-107</locus>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/744">Simeon
-                              Stylites</persName>.</title>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܡܪܝ ܫܡ̣ܥܘܢ ܕܐܣܛܘܢܗ</rubric>
               </msItem>
               <msItem xml:id="b11" n="19" defective="true">
@@ -239,8 +234,7 @@
               </msItem>
               <msItem xml:id="b16" n="24" defective="true">
                 <locus from="143a" to="145">Foll. 143a-145</locus>
-                <title xml:lang="en">The Commemoration of <persName>Isaiah of
-                           <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
+                <title xml:lang="en">The Commemoration of <persName>Isaiah of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܡܪܝ ܐܫܥܝܐ ܚܴ̇ܠܴܒܴܝܴܐ</rubric>
               </msItem>
@@ -253,16 +247,14 @@
               <msItem xml:id="b18" n="26">
                 <locus from="148b" to="151">Foll. 148b-151</locus>
                 <title xml:lang="en">Of <persName>Mār Simeon</persName> and
-                              <persName>Mār Samuel of
-                           <placeName>Kartamīn</placeName>
+                              <persName>Mār Samuel of <placeName>Kartamīn</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܣܕܪܐ ܥܠ ܡܪܝ ܫܡ̣ܥܘܢ ܘܡܪܝ ܫܡ̣ܘܐܝܠ ܕܥܘܼܡܪܐ
                            ܕܩܲܪܬܡܝܢ</rubric>
               </msItem>
               <msItem xml:id="b19" n="27">
                 <locus from="152a" to="155">Foll. 152a-155</locus>
-                <title xml:lang="en">Of <persName>Mār Gabriel of
-                                 <placeName>Kartamīn</placeName>
+                <title xml:lang="en">Of <persName>Mār Gabriel of <placeName>Kartamīn</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܐܚܪܢܐ ܕܥܠ ܡܪܝ ܓܒܪܐܝܠ ܕܥܘܼܡܪܐ</rubric>
               </msItem>
@@ -273,14 +265,12 @@
               </msItem>
               <msItem xml:id="b21" n="29">
                 <locus from="159a" to="160">Foll. 159a-160</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1122">Mār Ahā the
-                           ascetic</persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1122">Mār Ahā the ascetic</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܡܪܝ ܐܰܚܳܐ ܥ̇ܳܢܘܳܝܳܐ</rubric>
               </msItem>
               <msItem xml:id="b22" n="30">
                 <locus from="161a" to="163">Foll. 161a-163</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                           <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr"> ܛܟܣ̣ܐ ܕܩ̇ܕܝܫܐ ܡܪܝ ܦܻܝܠܳܠܘܟܣܶܢܳܘܣ ܐ܏ܦܝܣ
                            ܕܡܲܰܐܒܽܘܓ.</rubric>
@@ -300,14 +290,12 @@
               </msItem>
               <msItem xml:id="b25" n="33">
                 <locus from="169a" to="171">Foll. 169a-171</locus>
-                <title xml:lang="en">Of <persName>Elias the
-                           prophet</persName>.</title>
+                <title xml:lang="en">Of <persName>Elias the prophet</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܚ̈ܘܣܝܐ ܕܥܠ ܐܻܠܻܝܳܐ ܢܒܝܐ</rubric>
               </msItem>
               <msItem xml:id="b26" n="34">
                 <locus from="171b" to="173">Foll. 171b-173</locus>
-                <title xml:lang="en">Of <persName>George the
-                           martyr</persName>.</title>
+                <title xml:lang="en">Of <persName>George the martyr</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܣܗܕܐ ܏ܩܕ ܡܪܝ ܓܐܘܪܓܝܣ </rubric>
               </msItem>
               <msItem xml:id="b27" n="35">
@@ -337,8 +325,7 @@
               </msItem>
               <msItem xml:id="b31" n="39">
                 <locus from="199b" to="204">Foll. 199b-204</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1826">S. John the
-                                 Evangelist</persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1826">S. John the Evangelist</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܡܪܝ ܝܘܚ݊ܢܢ ܫܠܝ̣ܚܐ ܘܐܘܢܓܠܝ̣ܣܛܐ</rubric>
                 <note xml:lang="en">The sedra in this service is by <persName>Abraham of
                       <placeName>Chabūr</placeName>

--- a/data/tei/1015.xml
+++ b/data/tei/1015.xml
@@ -105,8 +105,7 @@
                         occasions.</title>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a"/>
-                <title xml:lang="en">The <foreign xml:lang="syr">ܡ̈ܥܢܝܬܐ</foreign> or hymns of <persName>Severus, patriarch of
-                           <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">The <foreign xml:lang="syr">ܡ̈ܥܢܝܬܐ</foreign> or hymns of <persName>Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>, 351
                               (<foreign xml:lang="syr">ܫܢܐ</foreign>) in number.</title>
                 <msItem xml:id="c1" n="3" defective="true">
@@ -173,8 +172,7 @@
               </msItem>
               <msItem xml:id="b9" n="12" defective="true">
                 <locus from="90a" to="154">Foll. 90a-154</locus>
-                <title xml:lang="en">Anthems and canons of the <persName ref="http://syriaca.org/person/624">blessed
-                              Virgin</persName>, the Martyrs, and the Dead.</title>
+                <title xml:lang="en">Anthems and canons of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>, the Martyrs, and the Dead.</title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܥ̈ܢܝܢܐ ܘܩ̈ܢܘܢܐ ܓܘ̈ܢܝܐ ܕܝ̇ܠܕܬ݀ ܐܠܗܐ ܘܕܣ̈ܗܕܐ
                            ܘܕܥ̈ܢܝܕܐ</rubric>
                 <note>They are arranged according to the eight tones, <foreign xml:lang="syr">ܟܠ ܩܝ̣ܢܬܐ
@@ -199,8 +197,7 @@
               </msItem>
               <msItem xml:id="b13" n="16">
                 <locus from="164b" to="174">Foll. 164b-174</locus>
-                <title xml:lang="en">Hymns for the festival of the <persName>holy
-                              Cross</persName>.</title>
+                <title xml:lang="en">Hymns for the festival of the <persName>holy Cross</persName>.</title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܩ̈ܠܐ ܕܝܠܗ ܕܥܐܕܐ ܕܨܠܝܒܐ</rubric>
                 <note>They are followed by prayers of <persName>Jacob</persName>,
                            <persName ref="http://syriaca.org/person/13">Ephraim</persName>, and <persName>Balaeus</persName>,
@@ -294,8 +291,7 @@
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܒ̈ܥܘܬܐ</rubric>
                 <msItem xml:id="c3" n="29" defective="true">
                   <locus from="307a" to="333">Foll. 307a-333</locus>
-                  <title xml:lang="en">Of <persName>Jacob of
-                              Batnae</persName>.</title>
+                  <title xml:lang="en">Of <persName>Jacob of Batnae</persName>.</title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ</rubric>
                 </msItem>
                 <msItem xml:id="c4" n="30" defective="true">

--- a/data/tei/1015.xml
+++ b/data/tei/1015.xml
@@ -105,8 +105,7 @@
                         occasions.</title>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a"/>
-                <title xml:lang="en">The <foreign xml:lang="syr">ܡ̈ܥܢܝܬܐ</foreign> or hymns of <persName>Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, 351
+                <title xml:lang="en">The <foreign xml:lang="syr">ܡ̈ܥܢܝܬܐ</foreign> or hymns of <persName>Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, 351
                               (<foreign xml:lang="syr">ܫܢܐ</foreign>) in number.</title>
                 <msItem xml:id="c1" n="3" defective="true">
                   <locus from="1a" to="5">Foll. 1a-5</locus>
@@ -254,8 +253,7 @@
                 <locus from="214a" to="216">Foll. 214a-216</locus>
                 <title xml:lang="en">A canon for the same occasion composed by
                                  <persName>Sa'īd (or Mār John) bar Sabūnī,
-                                    bishop of <placeName ref="http://syriaca.org/place/136">Melitene</placeName>
-                  </persName>.</title>
+                                    bishop of <placeName ref="http://syriaca.org/place/136">Melitene</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܟ̇ܬܒܝܢܢ ܬܘܒ ܘܬܫ̈ܒܚܬܐ ܕܩܢܘܢܐ ܚ̣ܕܬܐ. ܣ̇ܝܘܡܘܬܐ ܕܣܥ̣ܝܕ
                            ܡܢܚܐ ܒܪ ܨܒܘܢܝ ܗ̇ܘ ܕܐܬܬܣܪܚ ܠܡܠܝܛܝܢܝ ܘܐܬ݀ܟ̣ܢܝ ܡܪܝ ܝܘܚܢܢ. ܐܝܬܝ̈ܗܝܢ ܕܝܢ
                            ܬܫܒ̈ܚܬܐ ܕܡܪ̈ܟܒܢ ܥܠ ܏ܕܐܝܟܘܣ (sic) ܬܪܝܢܐ ܡ̈ܛܟܣܢ ܥܠ ܥܐܕܐ ܕܕܢܚܐ ܐܘܟܝܬ ܕܥܡ̇ܕܐ.

--- a/data/tei/1019.xml
+++ b/data/tei/1019.xml
@@ -157,8 +157,7 @@
               <msItem xml:id="b5" n="6">
                 <locus from="54b"/>
                 <title xml:lang="en">The second Sunday of Pentecost; the Commemoration of
-                    <persName>Joseph of <placeName>Arimathaea</placeName>
-                  </persName>,
+                    <persName>Joseph of <placeName>Arimathaea</placeName></persName>,
                     <persName>Nicodemus</persName>, and the women who brought the spices</title>
                 <rubric xml:lang="syr">ܚܕ܏ܒܫܒ ܒ ܕ܏ܦܝܢܛ ܕܘܟܪܢ ܝܘܣܦ ܘܢܩܕܘ܏ܡܝܘ ܕܥ̈ܦܝܘ ܠܡܪܢ ܘܕܢܫ̈ܐ
                   ܗܪ̈ܘܡܢܝܬܐ</rubric>

--- a/data/tei/1021.xml
+++ b/data/tei/1021.xml
@@ -276,8 +276,7 @@
                 <msItem xml:id="c23" n="30">
                   <locus from="153b" to="158">Foll. 153b-158</locus>
                   <title xml:lang="en">On the 25th, the Decease of <persName ref="http://syriaca.org/person/1590">Anna,
-                              the mother of the <persName ref="http://syriaca.org/person/624">Virgin Mary</persName>
-                    </persName>.</title>
+                              the mother of the <persName ref="http://syriaca.org/person/624">Virgin Mary</persName></persName>.</title>
                   <rubric xml:lang="syr">ܟܗ: ܒܬܡܘܙ: ܥܘܢܕܢܗ̇ ܕܩܕܝܫܬܐ ܚܢܹܐ: ܙܕܝܩܬܐ: ܐܡܐ
                               ܕܝܠܕܬ݀ ܐܠܗܐ ܡܪܝܡ</rubric>
                 </msItem>

--- a/data/tei/1021.xml
+++ b/data/tei/1021.xml
@@ -113,8 +113,7 @@
                 </msItem>
                 <msItem xml:id="c2" n="4" defective="true">
                   <locus from="2b" to="9">Foll. 2b-9</locus>
-                  <title xml:lang="en">On the 2nd, the Presentation of <persName ref="http://syriaca.org/person/2245">our
-                                 Lord</persName> in the Temple.</title>
+                  <title xml:lang="en">On the 2nd, the Presentation of <persName ref="http://syriaca.org/person/2245">our Lord</persName> in the Temple.</title>
                   <rubric xml:lang="syr-x-syrm">ܒ: ܒܫܒܛ: ܥܐܕܐ ܡܪܐܢܝܐ ܕܡܥܠܬܗ̣ ܕܡܪܢ ܝܫܘܥ
                               ܠܗܝܟܠܐ</rubric>
                 </msItem>
@@ -259,8 +258,7 @@
                 </msItem>
                 <msItem xml:id="c20" n="27">
                   <locus from="133a" to="137">Foll. 133a-137</locus>
-                  <title xml:lang="en">On the 8th, the Commemoration of the <persName ref="http://syriaca.org/person/2026">martyr
-                              Procopius</persName>.</title>
+                  <title xml:lang="en">On the 8th, the Commemoration of the <persName ref="http://syriaca.org/person/2026">martyr Procopius</persName>.</title>
                   <rubric xml:lang="syr">ܚ: ܒܬܡܘܙ܀ ܕܘܟܪܢܐ ܕܣܗܕܐ ܪܒܐ ܦܪܘܩܘܦܝܘܣ</rubric>
                 </msItem>
                 <msItem xml:id="c21" n="28">
@@ -278,8 +276,7 @@
                 <msItem xml:id="c23" n="30">
                   <locus from="153b" to="158">Foll. 153b-158</locus>
                   <title xml:lang="en">On the 25th, the Decease of <persName ref="http://syriaca.org/person/1590">Anna,
-                              the mother of the <persName ref="http://syriaca.org/person/624">Virgin
-                              Mary</persName>
+                              the mother of the <persName ref="http://syriaca.org/person/624">Virgin Mary</persName>
                     </persName>.</title>
                   <rubric xml:lang="syr">ܟܗ: ܒܬܡܘܙ: ܥܘܢܕܢܗ̇ ܕܩܕܝܫܬܐ ܚܢܹܐ: ܙܕܝܩܬܐ: ܐܡܐ
                               ܕܝܠܕܬ݀ ܐܠܗܐ ܡܪܝܡ</rubric>

--- a/data/tei/1023.xml
+++ b/data/tei/1023.xml
@@ -121,8 +121,7 @@
               </note>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a" to="6">Foll. 1a-6</locus>
-                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
               </msItem>
               <msItem xml:id="b2" n="3">
                 <locus from="7a" to="7">Foll. 7a-7</locus>
@@ -239,8 +238,7 @@
             </msItem>
             <msItem xml:id="a6" n="26">
               <locus from="135b" to="136">Foll. 135b-136</locus>
-              <title xml:lang="en">A hymn on <persName ref="http://syriaca.org/person/1192">Cyriacus the
-                        martyr</persName>.</title>
+              <title xml:lang="en">A hymn on <persName ref="http://syriaca.org/person/1192">Cyriacus the martyr</persName>.</title>
               <rubric xml:lang="syr">ܡܥܢܝܬܐ ܕܥܠ ܡܪܝ ܩܘܪܝܩܘܣ ܣܗܕܐ</rubric>
               <note>Another hymn, the title of which is torn away, is on fol. 136 b.</note>
             </msItem>

--- a/data/tei/1027.xml
+++ b/data/tei/1027.xml
@@ -194,8 +194,7 @@
               </msItem>
               <msItem xml:id="b12" n="18">
                 <locus from="125b" to="135">Foll. 125b-135</locus>
-                <title xml:lang="en">Of <persName>Michael the
-                           Archangel</persName>.</title>
+                <title xml:lang="en">Of <persName>Michael the Archangel</persName>.</title>
                 <rubric xml:lang="syr">ܠܪ̈ܝܫܐ ܕܡܠܐܟܐ ܡܝܟܐܝܠ</rubric>
               </msItem>
               <msItem xml:id="b13" n="19">

--- a/data/tei/1029.xml
+++ b/data/tei/1029.xml
@@ -155,8 +155,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">The metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob
-                                    of Batnae</persName> on the Crucifixion of our
+                <title xml:lang="en">The metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the Crucifixion of our
                                     <persName>Lord</persName>
               </title>
                 <rubric xml:lang="syr">ܥܠ ܚ̇ܝ̣ܠܐ ܕ[ܬܠܝܬܝܘ]ܬܐ: ܡ̇ܫܪܝܢܢ ܕܢܟܬܘܼܒ ܡܐܡܪܐ

--- a/data/tei/1032.xml
+++ b/data/tei/1032.xml
@@ -167,8 +167,7 @@
                 </msItem>
                 <msItem xml:id="p1b5" n="6">
                   <locus from="51b"/>
-                  <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the
-                  Baptist</persName>
+                  <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p1b6" n="7">

--- a/data/tei/1035.xml
+++ b/data/tei/1035.xml
@@ -169,8 +169,7 @@
                   <title xml:lang="en">The Commemoration of
                                         <persName ref="http://syriaca.org/person/856">Macarius</persName>,
                                     <persName ref="http://syriaca.org/person/1213">Domitius</persName>, <persName ref="http://syriaca.org/person/1175">Abba Bishoi</persName>
-                                        (<persName ref="http://syriaca.org/person/1175">Pisoes</persName>), and <persName>John the Less
-                                        (or the Younger)</persName>
+                                        (<persName ref="http://syriaca.org/person/1175">Pisoes</persName>), and <persName>John the Less (or the Younger)</persName>
                 </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܐܒܗ̈ܬܐ ܩܕܝ̈ܫܐ ܐܒܐ ܡ̇ܐܩܪܝܣ܀
                                     ܘܡ̇ܐܟܣܝܡܘܣ ܘܕܘܡܛܝܘܣ܀ ܘܐܒܐ ܒܝܫܘܝ. ܘܐܒܐ ܝܘܚܢܢ ܙܥܘܪܐ</rubric>

--- a/data/tei/1039.xml
+++ b/data/tei/1039.xml
@@ -135,8 +135,7 @@
                         tone.</note>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1b" to="1">Foll. 1b-1</locus>
-                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܝ̣ܠܕܗ ܕܡܪܢ ܕܒܒܣܪ</rubric>
                 <note>ܐ, ܒ </note>
               </msItem>
@@ -209,15 +208,13 @@
               <msItem xml:id="b13" n="14">
                 <locus from="28a" to="28">Foll. 28a-28</locus>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>.</title>
+                  <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܝܘ݊ܚܢܢ ܡܥܡܕܢܐ</rubric>
                 <incipit xml:lang="syr">ܩܢܓ</incipit>
               </msItem>
               <msItem xml:id="b14" n="15">
                 <locus from="29a" to="29">Foll. 29a-29</locus>
-                <title xml:lang="en">The Presentation of <persName ref="http://syriaca.org/person/2245">our
-                              Lord</persName>.</title>
+                <title xml:lang="en">The Presentation of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܡܥܠܬܗ ܕܡܪܢ ܠܗܝܟܠܐ</rubric>
                 <incipit xml:lang="syr">ܩܢܙ</incipit>
               </msItem>
@@ -232,8 +229,7 @@
                     <persName xml:lang="en">John bar Aphtūnāyā, the first abbat of Kinnesrīn
                 </persName>
                   </author>
-                  <title xml:lang="en">Hymns of <persName>John bar Aphtūnāyā, the first
-                              abbat of <placeName>Kinnesrīn</placeName>
+                  <title xml:lang="en">Hymns of <persName>John bar Aphtūnāyā, the first abbat of <placeName>Kinnesrīn</placeName>
                   </persName>.</title>
                   <rubric xml:lang="syr">ܝܘܚܢܢ ܒܪ ܐܦܬܘܢܝܐ̣. ܪܝܫ ܕܝܪܐ ܩܕܡܝܐ ܕܩܢܢܫܪܐ </rubric>
                 </msItem>
@@ -248,9 +244,7 @@
                     <persName xml:lang="en">John Psaltes, abbat of the convent of Beth Aphtūnāyā
                 </persName>
                   </author>
-                  <title xml:lang="en">Hymns of <persName ref="http://syriaca.org/person/1318">John Psaltes, abbat of the
-                                 <placeName>convent of Beth
-                           Aphtūnāyā</placeName>
+                  <title xml:lang="en">Hymns of <persName ref="http://syriaca.org/person/1318">John Psaltes, abbat of the <placeName>convent of Beth Aphtūnāyā</placeName>
                   </persName>.</title>
                   <rubric xml:lang="syr">ܝܘܚܢܢ ܦܣܐܠܛܝܣ ܪܝܫܕܝܪܐ ܕܒܝܬ ܐܦܬܘܢܝܐ </rubric>
                 </msItem>
@@ -265,8 +259,7 @@
                 <locus from="54a" to="55">Foll. 54a-55</locus>
                 <title xml:lang="en">The believing and victorious Emperors, viz.
                            <persName ref="http://syriaca.org/person/1655">Constantine</persName>, <persName ref="http://syriaca.org/person/1779">Honorius</persName>,
-                  <persName>Gratianus</persName>, and <persName ref="http://syriaca.org/person/2271">Theodosius the
-                              Great</persName>.</title>
+                  <persName>Gratianus</persName>, and <persName ref="http://syriaca.org/person/2271">Theodosius the Great</persName>.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܡ̈ܠܟܐ ܡ̈ܗܝܡܢܐ ܘܙܟ̈ܝܐ</rubric>
                 <incipit xml:lang="syr">ܪܠܒ</incipit>
               </msItem>

--- a/data/tei/1039.xml
+++ b/data/tei/1039.xml
@@ -229,8 +229,7 @@
                     <persName xml:lang="en">John bar Aphtūnāyā, the first abbat of Kinnesrīn
                 </persName>
                   </author>
-                  <title xml:lang="en">Hymns of <persName>John bar Aphtūnāyā, the first abbat of <placeName>Kinnesrīn</placeName>
-                  </persName>.</title>
+                  <title xml:lang="en">Hymns of <persName>John bar Aphtūnāyā, the first abbat of <placeName>Kinnesrīn</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܝܘܚܢܢ ܒܪ ܐܦܬܘܢܝܐ̣. ܪܝܫ ܕܝܪܐ ܩܕܡܝܐ ܕܩܢܢܫܪܐ </rubric>
                 </msItem>
                 <msItem xml:id="c2" n="18">
@@ -244,8 +243,7 @@
                     <persName xml:lang="en">John Psaltes, abbat of the convent of Beth Aphtūnāyā
                 </persName>
                   </author>
-                  <title xml:lang="en">Hymns of <persName ref="http://syriaca.org/person/1318">John Psaltes, abbat of the <placeName>convent of Beth Aphtūnāyā</placeName>
-                  </persName>.</title>
+                  <title xml:lang="en">Hymns of <persName ref="http://syriaca.org/person/1318">John Psaltes, abbat of the <placeName>convent of Beth Aphtūnāyā</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܝܘܚܢܢ ܦܣܐܠܛܝܣ ܪܝܫܕܝܪܐ ܕܒܝܬ ܐܦܬܘܢܝܐ </rubric>
                 </msItem>
               </msItem>

--- a/data/tei/1044.xml
+++ b/data/tei/1044.xml
@@ -172,8 +172,7 @@
               <msItem xml:id="b10" n="14">
                 <locus from="28b" to="33">Foll. 28b-33</locus>
                 <title xml:lang="en">Lent, concluding with the commemoration of the
-                           forty Martyrs of <placeName ref="http://syriaca.org/place/181">Sebaste
-                              </placeName>(<foreign xml:lang="syr">ܣܒܣܛܝܐ</foreign>) and <foreign xml:lang="syr">ܫܘܒ̈ܚܐ ܡܬܝ̈ܕܥܢܐ ܕܝܘ̈ܡܬܐ ܫ̈ܚܝ̣ܡܐ
+                           forty Martyrs of <placeName ref="http://syriaca.org/place/181">Sebaste </placeName>(<foreign xml:lang="syr">ܣܒܣܛܝܐ</foreign>) and <foreign xml:lang="syr">ܫܘܒ̈ܚܐ ܡܬܝ̈ܕܥܢܐ ܕܝܘ̈ܡܬܐ ܫ̈ܚܝ̣ܡܐ
                            ܕܨܘܡܐ</foreign>.</title>
               </msItem>
               <msItem xml:id="b11" n="15">

--- a/data/tei/1044.xml
+++ b/data/tei/1044.xml
@@ -216,8 +216,7 @@
               </msItem>
               <msItem xml:id="b17" n="22">
                 <locus from="64a" to="65">Foll. 64a-65</locus>
-                <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/624">blessed
-                              Virgin</persName>.</title>
+                <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>.</title>
                 <rubric xml:lang="syr">ܕܝ̇ܠܕܬ݀ ܐܠܗܐ ܕܥܠ ܫ̣̈ܒܠܐ </rubric>
               </msItem>
               <msItem xml:id="b18" n="23">
@@ -235,14 +234,12 @@
               </msItem>
               <msItem xml:id="b21" n="26">
                 <locus from="71b" to="72">Foll. 71b-72</locus>
-                <title xml:lang="en">The Transfiguration of <persName ref="http://syriaca.org/person/2245">our
-                              Lord</persName>.</title>
+                <title xml:lang="en">The Transfiguration of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܡܬܓܲܠܝܢܘܬܗ ܕܡܪܢ ܕܥܠ ܛܘܪ ܬܒܘܪ</rubric>
               </msItem>
               <msItem xml:id="b22" n="27">
                 <locus from="73a" to="75">Foll. 73a-75</locus>
-                <title xml:lang="en">The Obsequies of the <persName ref="http://syriaca.org/person/624">blessed
-                              Virgin</persName>.</title>
+                <title xml:lang="en">The Obsequies of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܥܘܿܦܝܗ̇ ܕܝܠܕܬ ܐܠܗܐ . . . ܒܐܒ</rubric>
               </msItem>
               <msItem xml:id="b23" n="28" defective="true">

--- a/data/tei/1045.xml
+++ b/data/tei/1045.xml
@@ -150,8 +150,7 @@
                   <persName xml:lang="en">John bar Aphtūnāyā</persName>
                 </author>
                 <title xml:lang="en">Part of the Hymns of
-                                    <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John bar
-                                    Aphtūnāyā</persName>
+                                    <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāyā</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܡ̈ܥܢܝܬܐ ܕܝܠ̇ܕܬ݀ ܐܠܗܐ ܘܕܣܗ̈ܕܐ ܘܕܬܝܒܘܬܐ
                                 ܘܕܥ̈ܢܝܕܐ</rubric>

--- a/data/tei/1048.xml
+++ b/data/tei/1048.xml
@@ -214,9 +214,7 @@
               <author>
                 <persName xml:lang="en">Ephraim</persName>
               </author>
-              <title xml:lang="en">Supplicatory hymns, ascribed to <persName>Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>, <persName>Maruthas of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                </persName>, and
+              <title xml:lang="en">Supplicatory hymns, ascribed to <persName>Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>, <persName>Maruthas of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName>, and
                            <persName ref="http://syriaca.org/person/13">Ephraim</persName>.</title>
               <rubric xml:lang="syr">ܬܟ̈ܫܦܬܐ ܕܟܠܗܘܢ ܛܟ̈ܣܐ ܕܡܪܝ ܪܒܘܠܐ ܐܦ܏ܝܣ ܕܐܘܪܗܝ ܕܡܪܝ ܡܪܘܬܐ
                         ܐܦ܏ܝܣ ܕܬܐܓܪܝܬ ܘܕܡܪܝ ܐܦܪܝܡ. </rubric>

--- a/data/tei/1048.xml
+++ b/data/tei/1048.xml
@@ -214,8 +214,7 @@
               <author>
                 <persName xml:lang="en">Ephraim</persName>
               </author>
-              <title xml:lang="en">Supplicatory hymns, ascribed to <persName>Rabulas
-                           of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+              <title xml:lang="en">Supplicatory hymns, ascribed to <persName>Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                 </persName>, <persName>Maruthas of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
                 </persName>, and
                            <persName ref="http://syriaca.org/person/13">Ephraim</persName>.</title>

--- a/data/tei/1049.xml
+++ b/data/tei/1049.xml
@@ -133,8 +133,7 @@
               </msItem>
               <msItem xml:id="b5" n="6">
                 <locus from="11a" to="11">Foll. 11a-11</locus>
-                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>.</title>
+                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="12a" to="26">Foll. 12a-26</locus>

--- a/data/tei/105.xml
+++ b/data/tei/105.xml
@@ -102,8 +102,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="1" to="62">Foll. 1-62</locus>
-              <title ref="http://syriaca.org/work/156">The book of Isaiah, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                </persName>
+              <title ref="http://syriaca.org/work/156">The book of Isaiah, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
               </title>
               <note>See <bibl>Ceriani, Monumenta Sacra et Profana, t. ii. fasc. i., p. xi.; t. v. fasc. i., p. 7</bibl> etc.</note>
               <note>The index to the <foreign xml:lang="syr">ܩ̈ܦܠܐܐ</foreign> is wanting, as well as the following portions of the text: ch. i. 1—ii. 21, iii. 12—vii. 2, vii. 15—viii. 1, viii. 12—xii. 2, xiii. 8—20, xix. 3—25, xxxv. 2—xl. 3, xl. 16 —xlv. 6, xlv. 17—xlvi. 1, li. 3—lvii. 1, lxiii. 9 —lxv. 24, lxvi. 1—3, and lxvi. 5 to the end.</note>

--- a/data/tei/1053.xml
+++ b/data/tei/1053.xml
@@ -981,8 +981,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p8a1" n="1">
                 <locus from="81a"/>
-                <title xml:lang="en">A fragment of the second part of a Choir-book, containing <ref target="http://syriaca.org/work/19">Psalms cxxxix. 4—cxlii. 3, according
-                  to the Peshitta version</ref>
+                <title xml:lang="en">A fragment of the second part of a Choir-book, containing <ref target="http://syriaca.org/work/19">Psalms cxxxix. 4—cxlii. 3, according to the Peshitta version</ref>
               </title>
               </msItem>
             </msContents>

--- a/data/tei/106.xml
+++ b/data/tei/106.xml
@@ -318,8 +318,7 @@
                 <msItem xml:id="p1_2a1" n="1" defective="true">
                   <locus from="2a"/>
                   <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9628">Genesis</ref>, translated from the Septuagint
-                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or
-                           Constantina</placeName>
+                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName>
                     </persName>.
                   </title>
                   <note type="footnote">See <bibl>Monumenta Sacra et Profana opera Collegii Doctorum Bibl.
@@ -351,8 +350,7 @@
                   <msItem xml:id="p1_2b2" n="3" defective="true">
                     <locus from="9a"/>
                     <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9628">Genesis</ref>, translated from the Septuagint
-                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or
-                           Constantina</placeName>
+                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName>
                 </persName>.</title>
                     <finalRubric xml:lang="syr">ܫܠܡ ܟܬܒܐ ܕܒܪܝܬܐ̣. ܐܝܟ ܡܫܠܡܢܘܬܐ ܕܫܒܥܝܢ
                                  ܘܬܪ̈ܝܢ</finalRubric>

--- a/data/tei/106.xml
+++ b/data/tei/106.xml
@@ -318,8 +318,7 @@
                 <msItem xml:id="p1_2a1" n="1" defective="true">
                   <locus from="2a"/>
                   <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9628">Genesis</ref>, translated from the Septuagint
-                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName>
-                    </persName>.
+                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName></persName>.
                   </title>
                   <note type="footnote">See <bibl>Monumenta Sacra et Profana opera Collegii Doctorum Bibl.
                     Ambros., tom. i. fasc. i. Prolegomena in editionem versionis Syriacae ex
@@ -350,8 +349,7 @@
                   <msItem xml:id="p1_2b2" n="3" defective="true">
                     <locus from="9a"/>
                     <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9628">Genesis</ref>, translated from the Septuagint
-                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName>
-                </persName>.</title>
+                        by <persName ref="http://syriaca.org/person/82">Paul, bishop of <placeName ref="http://syriaca.org/place/200">Tellā or Constantina</placeName></persName>.</title>
                     <finalRubric xml:lang="syr">ܫܠܡ ܟܬܒܐ ܕܒܪܝܬܐ̣. ܐܝܟ ܡܫܠܡܢܘܬܐ ܕܫܒܥܝܢ
                                  ܘܬܪ̈ܝܢ</finalRubric>
                     <note>The following passages of the text are missing: ch. i. 1—iv. 8, ix. 24— xvi. 2, xvi. 12 — xx. 1,

--- a/data/tei/1069.xml
+++ b/data/tei/1069.xml
@@ -173,8 +173,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">
-                  <foreign xml:lang="syr">ܒܥ̈ܘܬܐ</foreign>, or prayers, of <persName ref="http://syriaca.org/person/42">Jacob of
-                                    Batnae</persName>, etc</title>
+                  <foreign xml:lang="syr">ܒܥ̈ܘܬܐ</foreign>, or prayers, of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>, etc</title>
                 <note>Imperfect at the end.</note>
               </msItem>
             </msContents>

--- a/data/tei/1072.xml
+++ b/data/tei/1072.xml
@@ -136,8 +136,7 @@
               </msItem>
               <msItem xml:id="b5" n="6">
                 <locus from="7b" to="9">Foll. 7b-9</locus>
-                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>.</title>
+                <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="9b" to="10">Foll. 9b-10</locus>
@@ -149,8 +148,7 @@
               </msItem>
               <msItem xml:id="b8" n="9">
                 <locus from="14b" to="15">Foll. 14b-15</locus>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>.</title>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
               </msItem>
               <msItem xml:id="b9" n="10">
                 <locus from="16a" to="16">Foll. 16a-16</locus>

--- a/data/tei/1078.xml
+++ b/data/tei/1078.xml
@@ -126,9 +126,7 @@
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="1a"/>
               <title xml:lang="en">Dialogue between 
-                <persName ref="http://syriaca.org/person/856">
-                  Macarius, <foreign xml:lang="syr">ܐܒܐ ܡܩܪܝ</foreign>
-                </persName> and the Angels
+                <persName ref="http://syriaca.org/person/856">Macarius, <foreign xml:lang="syr">ܐܒܐ ܡܩܪܝ</foreign></persName> and the Angels
                 (<foreign xml:lang="syr">ܡ̈ܠܐܟܐ</foreign>), regarding the separation of the soul from the body, and the state of the
                 souls of the righteous and the wicked after death</title>
               <note>Imperfect at the end.</note>

--- a/data/tei/1078.xml
+++ b/data/tei/1078.xml
@@ -210,8 +210,7 @@
             </msItem>
             <msItem xml:id="a9" n="9">
               <locus from="78b"/>
-              <title xml:lang="en">Selections from a commentary on the discourses of <persName ref="http://syriaca.org/person/548">Isaiah
-                of Scete</persName>, by an unnamed author
+              <title xml:lang="en">Selections from a commentary on the discourses of <persName ref="http://syriaca.org/person/548">Isaiah of Scete</persName>, by an unnamed author
               </title>
               <note type="footnote">Perhaps the abbat <persName>Dād-yeshūa’</persName>. See <bibl>Assemani, Bibl. Or., t. iii., pars 1, p.
                 99</bibl>.

--- a/data/tei/1081.xml
+++ b/data/tei/1081.xml
@@ -289,8 +289,7 @@
               <msItem xml:id="p2a1" n="1">
                 <locus from="1"/>
                 <title xml:lang="en">A portion of a commentary on the
-                      <title>parable of the <persName>Prodigal Son</persName>
-                  </title>.</title>
+                      <title>parable of the <persName>Prodigal Son</persName></title>.</title>
               </msItem>
             </msContents>
             <physDesc>

--- a/data/tei/1108.xml
+++ b/data/tei/1108.xml
@@ -165,8 +165,7 @@
               </msItem>
               <msItem xml:id="b6" n="9">
                 <locus from="16b"/>
-                <title xml:lang="en">The Commemoration of <persName>S. John
-                                        the Baptist</persName>
+                <title xml:lang="en">The Commemoration of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b7" n="10">
@@ -183,14 +182,12 @@
               </msItem>
               <msItem xml:id="b9" n="12">
                 <locus from="19a"/>
-                <title xml:lang="en">Of <persName>S. Simeon the
-                                        Aged</persName>
+                <title xml:lang="en">Of <persName>S. Simeon the Aged</persName>
                 </title>
               </msItem>
               <msItem xml:id="b10" n="13">
                 <locus from="19b"/>
-                <title xml:lang="en">Of <persName>Severus the
-                                        patriarch</persName>
+                <title xml:lang="en">Of <persName>Severus the patriarch</persName>
                 </title>
               </msItem>
               <msItem xml:id="b11" n="14">

--- a/data/tei/1109.xml
+++ b/data/tei/1109.xml
@@ -141,8 +141,7 @@
             </msItem>
             <msItem xml:id="a3" n="6">
               <locus from="121a"/>
-              <title xml:lang="en">Portions of a Commentary on <title>the Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>
-                </title>, by some other author</title>
+              <title xml:lang="en">Portions of a Commentary on <title>the Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName></title>, by some other author</title>
             </msItem>
             <msItem xml:id="a4" n="7">
               <locus from="153a"/>
@@ -174,8 +173,7 @@
               </msItem>
               <msItem xml:id="b7" n="11">
                 <locus from="260a"/>
-                <title xml:lang="en">A single fragment of the Commentary on the <title>epistle to the
-                  Galatians</title>
+                <title xml:lang="en">A single fragment of the Commentary on the <title>epistle to the Galatians</title>
                 </title>
               </msItem>
             </msItem>

--- a/data/tei/1111.xml
+++ b/data/tei/1111.xml
@@ -661,9 +661,7 @@
               <msItem xml:id="b106" n="107">
                 <locus from="131b"/>
                 <title xml:lang="en">The second Friday; the
-                                    Commemoration of <persName>Achudemes</persName> and <placeName>other
-                                    bishops of <placeName>Nineveh</placeName>
-                  </placeName>
+                                    Commemoration of <persName>Achudemes</persName> and <placeName>other bishops of <placeName>Nineveh</placeName></placeName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ. ܒ . ܕܚܲܠܹܠܝܢܝ ܕܐܲܚܘܼܕܹ݁ܡܹܗ ܘܐܲܚܘܼܕ݁ܡܹܗ ܘܡܘܫܐ ܘܝܲܙܕܦܲܢܵܗ̇ ܘܡܵܪܐ ܘܝܫܘܥܝܗ̣ܒ ܐܦܣܩܘ̈ܦܐ ܕܢܝܢ̈ܘܐ</rubric>
               </msItem>

--- a/data/tei/1111.xml
+++ b/data/tei/1111.xml
@@ -113,8 +113,7 @@
               <msItem xml:id="b2" n="3">
                 <locus from="2b"/>
                 <title xml:lang="en">The first Friday; the Commemoration
-                                    of <persName>Babaeus of <placeName>Nisibis</placeName>
-                  </persName> and <persName>others</persName>
+                                    of <persName>Babaeus of <placeName>Nisibis</placeName></persName> and <persName>others</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ ܩܕܡܝܬܐ ܕܣܘܒܪܐ ܕܡܪܝ ܒܒܝ ܒܪ ܢܨܝ̈ܒܝܐ. ܩ</rubric>
               </msItem>
@@ -148,8 +147,7 @@
               </msItem>
               <msItem xml:id="b8" n="9">
                 <locus from="7b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār Abbā, bishop of <placeName>Nineveh</placeName>
-                  </persName>, on the <date>17th of the
+                <title xml:lang="en">The Commemoration of <persName>Mār Abbā, bishop of <placeName>Nineveh</placeName></persName>, on the <date>17th of the
                                         first Kānūn</date>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܕܡܪܝ ܐܒܐ ܐܲܦܣܩܘܿܦ݁ܐ ܕܢܝܢ̈ܘܐ <foreign xml:lang="en">(sic)</foreign> ܒܲܫܒܵܬܲܥܣܲܪ ܒܟܢܘܢ ܩܕܝܡ</rubric>
@@ -612,8 +610,7 @@
               <msItem xml:id="b97" n="98">
                 <locus from="121b"/>
                 <title xml:lang="en">The fifth Friday; the Commemoration
-                                    of <persName>Damasus, bishop of <placeName>Rome</placeName>
-                  </persName>, etc. </title>
+                                    of <persName>Damasus, bishop of <placeName>Rome</placeName></persName>, etc. </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܗܘ ܕܒܝܬ ܕܵܡܣܘܿܣ ܐܦܣ܏ܩܘ ܕܪ̈ܘܡܹܐ</rubric>
               </msItem>
               <msItem xml:id="b98" n="99">
@@ -653,8 +650,7 @@
               <msItem xml:id="b104" n="105">
                 <locus from="129b"/>
                 <title xml:lang="en">The first Friday of Hallelain; the
-                                    Commemoration of <persName>Jacob of <placeName>Nisibis</placeName>
-                  </persName>
+                                    Commemoration of <persName>Jacob of <placeName>Nisibis</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ ܩܕܡܝܬܐ ܕܚܲܠܹܠܲܝܢܝ. ܕܡܪܝ ܝܥܩܘܒ ܐܦܣ܏ܩܘ ܕܢܨܝܒܝܢ</rubric>
               </msItem>
@@ -685,8 +681,7 @@
               <msItem xml:id="b109" n="110">
                 <locus from="134a"/>
                 <title xml:lang="en">The third Friday; the Commemoration
-                                    of <persName>Shem-baiteh</persName> and <persName>other bishops of <placeName>Nineveh</placeName>
-                  </persName>
+                                    of <persName>Shem-baiteh</persName> and <persName>other bishops of <placeName>Nineveh</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ ܕܬܠܬ ܕܚܲܠܹܠܲܝܢܝ ܕܫܹܡܒܲܝܬ݁ܗ ܘܲܟܠܝ̣ܠܝܫܘܿܥ ܘܣܒܪܝܫܘܥ ܘܫܘܒܚܐ ܠܐܠܗܐ ܐܦܣ܏ܩ̈ܘ ܕܢܝ̈ܢܘܐ</rubric>
               </msItem>
@@ -704,8 +699,7 @@
                 <locus from="136b"/>
                 <title xml:lang="en">The fourth Friday; the
                                     Commemoration of <persName>Ma'nā</persName>,
-                                        <persName>Marwān</persName>, and <persName>others, bishops of <placeName>Pĕrāth (al-Basrah)</placeName>
-                  </persName>
+                                        <persName>Marwān</persName>, and <persName>others, bishops of <placeName>Pĕrāth (al-Basrah)</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܕܡܪܝ ܡܲܥܢܵܐ ܘܡܲܪܘܵܢ ܘܚܲܒܪ̈ܝܗܘܢ ܐ̈ܦܣ܏ܩ ܕܦܪܬ</rubric>
               </msItem>
@@ -866,9 +860,7 @@
                 <locus from="152b"/>
                 <title xml:lang="en">The fifth Friday after the
                                     Invention, being the seventh of <persName>Elias</persName>; the Commemoration of
-                                        <persName>
-                    <foreign xml:lang="syr">ܝܙܝܙܟܘܣܬ</foreign>
-                  </persName> and <persName>others</persName>
+                                        <persName><foreign xml:lang="syr">ܝܙܝܙܟܘܣܬ</foreign></persName> and <persName>others</persName>
                 </title>
                 <rubric xml:lang="syr">ܥܪܘܒܬܐ ܕܐܪܒܥ <foreign xml:lang="en">(sic)</foreign> ܕܫܟܚܬܐ ܘܕܫܒܥ ܕܐܠܝܐ. ܕܝܙܝܙܟܘܣܬ ܘܣܡܝܢ ܘܫܘܒܚܐ ܠܝܫܘܥ ܘܒܘܟܬܝܫܘܥ ܣ̈܏ܗܕ</rubric>
               </msItem>
@@ -931,9 +923,7 @@
               <msItem xml:id="b148" n="149">
                 <locus from="159a"/>
                 <title xml:lang="en">The fifth Friday; the Commemoration
-                                    of <persName>Sabar-yeshūa’</persName> and <persName>others, the founders of <persName>congregations in <placeName>Bēth-Nūhadrā</placeName>
-                    </persName>
-                  </persName>
+                                    of <persName>Sabar-yeshūa’</persName> and <persName>others, the founders of <persName>congregations in <placeName>Bēth-Nūhadrā</placeName></persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܏ܗ ܕܡܪܝ ܣܲܒ݂ܪܝܫܘܥ ܘܝܫܘܥܝܗܒ ܘܝܥܩܘܒ
                                     ܘܐܲܕ݁ܘܿܢܵܐ ܘܲܨܠܝܒܐ ܘܐܦܢܝ ܡܪܢ ܘܚܲܒ܏ܪ̈ܝ ܢܵܨܘ̈ܒܐ ܕܟܢܘܫ̈ܝܐ ܒܐܬܪܐ ܕܒܝܬ ܢܘܼ܏ܗܕ</rubric>
@@ -966,8 +956,7 @@
               </msItem>
               <msItem xml:id="b154" n="155">
                 <locus from="162a"/>
-                <title xml:lang="en">The third Friday; the Commemoration of <persName>Paul, bishop of <placeName>Nisibis</placeName>
-                  </persName>
+                <title xml:lang="en">The third Friday; the Commemoration of <persName>Paul, bishop of <placeName>Nisibis</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܦܘܠܘܣ ܐܦܣ܏ܩܘ ܕܢܨܝܒܝܢ</rubric>
               </msItem>
@@ -977,8 +966,7 @@
               </msItem>
               <msItem xml:id="b156" n="157">
                 <locus from="163a"/>
-                <title xml:lang="en">The fourth Friday; the Commemoration of <persName>Jacob of <placeName>Beth-'Abē</placeName>
-                  </persName>, etc.</title>
+                <title xml:lang="en">The fourth Friday; the Commemoration of <persName>Jacob of <placeName>Beth-'Abē</placeName></persName>, etc.</title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܝܲܥܩܘܿܒ ܢܵܨܘܿܒ݂ܵܐ ܕܒܝܬ ܥܵܒ̈ܐ ܘܒܪ ܚܲܕܒܫܲܒ݁ܐ ܘܩܵܡܝ̣܏ܫܘ ܘܐܦܪܝܡ ܘܒܲܪܥܕܬܐ ܘܚܲܒܪ̈܏ܝܗ ܢܵܨܘ̈ܒܐ ܕܟܢܘ̈ܫܝܐ ܐܠܗ̈ܝܐ ܒܐܬܪܐ ܕܡܲܪܓ݁ܐ ܘܲܕ݁ܕ݂ܣܢ</rubric>
               </msItem>
               <msItem xml:id="b157" n="158">

--- a/data/tei/1111.xml
+++ b/data/tei/1111.xml
@@ -147,15 +147,13 @@
               </msItem>
               <msItem xml:id="b8" n="9">
                 <locus from="7b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār Abbā, bishop of <placeName>Nineveh</placeName></persName>, on the <date>17th of the
-                                        first Kānūn</date>
+                <title xml:lang="en">The Commemoration of <persName>Mār Abbā, bishop of <placeName>Nineveh</placeName></persName>, on the <date>17th of the first Kānūn</date>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܕܡܪܝ ܐܒܐ ܐܲܦܣܩܘܿܦ݁ܐ ܕܢܝܢ̈ܘܐ <foreign xml:lang="en">(sic)</foreign> ܒܲܫܒܵܬܲܥܣܲܪ ܒܟܢܘܢ ܩܕܝܡ</rubric>
               </msItem>
               <msItem xml:id="b9" n="10">
                 <locus from="8a"/>
-                <title xml:lang="en">The Nativity of <persName>our Lord</persName>, on the <date>25th of the first
-                                        Kānūn</date>
+                <title xml:lang="en">The Nativity of <persName>our Lord</persName>, on the <date>25th of the first Kānūn</date>
                 </title>
               </msItem>
               <msItem xml:id="b10" n="11">
@@ -472,8 +470,7 @@
               <msItem xml:id="b74" n="75">
                 <locus from="100b"/>
                 <title xml:lang="en">The Commemoration of the martyr
-                                        <persName>George</persName>, on the <date>24th of
-                                        Nīsān</date>
+                                        <persName>George</persName>, on the <date>24th of Nīsān</date>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܓ݁ܝ̣ܘܲܪܓ݁ܝ̣ܣ ܣܗܕ݁ܐ. ܕܗܘ̇ܐ ܒܥܣܪܝܢ ܘܐܪܒܥܐ ܒܢܝ̣ܣܵܢ</rubric>
               </msItem>
@@ -783,8 +780,7 @@
               </msItem>
               <msItem xml:id="b126" n="127">
                 <locus from="144b"/>
-                <title xml:lang="en">The Invention of <persName>the Cross</persName>, on <date>the
-                                    13th of Ilūl</date>
+                <title xml:lang="en">The Invention of <persName>the Cross</persName>, on <date>the 13th of Ilūl</date>
                 </title>
               </msItem>
               <msItem xml:id="b127" n="128">

--- a/data/tei/1111.xml
+++ b/data/tei/1111.xml
@@ -125,8 +125,7 @@
               <msItem xml:id="b4" n="5">
                 <locus from="4a"/>
                 <title xml:lang="en">The second Friday; the Commemoration
-                                    of <persName>Yeshūa'-yab</persName> and <persName>the other
-                                    Catholics</persName>
+                                    of <persName>Yeshūa'-yab</persName> and <persName>the other Catholics</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ ܕܬܪܬܝܢ ܕܣܘܒܪܐ ܕܘܟܪܢܐ ܗ̣ܘ ܕܝܫܘܥ ܝܗ̣ܒ
                                     ܘܣܒܪܝܫܘܥ ܘܝܫܘܥܝܗ̣ܒ ܘܓ݂ܝܘܲܪܓܝܣ ܘܚܢܢܝܫܘܥ ܘܟܠܗܘܢ ܩܬܘ̈ܠܝܩܐ ܚܲܒܪ̈ܝܗܘܢ</rubric>
@@ -149,8 +148,7 @@
               </msItem>
               <msItem xml:id="b8" n="9">
                 <locus from="7b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār
-                                        Abbā, bishop of <placeName>Nineveh</placeName>
+                <title xml:lang="en">The Commemoration of <persName>Mār Abbā, bishop of <placeName>Nineveh</placeName>
                   </persName>, on the <date>17th of the
                                         first Kānūn</date>
                 </title>
@@ -219,8 +217,7 @@
               </msItem>
               <msItem xml:id="b20" n="21">
                 <locus from="23a"/>
-                <title xml:lang="en">The Friday of <persName>the
-                                    Evangelists</persName>
+                <title xml:lang="en">The Friday of <persName>the Evangelists</persName>
                 </title>
               </msItem>
               <msItem xml:id="b21" n="22">
@@ -241,8 +238,7 @@
               </msItem>
               <msItem xml:id="b24" n="25">
                 <locus from="27b"/>
-                <title xml:lang="en">The Friday of <persName>the Greek
-                                    Doctors</persName>
+                <title xml:lang="en">The Friday of <persName>the Greek Doctors</persName>
                 </title>
               </msItem>
               <msItem xml:id="b25" n="26" defective="true">
@@ -262,8 +258,7 @@
               </msItem>
               <msItem xml:id="b28" n="29">
                 <locus from="34b"/>
-                <title xml:lang="en">The Friday of <persName>the Syrian
-                                    Doctors</persName>
+                <title xml:lang="en">The Friday of <persName>the Syrian Doctors</persName>
                 </title>
               </msItem>
               <msItem xml:id="b29" n="30">
@@ -273,8 +268,7 @@
               </msItem>
               <msItem xml:id="b30" n="31">
                 <locus from="37a" to="38b"/>
-                <title xml:lang="en">The Commemoration of <persName>any one
-                                    Saint</persName>
+                <title xml:lang="en">The Commemoration of <persName>any one Saint</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܚܕ ܦܪܨܘܦܐ</rubric>
               </msItem>
@@ -285,8 +279,7 @@
               </msItem>
               <msItem xml:id="b32" n="33">
                 <locus from="40a"/>
-                <title xml:lang="en">The Friday of <persName>the Forty
-                                    Martyrs</persName>
+                <title xml:lang="en">The Friday of <persName>the Forty Martyrs</persName>
                 </title>
               </msItem>
               <msItem xml:id="b33" n="34">
@@ -489,8 +482,7 @@
               <msItem xml:id="b75" n="76">
                 <locus from="101b"/>
                 <title xml:lang="en">The Commemoration of
-                                        <persName>Rabban Hormizd</persName> and <persName>the
-                                    Solitaries</persName>
+                                        <persName>Rabban Hormizd</persName> and <persName>the Solitaries</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܪܒܢ ܗܘܿܪܡ̣ܙܕ݁ ܘܠܝܚ̈ܝ܏ܕ</rubric>
               </msItem>
@@ -579,23 +571,20 @@
               </msItem>
               <msItem xml:id="b90" n="91">
                 <locus from="115b"/>
-                <title xml:lang="en">The second Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The second Sunday of <persName>the Apostles</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܚܕܒܫܒܐ ܕܬܪܝܢ ܕܫ̈ܠܝܚܐ</rubric>
               </msItem>
               <msItem xml:id="b91" n="92">
                 <locus from="116b"/>
-                <title xml:lang="en">The second Friday of <persName>the
-                  Apostles</persName>;
+                <title xml:lang="en">The second Friday of <persName>the Apostles</persName>;
                                     the Commemoration of <persName>Clement</persName>,
                                         <persName>Irenaeus</persName>, etc.</title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܗ̣ܘ ܕܲܩܠܹܡ̣ܝܸܣ ܘܐܝ̣ܪܹܢܹܐܘܣ ܘܚܲ܏ܒܪ</rubric>
               </msItem>
               <msItem xml:id="b92" n="93">
                 <locus from="117a"/>
-                <title xml:lang="en">The third Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The third Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b93" n="94">
@@ -606,8 +595,7 @@
               </msItem>
               <msItem xml:id="b94" n="95">
                 <locus from="118a"/>
-                <title xml:lang="en">The fourth Sunday of <persName>the
-                  Apostles</persName>
+                <title xml:lang="en">The fourth Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b95" n="96">
@@ -618,8 +606,7 @@
               </msItem>
               <msItem xml:id="b96" n="97">
                 <locus from="120b"/>
-                <title xml:lang="en">The fifth Sunday of <persName>the
-                  Apostles</persName>
+                <title xml:lang="en">The fifth Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b97" n="98">
@@ -631,8 +618,7 @@
               </msItem>
               <msItem xml:id="b98" n="99">
                 <locus from="122b"/>
-                <title xml:lang="en">The sixth Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The sixth Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b99" n="100">
@@ -644,8 +630,7 @@
               </msItem>
               <msItem xml:id="b100" n="101">
                 <locus from="123b"/>
-                <title xml:lang="en">The seventh Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The seventh Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b101" n="102">
@@ -656,15 +641,13 @@
               </msItem>
               <msItem xml:id="b102" n="103">
                 <locus from="127a"/>
-                <title xml:lang="en">The last Friday of the week of <persName>the
-                                    Apostles</persName>; the Commemoration of <persName>the Seventy (Disciples)</persName>
+                <title xml:lang="en">The last Friday of the week of <persName>the Apostles</persName>; the Commemoration of <persName>the Seventy (Disciples)</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܗ̣ܘ ܠܫܲܒܥܝܢ</rubric>
               </msItem>
               <msItem xml:id="b103" n="104">
                 <locus from="128a"/>
-                <title xml:lang="en">The last Sunday of the week of <persName>the
-                                    Apostles</persName>, called Nūsārdīl</title>
+                <title xml:lang="en">The last Sunday of the week of <persName>the Apostles</persName>, called Nūsārdīl</title>
                 <rubric xml:lang="syr">ܕܚܕܒܫܒܐ ܕܫܘܠܡ ܫܒܘܥܐ ܕܫܠܝ̈ܚܐ. ܕܡܬܩܪܸܐ ܢܘܼܣܵܪܕܐܹܝܠ</rubric>
               </msItem>
               <msItem xml:id="b104" n="105">
@@ -690,8 +673,7 @@
               </msItem>
               <msItem xml:id="b107" n="108">
                 <locus from="131b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār
-                                        Mārī the Apostle</persName>
+                <title xml:lang="en">The Commemoration of <persName>Mār Mārī the Apostle</persName>
                 </title>
                 <rubric xml:lang="syr">ܘܕܡܪܡܪܝ ܫܠܝܚܐ</rubric>
               </msItem>
@@ -703,8 +685,7 @@
               <msItem xml:id="b109" n="110">
                 <locus from="134a"/>
                 <title xml:lang="en">The third Friday; the Commemoration
-                                    of <persName>Shem-baiteh</persName> and <persName>other bishops of
-                                        <placeName>Nineveh</placeName>
+                                    of <persName>Shem-baiteh</persName> and <persName>other bishops of <placeName>Nineveh</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬܐ ܕܬܠܬ ܕܚܲܠܹܠܲܝܢܝ ܕܫܹܡܒܲܝܬ݁ܗ ܘܲܟܠܝ̣ܠܝܫܘܿܥ ܘܣܒܪܝܫܘܥ ܘܫܘܒܚܐ ܠܐܠܗܐ ܐܦܣ܏ܩ̈ܘ ܕܢܝ̈ܢܘܐ</rubric>
@@ -723,9 +704,7 @@
                 <locus from="136b"/>
                 <title xml:lang="en">The fourth Friday; the
                                     Commemoration of <persName>Ma'nā</persName>,
-                                        <persName>Marwān</persName>, and <persName>others, bishops of
-                                        <placeName>Pĕrāth
-                                        (al-Basrah)</placeName>
+                                        <persName>Marwān</persName>, and <persName>others, bishops of <placeName>Pĕrāth (al-Basrah)</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܕܡܪܝ ܡܲܥܢܵܐ ܘܡܲܪܘܵܢ ܘܚܲܒܪ̈ܝܗܘܢ ܐ̈ܦܣ܏ܩ ܕܦܪܬ</rubric>
@@ -754,15 +733,13 @@
               </msItem>
               <msItem xml:id="b117" n="118">
                 <locus from="139a"/>
-                <title xml:lang="en">Saturday, the Commemoration of <persName>the
-                                    Prophets</persName>
+                <title xml:lang="en">Saturday, the Commemoration of <persName>the Prophets</persName>
                 </title>
                 <rubric xml:lang="syr">ܝܘܡܐ ܕܬܪܝ̣ܢ ܫܒܬܐ. ܕܘܟܪܢܐ ܗ̣ܘ ܕܢܒ̈ܝܐ</rubric>
               </msItem>
               <msItem xml:id="b118" n="119">
                 <locus from="139a"/>
-                <title xml:lang="en">The Commemoration of <persName>Simeon bar
-                  Sabbā'ē</persName>
+                <title xml:lang="en">The Commemoration of <persName>Simeon bar Sabbā'ē</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܟܪܢܐ ܕܡܪܝ ܫܡܥܘܢ ܩܬܘܠܝܩܐ ܒܪ ܨ̈ܒܥܐ</rubric>
               </msItem>
@@ -954,8 +931,7 @@
               <msItem xml:id="b148" n="149">
                 <locus from="159a"/>
                 <title xml:lang="en">The fifth Friday; the Commemoration
-                                    of <persName>Sabar-yeshūa’</persName> and <persName>others, the founders
-                                    of <persName>congregations in <placeName>Bēth-Nūhadrā</placeName>
+                                    of <persName>Sabar-yeshūa’</persName> and <persName>others, the founders of <persName>congregations in <placeName>Bēth-Nūhadrā</placeName>
                     </persName>
                   </persName>
                 </title>

--- a/data/tei/1115.xml
+++ b/data/tei/1115.xml
@@ -279,8 +279,7 @@
               </msItem>
               <msItem xml:id="b35" n="38">
                 <locus from="79a"/>
-                <title xml:lang="en">The Commemoration of <persName>the forty Martyrs of <placeName>Sebaste</placeName>
-                  </persName>
+                <title xml:lang="en">The Commemoration of <persName>the forty Martyrs of <placeName>Sebaste</placeName></persName>
                 </title>
               </msItem>
               <msItem xml:id="b36" n="39">

--- a/data/tei/1115.xml
+++ b/data/tei/1115.xml
@@ -149,8 +149,7 @@
               </msItem>
               <msItem xml:id="b8" n="10">
                 <locus from="20b"/>
-                <title xml:lang="en">The Commemoration of the <persName>blessed
-                                    Virgin</persName>
+                <title xml:lang="en">The Commemoration of the <persName>blessed Virgin</persName>
                 </title>
               </msItem>
               <msItem xml:id="b9" n="11">
@@ -182,8 +181,7 @@
               </msItem>
               <msItem xml:id="b13" n="16">
                 <locus from="29b"/>
-                <title xml:lang="en">The Decollation of <persName>S. John
-                                        the Baptist</persName>
+                <title xml:lang="en">The Decollation of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b14" n="17">
@@ -194,8 +192,7 @@
               </msItem>
               <msItem xml:id="b15" n="18">
                 <locus from="34b"/>
-                <title xml:lang="en">The Commemoration of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The Commemoration of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b16" n="19">

--- a/data/tei/1117.xml
+++ b/data/tei/1117.xml
@@ -261,8 +261,7 @@
               <textLang mainLang="syr-Syrn">Syriac</textLang>
               <msItem xml:id="p2a1" n="1">
                 <locus from="2b"/>
-                <title xml:lang="en">An exposition of <ref>the Order of the holy
-                                Eucharist, according to the Nestorian use</ref>
+                <title xml:lang="en">An exposition of <ref>the Order of the holy Eucharist, according to the Nestorian use</ref>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܚܝܠܗ ܕܡܪܢ ܝܫܘܥ ܡܫܝܚܐ ܡܫܪܝܢܢ ܠܡܹܟܬܒ ܡܐܡܪܐ ܬܗܝܪܐ
                                 ܕܥܠ ܪܒܘܬܗܘܢ ܕܐܪ̈ܙܐ ܩܕ̈ܝܫܐ ܕܓܡܪܐ ܥܕܬܐ ܩܕܝ̣ܫܬܐ ܕܢܣܛܘܪ̈ܝܢܐ ܐܚܝܕ̈ܝ ܬܵܘܕܝܬܐ ܏ܘܫ</rubric>

--- a/data/tei/1124.xml
+++ b/data/tei/1124.xml
@@ -127,13 +127,10 @@
               <author ref="http://syriaca.org/person/78">
                 <persName xml:lang="en">John Psaltes</persName>
               </author>
-              <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus, patriarch of
-                <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-              </persName>, <persName ref="http://syriaca.org/person/52">John bar
-                Aphtūnāyā, abbat of <placeName ref="http://syriaca.org/place/230">Kinnesrīn</placeName>
+              <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+              </persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāyā, abbat of <placeName ref="http://syriaca.org/place/230">Kinnesrīn</placeName>
                 </persName>,
-                <persName ref="http://syriaca.org/person/1318">John Psaltes</persName>, etc., as translated by <persName ref="http://syriaca.org/person/1405">Paul
-                  of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <persName ref="http://syriaca.org/person/1318">John Psaltes</persName>, etc., as translated by <persName ref="http://syriaca.org/person/1405">Paul of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                 </persName>, and revised by
                 <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                 </persName>.</title>

--- a/data/tei/1124.xml
+++ b/data/tei/1124.xml
@@ -127,13 +127,9 @@
               <author ref="http://syriaca.org/person/78">
                 <persName xml:lang="en">John Psaltes</persName>
               </author>
-              <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-              </persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāyā, abbat of <placeName ref="http://syriaca.org/place/230">Kinnesrīn</placeName>
-                </persName>,
-                <persName ref="http://syriaca.org/person/1318">John Psaltes</persName>, etc., as translated by <persName ref="http://syriaca.org/person/1405">Paul of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>, and revised by
-                <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>.</title>
+              <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāyā, abbat of <placeName ref="http://syriaca.org/place/230">Kinnesrīn</placeName></persName>,
+                <persName ref="http://syriaca.org/person/1318">John Psaltes</persName>, etc., as translated by <persName ref="http://syriaca.org/person/1405">Paul of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>, and revised by
+                <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>.</title>
               <note>See <bibl>Add. 17,134</bibl>, from which manuscript, or one very similar to it, the
                         present seems to have been copied.</note>
               <msItem xml:id="b1" n="2">

--- a/data/tei/1127.xml
+++ b/data/tei/1127.xml
@@ -161,8 +161,7 @@
                 <author ref="http://syriaca.org/person/52">
                   <persName xml:lang="en">John bar Aphtunaya</persName>
                 </author>
-                <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John
-                  bar Aphtūnāyā</persName>, etc. </title>
+                <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāyā</persName>, etc. </title>
                 <note>The last number in the older portion of the manuscript is 143 (fol. <locus from="79b">79 b</locus>,
                 <foreign xml:lang="syr">ܫܡܓ</foreign>).</note>
                 <note>The principal rubrics are noted below.</note>
@@ -343,8 +342,7 @@
                 <author ref="http://syriaca.org/person/52">
                   <persName xml:lang="en">John bar Aphtūnāyā</persName>
                 </author>
-                <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John
-                  bar Aphtūnāya</persName>̄, etc., from no. 374 (<foreign xml:lang="syr">ܫܥܕ</foreign>) to no. 402 (<foreign xml:lang="syr">ܬܒ</foreign>)</title>
+                <title xml:lang="en">The Hymns of <persName ref="http://syriaca.org/person/51">Severus</persName>, <persName ref="http://syriaca.org/person/52">John bar Aphtūnāya</persName>̄, etc., from no. 374 (<foreign xml:lang="syr">ܫܥܕ</foreign>) to no. 402 (<foreign xml:lang="syr">ܬܒ</foreign>)</title>
                 <finalRubric xml:lang="syr">
                   <locus from="101b"/>ܫܠܡ ܠܡܟܬܒ ܡ̈ܥܢܝܬܐ ܕܩܕܝܫܐ ܘܠܒ̣ܝܫ ܠܐܠܗܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ
                 ܕܟܘܪܣܝܐ ܫܠܝܚܝܐ ܕܐܢܛܘܝܟܝܐ <foreign xml:lang="en">(sic)</foreign> ܡܕܝܢܬܐ ܕܣܘܪܝܐ</finalRubric>

--- a/data/tei/1131.xml
+++ b/data/tei/1131.xml
@@ -159,8 +159,7 @@
                 </msItem>
                 <msItem xml:id="p1b4" n="5">
                   <locus from="4a" to="5"/>
-                  <title xml:lang="en">The Nativity of <persName>S. John the
-                                        Baptist</persName>
+                  <title xml:lang="en">The Nativity of <persName>S. John the Baptist</persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p1b5" n="6">
@@ -172,8 +171,7 @@
                 </msItem>
                 <msItem xml:id="p1b6" n="7">
                   <locus from="11a" to="12"/>
-                  <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/42">Jacob of
-                                        Batnae</persName>
+                  <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p1b7" n="8">
@@ -203,8 +201,7 @@
                 </msItem>
                 <msItem xml:id="p1b11" n="12">
                   <locus from="15a" to="16"/>
-                  <title xml:lang="en">Of <persName>Mār
-                                    Gabriel</persName>
+                  <title xml:lang="en">Of <persName>Mār Gabriel</persName>
                 </title>
                 </msItem>
               </msItem>
@@ -393,8 +390,7 @@
                 </msItem>
                 <msItem xml:id="p2b13" n="14">
                   <locus from="46b" to="48"/>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/744">Simeon
-                                    Stylites</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p2b14" n="15">

--- a/data/tei/1134.xml
+++ b/data/tei/1134.xml
@@ -227,8 +227,7 @@
             <msItem xml:id="a2" n="14" defective="true">
               <locus from="17a"/>
               <title xml:lang="en">A fragment of a selection from the Scholia or
-                        Commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName>
+                        Commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                         on the Organon of <persName>Aristotle</persName>.</title>
               <rubric xml:lang="syr">ܬܘܒ ܥܡ ܐܠܗܐ ܟܬ̇ܒܝܢ ܣܟܘ̈ܠܝܐ ܡܢ ܒܪܬ ܩܠܐ
                         ܕܐܘܠܘܡܦܝܘܕܘܪܘܣ [ܕܐܠܟܣ]ܐܢܕܪܝܐ ܥܠ . . . ܣ ܕܐܪܝܣܛܘܛܘܐܠܝܣ.</rubric>

--- a/data/tei/1136.xml
+++ b/data/tei/1136.xml
@@ -416,8 +416,7 @@
                 <author>
                   <persName xml:lang="en">John bar Gannavai of Tagrit</persName>
                 </author>
-                <title xml:lang="en">Extract from a discourse of <persName>John bar Gannavai of
-                  <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
+                <title xml:lang="en">Extract from a discourse of <persName>John bar Gannavai of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
                   </persName>, on the brazen thurible</title>
                 <rubric xml:lang="syr">ܦܘܫܩܐ ܡܛܠ ܦܝܪܡܐ ܕܢܚܳܫܐ. ܘܐܡ̇ܪܝܢܢ. ܕܝܘܚܢܢ ܒܪ ܓܰܢܳܘܰܝ ܕܝܪܝܐ.
                   ܬܓܪܝܬܢܝܐ ܐܡ̣ܪ ܒܡܐܡܪܐ ܕܥܒ̣ܕ ܥܠ ܦܝܪܡܐ. ܕܡܛܠܡܢܐ ܡܬܥܒܕ ܕܢܚܵܫܐ. ܡܛܠ ܕܫܡܐ ܕܢܚܫܐ ܠܫܡܐ

--- a/data/tei/1136.xml
+++ b/data/tei/1136.xml
@@ -416,8 +416,7 @@
                 <author>
                   <persName xml:lang="en">John bar Gannavai of Tagrit</persName>
                 </author>
-                <title xml:lang="en">Extract from a discourse of <persName>John bar Gannavai of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                  </persName>, on the brazen thurible</title>
+                <title xml:lang="en">Extract from a discourse of <persName>John bar Gannavai of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName>, on the brazen thurible</title>
                 <rubric xml:lang="syr">ܦܘܫܩܐ ܡܛܠ ܦܝܪܡܐ ܕܢܚܳܫܐ. ܘܐܡ̇ܪܝܢܢ. ܕܝܘܚܢܢ ܒܪ ܓܰܢܳܘܰܝ ܕܝܪܝܐ.
                   ܬܓܪܝܬܢܝܐ ܐܡ̣ܪ ܒܡܐܡܪܐ ܕܥܒ̣ܕ ܥܠ ܦܝܪܡܐ. ܕܡܛܠܡܢܐ ܡܬܥܒܕ ܕܢܚܵܫܐ. ܡܛܠ ܕܫܡܐ ܕܢܚܫܐ ܠܫܡܐ
                   ܕܡܫܝܚܐ ܨ̇ܐܪ. ܒܡܢܝܢܐ ܗܟܢܐ. ܏ܘܫ.</rubric>

--- a/data/tei/1137.xml
+++ b/data/tei/1137.xml
@@ -108,8 +108,7 @@
             <msItem xml:id="a1" n="1" defective="false">
               <locus from="2b" to="44">Foll. 2b-44</locus>
               <title xml:lang="en">An elementary Syriac Grammar, <foreign xml:lang="syr">ܢܘܗܵܪ
-                           ܫܲܪ̈ܘܵܝܹܐ</foreign> composed by <persName>Timotheus (or Isaac) bar
-                           'Ebed-Haiya</persName>, metropolitan of <placeName ref="http://syriaca.org/place/8">Amid</placeName>.</title>
+                           ܫܲܪ̈ܘܵܝܹܐ</foreign> composed by <persName>Timotheus (or Isaac) bar 'Ebed-Haiya</persName>, metropolitan of <placeName ref="http://syriaca.org/place/8">Amid</placeName>.</title>
               <rubric xml:lang="syr">ܒܫܡ ܐܒܐ ܘܒܪܐ ܘܪܘܚܐ ܚܝܐ ܩܕܝܫܐ ܡܫܪܝܢܢ ܕܢܟܬܘܒ ܟܬܒܐ ܕܢܘܼܗܳܪ
                         ܫܲܪ̈ܘܵܝܹܐ ܕܐܝܬ܏ܘ ܥܠ ܐܘܪܗܳܝܐ ܡܢ ܣܝܵܡܹ̈ܐ ܒܚܝܪ̈ܐ ܕܥܒܕܐ ܡܚܝܠܐ ܘܚܛܝܐ ܥܒܹܕ
                         ܝܰܕܘܥ̈ܬܢܹܐ ܛܝܡܘܬܹܐܘܿܣ ܐܝ̣ܣܚܵܩ ܡܝܛܪܘܦܘܠܝܛܐ ܕܰܐܡܝ̣ܕ ܒܪ ܏ܡܫܡ ܥܒܹܕ ܚܲܝܐ
@@ -141,8 +140,7 @@
             </msItem>
             <msItem xml:id="a2" n="2">
               <locus from="44b"/>
-              <title xml:lang="en">The metrical Grammar of <persName ref="http://syriaca.org/person/239">Gregory bar
-                           Hebraeus</persName>, with the scholia.</title>
+              <title xml:lang="en">The metrical Grammar of <persName ref="http://syriaca.org/person/239">Gregory bar Hebraeus</persName>, with the scholia.</title>
               <rubric xml:lang="syr">ܒܚܲܝܠܐ ܕܰܐܒܳܐ ܘܕܰܒܪܳܐ ܘܪܘܼܚܳܐ܇ ܚܲܕ ܐܰܠܗܵܐ ܝܵܗܹ̇ܒ ܪܘܼܚܵܐ܆
                 ܢܸ̇ܟܬܘܿܒ ܡ̇ܰܥܰܠܬܴܐ ܕܰܢܟܝ̣ܺܚܵܐ. ܠܰܓܪܰܡܰܛܝܹܩܝ̣ ܕܰܫܒܝ̣ܚܵܐ .. ܕܣܝ̣ܺܡܵܐ ܠܡܲܦܪܝܵܢܳܐ
                 ܕܡܲܕܢܚܵܐ܇ ܓܪܝܺܓܵܘܪܝܘܿܣ ܢܲܗܝ̣ܺܪ ܨܹܡ̣ܚܵܐ܆ ܐܰܒ݁ܰܕܹܝܺܗ ܕܢܘܼܗܵܪܐ ܕܢܚܵܐ. ܕܰܠܒܘܼܝܵܢܵܐ

--- a/data/tei/1139.xml
+++ b/data/tei/1139.xml
@@ -120,8 +120,7 @@
               <author ref="http://syriaca.org/person/239">
                 <persName xml:lang="en">Gregory bar Hebraeus</persName>
               </author>
-              <title xml:lang="en">The metrical Grammar of <persName ref="http://syriaca.org/person/239">Gregory bar Hebraeus
-                           ('Ebrāyā)</persName>, with the scholia.</title>
+              <title xml:lang="en">The metrical Grammar of <persName ref="http://syriaca.org/person/239">Gregory bar Hebraeus ('Ebrāyā)</persName>, with the scholia.</title>
               <rubric xml:lang="syr">ܥܠ ܚܲܝܠܐ ܗ̇ܘ ܐܠܗܝܐ ܡܫܲܪܝܢܢ ܠܡ̣ܟ̣ܬ݀ܒ̣ ܡ̇ܥܠܬ݀ܐ ܕܠܘܬ݂ ܝܕܥܬܐ
                 ܓ̣ܪܐܡܛܝܩܝܬ݀ܐ ܡܛܟ̇ܣܐ ܕ݂ܝܢ ܠܓ̣ܒ̣ܝܐ ܘܠܒܝ̣ܫ ܠܐܠܗܐ ܛܘܒ̣ܬ݂ܢܐ ܢܲܨܝܚ ܒܟ̣ܠ ܐܒܘܢ ܡܪܝ
                 ܓ̣ܪܝܓ̣ܘܪܝܘܣ ܡܲܦ̣ܪܝܢܐ ܕܡܲܕܢܚܐ ܛܲܟ̇ܣܗ̇ ܕܝܢ ܒܡܫܘܚܬ݂ܐ ܐܦܪܸܝܡ̇ܝܬ݁ܐ ܨܠܘܬ݂ܗ ܬ݀ܢܲܛܪ ܠܟ̣ܠܗ
@@ -204,8 +203,7 @@
                   </msItem>
                   <msItem xml:id="d9" n="16">
                     <locus from="112b" to="113">Foll. 112b-113</locus>
-                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of
-                                       <persName>Sirach</persName>
+                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܟܬܒܐ ܕܒܪܐܣܝܪܐ</rubric>
                   </msItem>

--- a/data/tei/1139.xml
+++ b/data/tei/1139.xml
@@ -203,8 +203,7 @@
                   </msItem>
                   <msItem xml:id="d9" n="16">
                     <locus from="112b" to="113">Foll. 112b-113</locus>
-                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName>
-                      </persName>.</title>
+                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName></persName>.</title>
                     <rubric xml:lang="syr">ܟܬܒܐ ܕܒܪܐܣܝܪܐ</rubric>
                   </msItem>
                   <msItem xml:id="d10" n="17">

--- a/data/tei/1141.xml
+++ b/data/tei/1141.xml
@@ -163,8 +163,7 @@
                   </msItem>
                   <msItem xml:id="d8" n="12">
                     <locus from="238a" to="242">Foll. 238a-242</locus>
-                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName>
-                      </persName>.</title>
+                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName></persName>.</title>
                   </msItem>
                   <msItem xml:id="d9" n="13">
                     <locus from="242b" to="244">Foll. 242b-244</locus>

--- a/data/tei/1141.xml
+++ b/data/tei/1141.xml
@@ -163,8 +163,7 @@
                   </msItem>
                   <msItem xml:id="d8" n="12">
                     <locus from="238a" to="242">Foll. 238a-242</locus>
-                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of
-                                 <persName>Sirach</persName>
+                    <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName>
                       </persName>.</title>
                   </msItem>
                   <msItem xml:id="d9" n="13">
@@ -259,8 +258,7 @@
             </msItem>
             <msItem xml:id="a2" n="32">
               <locus from="421"/>
-              <title xml:lang="en">a list of the works of <persName ref="http://syriaca.org/person/239">Gregory bar
-                           Hebraeus</persName>, with a few particulars regarding his life</title>
+              <title xml:lang="en">a list of the works of <persName ref="http://syriaca.org/person/239">Gregory bar Hebraeus</persName>, with a few particulars regarding his life</title>
               <quote xml:lang="syr">ܫܡ̈ܗܐ ܕܟܬܒ̈ܐ ܕܣܵܡ ܣܘܪܝܐܝܬ ܘܐܪܐܒܐܝܬ ܒܥܕܬܐ ܗ̣ܘ ܡܲܦܪܝܢܐ ܏ܩܕ
                         ܡܪܝ ܓܪܝܓܘܿܪܝܘܿܣ
               </quote>
@@ -290,8 +288,7 @@
               </msItem>
               <msItem xml:id="b5" n="36">
                 <locus from="207"/>
-                <title xml:lang="en">A list of the works of <persName ref="http://syriaca.org/person/239">Gregory bar
-                              Hebraeus</persName>, etc., similar to that mentioned above.</title>
+                <title xml:lang="en">A list of the works of <persName ref="http://syriaca.org/person/239">Gregory bar Hebraeus</persName>, etc., similar to that mentioned above.</title>
                 <rubric xml:lang="syr">ܫܡ̈ܗܐ ܕܟܬ̈ܒܐ ܕܣܡ ܣܘܪܝܐܝܬ ܘܐܪܒܐܝܬ ܒܥܕܬܐ ܗ̣ܘ ܡܲܦܪܝܢܐ
                            ܩ܏ܕ ܡܪܝ ܓܪܝܓܘܪܝܘܣ ܐܒܘ ܐܠܦܪܓ ܐܒܘܢ ܕܗ̣ܘ ܒܲܪ ܐܗܪܘܢ ܐܣܝܐ.</rubric>
               </msItem>

--- a/data/tei/1142.xml
+++ b/data/tei/1142.xml
@@ -98,8 +98,7 @@
           <msContents>
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
-              <title xml:lang="en">The Syriac and Arabic Lexicon of <persName ref="http://syriaca.org/person/472">Elias of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                </persName>
+              <title xml:lang="en">The Syriac and Arabic Lexicon of <persName ref="http://syriaca.org/person/472">Elias of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName>
               </title>
               <title>The book called the Interpreter, for teaching the
                         language of the Syrians.</title>

--- a/data/tei/1143.xml
+++ b/data/tei/1143.xml
@@ -143,8 +143,7 @@
                 <author ref="http://syriaca.org/person/812">
                   <persName xml:lang="en">Patriarch Joseph I</persName>
                 </author>
-                <title xml:lang="en">The same, by the <persName ref="http://syriaca.org/person/812">patriarch Joseph
-                              I</persName>.</title>
+                <title xml:lang="en">The same, by the <persName ref="http://syriaca.org/person/812">patriarch Joseph I</persName>.</title>
                 <rubric xml:lang="syr"> ܚܬܐܡ ܐܵܟ݂ܪ ܓ̣ܝܪܗܳ ܐܠܝ ܥܝ̣ܕ ܐܠܥܕܪܝ ܡ̣ܢ ܩܲܘܠ ܡܵܐܪ ܝܳܘܼܣܦ݁
                   ܐܠܐܘّܠ ܒܲܛܪܟ ܐܠܟܲܠ܏ܕܐ:</rubric>
                 <incipit xml:lang="syr">ܒܸܣܡ ܐܲܠܬ݂ܐܠܘܼܳܬ݂ ܐܲܠܡܲܣܓܘܼܳܕ: ܐܸܠܵܐܗً ܘܵܐܚܸܕ ܡܲܥܒ݁ܘܳܕ.

--- a/data/tei/1144.xml
+++ b/data/tei/1144.xml
@@ -185,8 +185,7 @@
             </msItem>
             <msItem xml:id="a5" n="5">
               <locus from="58b"/>
-              <title xml:lang="en">Revelations and Visions of <persName>the Just of old</persName> and of <persName>the true
-                Prophets</persName>, regarding the Dispensation of <persName>the Messiah</persName>
+              <title xml:lang="en">Revelations and Visions of <persName>the Just of old</persName> and of <persName>the true Prophets</persName>, regarding the Dispensation of <persName>the Messiah</persName>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܢܸܥܒܸ݁ܕ ܫܘܼܪܵܝܐ ܕܡܝܬܪܘܬܐ ܥܠ ܡܕܒܪܢܘܬܗ ܕܡܫܝܚܐ ܡܪܢ ܘܥܠ
                 ܓܸܠܝ̈ܢܐ. ܘܥܠ ܚܹܙܘܵܢ̈ܐ ܐܝܠܝܢ ܕܗܘ̤ܘ ܠܘܬ ܙܕܝ̈ܩܐ ܩܕܡ̈ܝܐ. ܘܢܒ̈ܝܐ ܫܪܝܪ̈ܐ ܗܐ ܡܹܟ݁ܐ ܓܝܪ

--- a/data/tei/1144.xml
+++ b/data/tei/1144.xml
@@ -230,8 +230,7 @@
               <author ref="http://syriaca.org/person/745">
                 <persName xml:lang="en">Solomon of Basra</persName>
               </author>
-              <title xml:lang="en">The Bee, compiled by <persName ref="http://syriaca.org/person/745">Solomon, metropolitan of <placeName>Pĕrath Maishān</placeName> or <placeName>al-Baṣra</placeName>
-                </persName>
+              <title xml:lang="en">The Bee, compiled by <persName ref="http://syriaca.org/person/745">Solomon, metropolitan of <placeName>Pĕrath Maishān</placeName> or <placeName>al-Baṣra</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܟܬܒܐ ܕܠܘܼܩܵܛ̈ܐ ܕܡܬܩܪܐ ܕܸܒ݁ܘܿܪܝ̣ܬ݂ܐ: ܕܥܒܝܕ ܠܚܣܝܐ ܕܐܠܗܐ ܡܪܝ
                 ܫܠܹܝܡܘܿܢ ܡܝܛܪܦܘܠܝܛܐ ܕܲܦܪܲܬ ܕܡܲܝܫܵܢ ܕܗܝ̤ ܗ݇ܝ̣ ܒܲܨܪܵܗ܀</rubric>
@@ -279,8 +278,7 @@
             </msItem>
             <msItem xml:id="a10" n="11">
               <locus from="232b"/>
-              <title xml:lang="en">The history of <persName>Shalita, the disciple of <persName>Eugenius</persName>
-                </persName>
+              <title xml:lang="en">The history of <persName>Shalita, the disciple of <persName>Eugenius</persName></persName>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܡܪܝ ܫܲܠܝ̣ܛܵܐ</rubric>
             </msItem>

--- a/data/tei/1144.xml
+++ b/data/tei/1144.xml
@@ -284,8 +284,7 @@
             </msItem>
             <msItem xml:id="a11" n="12">
               <locus from="253a"/>
-              <title xml:lang="en">The martyrdom of <persName>Mamas</persName> at <placeName>Caesarea in <placeName>Cappadocia</placeName>
-                </placeName>
+              <title xml:lang="en">The martyrdom of <persName>Mamas</persName> at <placeName>Caesarea in <placeName>Cappadocia</placeName></placeName>
               </title>
               <rubric xml:lang="syr">ܣܗܕܘܬܐ ܕܡܪܝ ܡܵܡܵܐ ܣܗܕܐ ܒܩܹܣܲܪܝܐ ܡܕܝܢܬܐ ܕܩܵܦܵܕ݂ܘܿܩܝ̣ܵܐ.</rubric>
               <note>See <bibl>Add. 14,645, no. 38.</bibl>

--- a/data/tei/1145.xml
+++ b/data/tei/1145.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/472">
                 <persName xml:lang="en">Elias of Nisibis</persName>
               </author>
-              <title xml:lang="en">The Syriac Grammar of <persName>Elias of
-                                    Nisibis</persName>
+              <title xml:lang="en">The Syriac Grammar of <persName>Elias of Nisibis</persName>
               </title>
               <rubric xml:lang="syr">ܥܠ ܚܝܠܐ ܘܬܘܟܠܢܐ ܐܠܗܝܐ ܡܫܪܐ ܐ݇ܢܐ ܠܡܟܬܒ ܬܘܼܪܵܨ
                                 ܡܲܡܠܠܵܐ ܕܠܸܫܵܢܐ ܐܲܪܡܵܝܐ. ܗ̇ܢܘ ܕܝܢ. ܣܘܼܪܝܵܝܵܐ܀ ܘܲܣܝܵܡܐ ܗ̣݇ܘ ܕܩܕܝܫܐ
@@ -473,8 +472,7 @@
               <author ref="http://syriaca.org/person/563">
                 <persName xml:lang="en">Joseph bar Malkon, bishop of Maridin</persName>
               </author>
-              <title xml:lang="en">A metrical treatise by <persName ref="http://syriaca.org/person/563">Joseph bar
-                Malkon, bishop of <placeName ref="http://syriaca.org/place/2342">Maridin</placeName>
+              <title xml:lang="en">A metrical treatise by <persName ref="http://syriaca.org/person/563">Joseph bar Malkon, bishop of <placeName ref="http://syriaca.org/place/2342">Maridin</placeName>
                 </persName>, on the points</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܙܥܘܪܐ ܕܥܒܝܕ ܠܡܪܝ ܝܵܘܣܸܦ ܐܲܦܸܣܩܘܿܦܐ ܕܡܸܪܕܵܐ܀
                                 ܨܠܘܬܗ ܠܓܵـ݂ܘܵܐ ܕܡܗ̈ܝܡܢܐ ܐܡܝܢ܀ ܕܡܵܘܕܲܥ ܒܦܵܣ̈ܝ̣ܩܵܬ݂ܐ ܥܠ ܢܘܼܩ̈ܙܹܐ

--- a/data/tei/1145.xml
+++ b/data/tei/1145.xml
@@ -284,8 +284,7 @@
                   <author ref="http://syriaca.org/person/444">
                     <persName xml:lang="en">Denha, the disciple of the Catholicus Yeshua' bar Nun</persName>
                   </author>
-                  <title xml:lang="en">the commentary of <persName ref="http://syriaca.org/person/444">Denha, the disciple of the <persName ref="http://syriaca.org/person/552">Catholicus Yeshua' bar Nun</persName></persName>, on the <title>Analytics of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
-                    </title>
+                  <title xml:lang="en">the commentary of <persName ref="http://syriaca.org/person/444">Denha, the disciple of the <persName ref="http://syriaca.org/person/552">Catholicus Yeshua' bar Nun</persName></persName>, on the <title>Analytics of <persName ref="http://syriaca.org/person/342">Aristotle</persName></title>
                   </title>
                   <rubric xml:lang="syr">ܦܘܼܫ̇ܩܐ ܕܐܵܢܵܠܘܿܛ̈ܝ̣ܩܹܐ ܕܐܪܝ̣ܣܛܘܿܛܵܠܝ̣ܣ.
                                         ܕܦܲܫܩܵܗ̇ ܪܒ݁ܢ ܕܢܚܵܐ ܬܠܡܝܕܗ ܕܡܪܝ ܝ̣ܫܘܿܥ ܒܲܪܢܘܢ

--- a/data/tei/1145.xml
+++ b/data/tei/1145.xml
@@ -284,8 +284,7 @@
                   <author ref="http://syriaca.org/person/444">
                     <persName xml:lang="en">Denha, the disciple of the Catholicus Yeshua' bar Nun</persName>
                   </author>
-                  <title xml:lang="en">the commentary of <persName ref="http://syriaca.org/person/444">Denha, the disciple of the <persName ref="http://syriaca.org/person/552">Catholicus Yeshua' bar Nun</persName>
-                    </persName>, on the <title>Analytics of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
+                  <title xml:lang="en">the commentary of <persName ref="http://syriaca.org/person/444">Denha, the disciple of the <persName ref="http://syriaca.org/person/552">Catholicus Yeshua' bar Nun</persName></persName>, on the <title>Analytics of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
                     </title>
                   </title>
                   <rubric xml:lang="syr">ܦܘܼܫ̇ܩܐ ܕܐܵܢܵܠܘܿܛ̈ܝ̣ܩܹܐ ܕܐܪܝ̣ܣܛܘܿܛܵܠܝ̣ܣ.
@@ -472,8 +471,7 @@
               <author ref="http://syriaca.org/person/563">
                 <persName xml:lang="en">Joseph bar Malkon, bishop of Maridin</persName>
               </author>
-              <title xml:lang="en">A metrical treatise by <persName ref="http://syriaca.org/person/563">Joseph bar Malkon, bishop of <placeName ref="http://syriaca.org/place/2342">Maridin</placeName>
-                </persName>, on the points</title>
+              <title xml:lang="en">A metrical treatise by <persName ref="http://syriaca.org/person/563">Joseph bar Malkon, bishop of <placeName ref="http://syriaca.org/place/2342">Maridin</placeName></persName>, on the points</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܙܥܘܪܐ ܕܥܒܝܕ ܠܡܪܝ ܝܵܘܣܸܦ ܐܲܦܸܣܩܘܿܦܐ ܕܡܸܪܕܵܐ܀
                                 ܨܠܘܬܗ ܠܓܵـ݂ܘܵܐ ܕܡܗ̈ܝܡܢܐ ܐܡܝܢ܀ ܕܡܵܘܕܲܥ ܒܦܵܣ̈ܝ̣ܩܵܬ݂ܐ ܥܠ ܢܘܼܩ̈ܙܹܐ
                                 ܩܵܢܘܿܢܵܐܝ̣ܬ݂. ܘܡܛܲܟܲܣ ܒܲܩܪܵܝܬ݁ܐ ܕܬܪ̈ܬܝܢ. </rubric>

--- a/data/tei/1151.xml
+++ b/data/tei/1151.xml
@@ -129,8 +129,7 @@
               </msItem>
               <msItem xml:id="b5" n="7">
                 <locus from="9a"/>
-                <title xml:lang="en">The Nativity of <persName>our
-                                        Lord</persName>
+                <title xml:lang="en">The Nativity of <persName>our Lord</persName>
                 </title>
               </msItem>
               <msItem xml:id="b6" n="8">
@@ -176,8 +175,7 @@
               </msItem>
               <msItem xml:id="b14" n="16">
                 <locus from="24a"/>
-                <title xml:lang="en">The Commemoration of <persName>the
-                                    Evangelists</persName>
+                <title xml:lang="en">The Commemoration of <persName>the Evangelists</persName>
                 </title>
               </msItem>
               <msItem xml:id="b15" n="17">
@@ -198,8 +196,7 @@
               </msItem>
               <msItem xml:id="b18" n="20">
                 <locus from="30a"/>
-                <title xml:lang="en">The Commemoration of <persName>the Greek
-                                    Doctors</persName>
+                <title xml:lang="en">The Commemoration of <persName>the Greek Doctors</persName>
                 </title>
               </msItem>
               <msItem xml:id="b19" n="21">
@@ -209,8 +206,7 @@
               </msItem>
               <msItem xml:id="b20" n="22">
                 <locus from="33b"/>
-                <title xml:lang="en">The Commemoration of <persName>the Syrian
-                                    Doctors</persName>
+                <title xml:lang="en">The Commemoration of <persName>the Syrian Doctors</persName>
                 </title>
               </msItem>
               <msItem xml:id="b21" n="23">
@@ -220,8 +216,7 @@
               </msItem>
               <msItem xml:id="b22" n="24">
                 <locus from="36a"/>
-                <title xml:lang="en">The Commemoration of <persName>any one
-                                    Saint</persName>
+                <title xml:lang="en">The Commemoration of <persName>any one Saint</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܕܘܟܪܢܐ ܕܚܲܕ ܦ݁ܪܨܘܿܦ݁ܐ</rubric>
               </msItem>
@@ -232,8 +227,7 @@
               </msItem>
               <msItem xml:id="b24" n="26">
                 <locus from="41b"/>
-                <title xml:lang="en">The Commemoration of <persName>the Dead, the
-                                    Children of <persName>Adam</persName>
+                <title xml:lang="en">The Commemoration of <persName>the Dead, the Children of <persName>Adam</persName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܼܟܪܢܐ ܕܥܢܝ̈ܕܐ ܝܠܕܘ̈ܗܝ ܕܐܕܡ</rubric>
@@ -403,8 +397,7 @@
               </msItem>
               <msItem xml:id="b62" n="64">
                 <locus from="112b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār
-                                        George</persName> (24th of Nīsān)</title>
+                <title xml:lang="en">The Commemoration of <persName>Mār George</persName> (24th of Nīsān)</title>
               </msItem>
               <msItem xml:id="b63" n="65">
                 <locus from="113b"/>
@@ -491,8 +484,7 @@
               </msItem>
               <msItem xml:id="b76" n="78">
                 <locus from="128b"/>
-                <title xml:lang="en">The Lesson of the Adoration (of <persName>the
-                                    holy Cross</persName>)</title>
+                <title xml:lang="en">The Lesson of the Adoration (of <persName>the holy Cross</persName>)</title>
                 <rubric xml:lang="syr">ܩܸܪܝܵܢܵܐ ܕܣܸܓܕ݁ܬ݂ܐ</rubric>
               </msItem>
               <msItem xml:id="b77" n="79">
@@ -502,8 +494,7 @@
               </msItem>
               <msItem xml:id="b78" n="80">
                 <locus from="133a"/>
-                <title xml:lang="en">The second Sunday of the Week of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The second Sunday of the Week of <persName>the Apostles</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܚܲܕܒܫܲܒ݁ܐ ܕܲܬܪܹ̈ܝܢ ܕܫܒܘܿܥܵܐ ܕܫܠܝ̈ܚܐ</rubric>
               </msItem>
@@ -547,26 +538,22 @@
               </msItem>
               <msItem xml:id="b86" n="88">
                 <locus from="141b"/>
-                <title xml:lang="en">The sixth Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The sixth Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b87" n="89">
                 <locus from="143b"/>
                 <title xml:lang="en">The sixth Friday, the Commemoration
-                                    of <persName>Gregory</persName> and of <persName>S. Thomas the
-                                        Apostle</persName> (3rd of Tamūz)</title>
+                                    of <persName>Gregory</persName> and of <persName>S. Thomas the Apostle</persName> (3rd of Tamūz)</title>
               </msItem>
               <msItem xml:id="b88" n="90">
                 <locus from="143b"/>
-                <title xml:lang="en">The seventh Sunday of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The seventh Sunday of <persName>the Apostles</persName>
                 </title>
               </msItem>
               <msItem xml:id="b89" n="91">
                 <locus from="145a"/>
-                <title xml:lang="en">The last Friday of the week of <persName>the
-                                    Apostles</persName>
+                <title xml:lang="en">The last Friday of the week of <persName>the Apostles</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܒܬ݁ܐ ܕܫܘܼܠܵܡ ܫܵܒ̣ܘܿܥܵܐ ܕܫܠܝ̈ܚܐ</rubric>
               </msItem>
@@ -630,8 +617,7 @@
               <msItem xml:id="b99" n="101">
                 <locus from="158a"/>
                 <title xml:lang="en">The fifth Friday; the Commemoration
-                                    of <persName>Shamūnī</persName> and <persName>her sons (the
-                                    Maccabees)</persName>
+                                    of <persName>Shamūnī</persName> and <persName>her sons (the Maccabees)</persName>
                 </title>
               </msItem>
               <msItem xml:id="b100" n="102">
@@ -667,9 +653,7 @@
                 <locus from="163a"/>
                 <title xml:lang="en">The first Friday; the Commemoration
                   of <persName>Pāpā (<foreign xml:lang="syr">ܦ݁̈ܦ݁̈ܐ</foreign>)</persName>,
-                                        <persName>Simeon</persName>, <persName>Shahdost
-                                          (<foreign xml:lang="syr">ܫܲܗܕܘܣܬ݁</foreign>)</persName>, and <persName>all the
-                                    Catholics</persName>
+                                        <persName>Simeon</persName>, <persName>Shahdost (<foreign xml:lang="syr">ܫܲܗܕܘܣܬ݁</foreign>)</persName>, and <persName>all the Catholics</persName>
                 </title>
               </msItem>
               <msItem xml:id="b106" n="108">
@@ -680,8 +664,7 @@
               <msItem xml:id="b107" n="109">
                 <locus from="165a"/>
                 <title xml:lang="en">The second Friday; the
-                                    Commemoration of <persName>‘Abda, bishop of
-                                      <placeName>Pĕrāth</placeName>
+                                    Commemoration of <persName>‘Abda, bishop of <placeName>Pĕrāth</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܥܲܒ݂ܕܐ ܐܲܦ̱ܣܩܘܿܦܐ ܕܦܪܵܬ݂</rubric>
@@ -752,8 +735,7 @@
               <msItem xml:id="b118" n="120">
                 <locus from="179b"/>
                 <title xml:lang="en">The Commemoration of
-                                        <persName>Phetion
-                                          (<foreign xml:lang="syr">ܦܸܬ݂ܝܘܿܢ</foreign>)</persName>, 25th of the first
+                                        <persName>Phetion (<foreign xml:lang="syr">ܦܸܬ݂ܝܘܿܢ</foreign>)</persName>, 25th of the first
                                     Teshri</title>
               </msItem>
               <msItem xml:id="b119" n="121">
@@ -764,8 +746,7 @@
               </msItem>
               <msItem xml:id="b120" n="122">
                 <locus from="180a"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār
-                                        Kosrē</persName>
+                <title xml:lang="en">The Commemoration of <persName>Mār Kosrē</persName>
                                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܩܘܿܣܪܹ̈ܐ</rubric>
               </msItem>

--- a/data/tei/1151.xml
+++ b/data/tei/1151.xml
@@ -227,8 +227,7 @@
               </msItem>
               <msItem xml:id="b24" n="26">
                 <locus from="41b"/>
-                <title xml:lang="en">The Commemoration of <persName>the Dead, the Children of <persName>Adam</persName>
-                  </persName>
+                <title xml:lang="en">The Commemoration of <persName>the Dead, the Children of <persName>Adam</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܘܼܟܪܢܐ ܕܥܢܝ̈ܕܐ ܝܠܕܘ̈ܗܝ ܕܐܕܡ</rubric>
               </msItem>
@@ -425,8 +424,7 @@
                 <title xml:lang="en">The third Friday, the Commemoration
                                     of <persName>Sĕlīmōth</persName>, <persName>Adūnā</persName>,
                                         <persName>John</persName>, <persName>Abraham</persName>, and
-                                    all the <persName>Metropolitans of <placeName>Arbil</placeName>
-                  </persName>
+                                    all the <persName>Metropolitans of <placeName>Arbil</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܪܘܼܒ̣ܬ݁ܐ ܕܬܠܬ ܕܲܣܠܹܝܡܘܿܬ݂ ܘܐܲܕ݁ܘܼܢܵܐ ܘܝܘܚܢܢ ܘܐܒܪܗܡ. ܘܟܠܗܘܢ ܡܝܛܪ̈܏ܦܘܼ ܕܐܲܪܒܹܝܠ</rubric>
               </msItem>
@@ -664,8 +662,7 @@
               <msItem xml:id="b107" n="109">
                 <locus from="165a"/>
                 <title xml:lang="en">The second Friday; the
-                                    Commemoration of <persName>‘Abda, bishop of <placeName>Pĕrāth</placeName>
-                  </persName>
+                                    Commemoration of <persName>‘Abda, bishop of <placeName>Pĕrāth</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܥܲܒ݂ܕܐ ܐܲܦ̱ܣܩܘܿܦܐ ܕܦܪܵܬ݂</rubric>
               </msItem>

--- a/data/tei/1155.xml
+++ b/data/tei/1155.xml
@@ -172,8 +172,7 @@
               </msItem>
               <msItem xml:id="b3" n="7">
                 <locus from="170a" to="174">Foll. 170a-174</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1826">S. John the
-                           Evangelist</persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1826">S. John the Evangelist</persName>.</title>
                 <rubric xml:lang="syr">ܐܰܢܢܰܐܦ݂ܘܽܪܰܐ ܕܝܽܘܚܲܢܢ ܐܷܘܰܐܢܓܹܠܝ̣ܣܛܳܐ</rubric>
               </msItem>
             </msItem>

--- a/data/tei/1155.xml
+++ b/data/tei/1155.xml
@@ -158,15 +158,13 @@
               <title xml:lang="en">A collection of Anaphoras in Syriac.</title>
               <msItem xml:id="b1" n="5">
                 <locus from="165a" to="166">Foll. 165a-166</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/212">Dionysius bar Salibi, bishop of <placeName ref="http://syriaca.org/place/8">Amid</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/212">Dionysius bar Salibi, bishop of <placeName ref="http://syriaca.org/place/8">Amid</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܐܰܢܢܰܐܦ݂ܽܘܪܰܐ ܕܩܰܕܺܝܫܵܐ ܡܳܪܝ ܕܻܝܳܣܢܢܳܘܣܝܻܘܳܣ
                            ܐܸܦܝ̣ܣܩܵܘܦܵܐ ܕܰܐܡܝ̣ܕ ܕܗ̣ܘ ܒ݁ܰܪ ܨܰܠܺܝ̣ܒ݁ܝ</rubric>
               </msItem>
               <msItem xml:id="b2" n="6">
                 <locus from="167a" to="169">Foll. 167a-169</locus>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/22">Xystus, bishop of <placeName ref="http://syriaca.org/place/641">Rome</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/22">Xystus, bishop of <placeName ref="http://syriaca.org/place/641">Rome</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܐܰܢܢܰܐܦ݂ܘܽܪܰܐ ܏ܕܩܕ. ܟܣܘܽܣܛܳܘܣ ܐܸܦܝ̣ܣܩܵܘܦܵܐ
                            ܕܪܘܽܡܝ</rubric>
               </msItem>

--- a/data/tei/1156.xml
+++ b/data/tei/1156.xml
@@ -631,8 +631,7 @@
                 <author ref="http://syriaca.org/person/550">
                   <persName xml:lang="en">Isaac of Nineveh</persName>
                 </author>
-                <title xml:lang="en">An extract from Mar <persName ref="http://syriaca.org/person/550">Isaac (of
-                <placeName ref="http://syriaca.org/place/144">Nineveh</placeName>)</persName>
+                <title xml:lang="en">An extract from Mar <persName ref="http://syriaca.org/person/550">Isaac (of <placeName ref="http://syriaca.org/place/144">Nineveh</placeName>)</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܐܝܣܚܩ ܥܠ ܦܘܪܫܢܐ ܟܝ̇ܢܝܐ ܕܚܘܫܒܐ ܟܝ̇ܢܝܐ. ܥܠ ܟܝ̈ܠܐ ܘܡܢ̈ܘܬܐ
                 ܘܦܘܪ̈ܫܢܐ ܕܒܨܠܸܡ ܐܕܡ܀ ܩܕܡܝܐ ܒܗܘܢ ܬܪܥܝܬܐ܀ ܬܪܝܢܝܬܐ ܡܚܫܒܬܐ܀ ܒܘܝܢܐ ܐܦ ܣܘܟܠܐ܀ ܥܡ ܡܲܕܥܐ ܐܦ
@@ -909,8 +908,7 @@
                 <title xml:lang="en">The <title xml:lang="syr">ܟܬܒܐ ܕܐܷܝܪܰܬܷܐܳܘܣ</title>, or "Book of <persName>Hierotheus</persName>," extracts
                   from the work of <persName ref="http://syriaca.org/person/36">Hierotheus</persName> <title xml:lang="syr">ܕܥܠ ܪ̈ܐܙܐ ܓܢ̈ܝܙܐ ܕܒܝܬ ܐܠܗܐ</title>, selected and arranged by
                   <persName ref="http://syriaca.org/person/239">Bar Hebraeus</persName>, and accompanied by a commentary chiefly
-                  derived from that of <persName ref="http://syriaca.org/person/169">Theodosius, patriarch of
-                    <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                  derived from that of <persName ref="http://syriaca.org/person/169">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                   <!--JA: Element <ptr> requires target attribute to manuscript URI for Add. 7189-->
                 </title>

--- a/data/tei/1156.xml
+++ b/data/tei/1156.xml
@@ -908,8 +908,7 @@
                 <title xml:lang="en">The <title xml:lang="syr">ܟܬܒܐ ܕܐܷܝܪܰܬܷܐܳܘܣ</title>, or "Book of <persName>Hierotheus</persName>," extracts
                   from the work of <persName ref="http://syriaca.org/person/36">Hierotheus</persName> <title xml:lang="syr">ܕܥܠ ܪ̈ܐܙܐ ܓܢ̈ܝܙܐ ܕܒܝܬ ܐܠܗܐ</title>, selected and arranged by
                   <persName ref="http://syriaca.org/person/239">Bar Hebraeus</persName>, and accompanied by a commentary chiefly
-                  derived from that of <persName ref="http://syriaca.org/person/169">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                  derived from that of <persName ref="http://syriaca.org/person/169">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                   <!--JA: Element <ptr> requires target attribute to manuscript URI for Add. 7189-->
                 </title>
                 <note type="footnote">See the work of <persName ref="http://syriaca.org/person/36">Hierotheus</persName>, with the commentary of
@@ -1052,8 +1051,7 @@
                   <persName xml:lang="en">John bar Andreas, bishop of Tūr-'Abdīn</persName>
                 </author>
                 <title xml:lang="en">Two metrical homilies of <persName>John bar Andreas,
-                bishop of <placeName ref="http://syriaca.org/place/221">Tūr-'Abdīn</placeName>
-                  </persName>
+                bishop of <placeName ref="http://syriaca.org/place/221">Tūr-'Abdīn</placeName></persName>
                 </title>
                 <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 362</bibl>.</note>
                 <msItem xml:id="c12" n="100">

--- a/data/tei/14.xml
+++ b/data/tei/14.xml
@@ -410,8 +410,7 @@
                   <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1180">Pantaleon</persName>,
                   <persName ref="http://syriaca.org/person/1772">Hermolaus</persName>, <persName>Hermippus</persName>,
                     <persName>Hermocrates</persName>, and others, at
-                  <placeName ref="http://syriaca.org/place/502">Nicomedia</placeName>, during the reign of <persName>Maximian
-                    II</persName>
+                  <placeName ref="http://syriaca.org/place/502">Nicomedia</placeName>, during the reign of <persName>Maximian II</persName>
                 </title>
                   <rubric xml:lang="syr">
                   <locus from="87a"/>ܣܗܕܘܬܐ ܕܩܕܝܫܐ ܦܢܛܠܐܘܢ ܘܕܐܪܡܠܐܣ

--- a/data/tei/1472.xml
+++ b/data/tei/1472.xml
@@ -180,9 +180,7 @@
                   <author ref="http://syriaca.org/person/574">
                     <persName xml:lang="en">John Climacus</persName>
                   </author>
-                  <title xml:lang="en">His reply to <ref>a letter of <persName>John, abbat of
-                    Raithū</persName>
-                    </ref>
+                  <title xml:lang="en">His reply to <ref>a letter of <persName>John, abbat of Raithū</persName></ref>
                   </title>
                   <title xml:lang="en">Spiritual Tablets</title>
                   <rubric xml:lang="syr">ܠܘ̈ܚܐ ܪ̈ܘܚܢܝܬܐ</rubric>

--- a/data/tei/169.xml
+++ b/data/tei/169.xml
@@ -638,8 +638,7 @@
               </msItem>
               <msItem xml:id="p5a2" n="2">
                 <locus from="130b"/>
-                <title xml:lang="en">Precepts and Admonitions of the blessed <persName ref="http://syriaca.org/person/744">Mar
-                  Simeon</persName>
+                <title xml:lang="en">Precepts and Admonitions of the blessed <persName ref="http://syriaca.org/person/744">Mar Simeon</persName>
               </title>
                 <rubric xml:lang="syr">ܦܘ̈ܩܕܢܐ ܘܙܘܗܪ̈ܐ ܕܡܪܝ ܫܡܥܘܢ ܛܘܒܢܐ</rubric>
                 <incipit xml:lang="syr">ܐ̈ܚܝ ܘܒ̈ܢܝ ܘܚ̈ܒܝܒܝ. ܟܬܝܒ ܒܟ̈ܬܒܐ ܩܕܝ̈ܫܐ. ܕܐܪܝܐ ܢܗܡ ܡܢ ܠܐ ܢܕܚܠ

--- a/data/tei/182.xml
+++ b/data/tei/182.xml
@@ -271,8 +271,7 @@
               </msItem>
               <msItem xml:id="b35" n="36">
                 <locus from="94a" to="95"/>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1749">Mar
-                    George<!--Check ref. This is the only Gewargis that I could find. -->
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1749">Mar George<!--Check ref. This is the only Gewargis that I could find. -->
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܓܝܘܪܓܝܣ</rubric>

--- a/data/tei/182.xml
+++ b/data/tei/182.xml
@@ -271,8 +271,7 @@
               </msItem>
               <msItem xml:id="b35" n="36">
                 <locus from="94a" to="95"/>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1749">Mar George<!--Check ref. This is the only Gewargis that I could find. -->
-                  </persName>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1749">Mar George<!--Check ref. This is the only Gewargis that I could find. --></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܓܝܘܪܓܝܣ</rubric>
               </msItem>

--- a/data/tei/183.xml
+++ b/data/tei/183.xml
@@ -161,8 +161,7 @@
                   <author ref="http://syriaca.org/person/1607">
                     <persName xml:lang="en">the holy Apostles</persName>
                   </author>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1605">the
-                      holy Apostles</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1605">the holy Apostles</persName>
                   </title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܫܠܝ̈ܚܐ ܩܕܝܫ̈ܐ</rubric>
                 </msItem>

--- a/data/tei/183.xml
+++ b/data/tei/183.xml
@@ -141,8 +141,7 @@
                     <persName xml:lang="en">Jacob of Edessa</persName>
                   </author>
                   <title xml:lang="en">The Anaphora of <persName>S. James</persName>, as
-                    revised by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>
+                    revised by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">: ܐܢܦܘܪܐ ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܐܚܘܗܝ ܕܡܪܢ. ܬܘܪܨܐ ܚܕܬܐ ܕܡܪܝ ܝܥܩܘܒ
                     ܕܐܘܪܗܝ</rubric>
@@ -170,8 +169,7 @@
                   <author ref="http://syriaca.org/person/3514">
                     <persName xml:lang="en">Celestine, bishop of Rome</persName>
                   </author>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/3514">Celestine, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName>
-                    </persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/3514">Celestine, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܩܘܪܒܐ ܕ܏ܩܕ ܩܠܣܛܝܢܘܣ. ܐܦܝܣܩܘܦܐ ܕܪܗܡܐ(sic) </rubric>
                 </msItem>
@@ -180,8 +178,7 @@
                   <author ref="http://syriaca.org/person/2163">
                     <persName xml:lang="en">Julius, bishop of Rome</persName>
                   </author>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/2163">Julius, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName>
-                    </persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/2163">Julius, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܩܕܝܫܐ ܝܘܠܝܘܣ</rubric>
                 </msItem>
@@ -191,8 +188,7 @@
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
                   <title xml:lang="en">The Signing of the Cup, or Benediction of the Chalice,
-                    of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName>
-                    </persName>,
+                    of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName></persName>,
                     according to a new revision</title>
                   <rubric xml:lang="syr">ܪܫܡ ܟܣܐ ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ ܕܐܢܟܝܘܟܝܐ ܐܝܟ ܬܘܪܨܐ
                     ܚܕܬܐ</rubric>
@@ -554,8 +550,7 @@
                   <author ref="http://syriaca.org/person/423">
                     <persName xml:lang="en">Clement of Rome</persName>
                   </author>
-                  <title xml:lang="en">An extract from the book of <persName ref="http://syriaca.org/person/423">Clement of <placeName ref="http://syriaca.org/place/2360">Rome</placeName>
-                    </persName>, <foreign xml:lang="syr">ܕܩܠܡܝܣ</foreign>, called the Testament of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
+                  <title xml:lang="en">An extract from the book of <persName ref="http://syriaca.org/person/423">Clement of <placeName ref="http://syriaca.org/place/2360">Rome</placeName></persName>, <foreign xml:lang="syr">ܕܩܠܡܝܣ</foreign>, called the Testament of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܝܬܝܩܝ ܕܡܪܢ</rubric>
                   <incipit xml:lang="syr">ܩܠܡܝܣ ܕܝܢ ܐܡ̣ܪ .. ܕܒܥܠܝܬܐ ܐܠܦ ܡܪܢ ܠܬܠܡ̈ܝܕܘܗܝ ܟܠܗܘܢ ܪ̈ܐܙܐ ܩ̈ܕܝܫܐ. ܘܗܕܐ ܗܝ ܗ̇ܝ ܕܪܐܙ ܠܝ ܪܐܙ ܠܝ. ܘܒܪܘܚܐ ܘܠܘ ܒܟܬܒܐ ܐܫܠܡ ܐܢ̈ܝܢ. ܐܝܟ ܗ̇ܝ ܕܟܬܝܒܐ. ܕܐܟܬܒܝܘܗܝ ܠܢܡܘܣܝ ܒܓܘܗܘܢ .. ܐܠܦ ܐܢܘܢ ܬܘܒ ܘܕܐܝܟܢܐ ܢܪܫܡܘܢ ܥܕ̈ܬܐ. ܘܕܒܐܝܢܐ ܙܒܢܐ .. ܘܕܐܝܟܢܐ ܒܝܬ ܡܥܡܘܕܝܬܐ ܢܒܢܘܢ. ܘܕܢܩܒܥܘܢ ܡ̈ܕܒܚܐ. ܘܕܐܝܠܝܢ ܡܕܒ̈ܚܐ ܢܗܘܘܢ ܥܡ ܥܕܬܐ .. ܏ܘܫ.</incipit>
@@ -569,8 +564,7 @@
                   <author ref="http://syriaca.org/person/113">
                     <persName xml:lang="en">Jacob of Edessa</persName>
                   </author>
-                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>, contained in a letter to <persName ref="http://syriaca.org/person/1054">John the Stylite</persName>
+                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>, contained in a letter to <persName ref="http://syriaca.org/person/1054">John the Stylite</persName>
                   </title>
                   <rubric xml:lang="syr">ܩ̈ܢܘܢܐ ܥܕ̈ܬܢܝܐ ܏ܕܩܕ ܡܪܝ ܝܥܩܘܒ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ܀ ܡܟܬܒܝܢ ܠܗ ܕܝܢ ܠܘܬ ܡܪܝ ܝܘܚܢܢ ܐܣܛܘܢܪܐ ܕܒܠܝܬܐܪܒ ܩܪܝܬܐ</rubric>
                   <incipit xml:lang="syr">ܠܐܚܐ ܢܟܦܐ ܘܡܝܩܪܐ ܡܪܝ ܝܘܚܢܢ ܕܩܐܡ ܥܠ ܐܣܛܘܢܐ ܕܒܠܝܬܐܪܒ ܩܪ̣ܝܬܐ. ܝܥܩܘܒ ܡܣܟܢܐ ܒܡܪܝܐ ܠܡܚܕܐ. ܫܪܝܪܐܝܬ ܐܡ̇ܪ ܐܢܐ ܠܟ ܕܠܐ ܡܛܝܐ ܗܘܬ ܐܥܒܕ ܠܘܬܟ ܦܘܢܝ ܦܬܓܡܐ ܕܟܬܝܒܬܐ. ܗܝ ܕܡܫܕܪ ܗܘܐ ܠܗ̇ ܠܐܚܘܬܟ ܠܘܬ ܡܣܟܢܘܬܝ ܡܢ ܩܕܡ ܙܒܢܐ. ܏ܘܫ.</incipit>
@@ -580,8 +574,7 @@
                   <author ref="http://syriaca.org/person/50">
                     <persName xml:lang="en">John, bishop of Tellā</persName>
                   </author>
-                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/50">John, bishop of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                    </persName>, addressed to the priest <persName>Sergius</persName>
+                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/50">John, bishop of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName></persName>, addressed to the priest <persName>Sergius</persName>
                   </title>
                   <rubric xml:lang="syr">ܩ̈ܢܘܢܐ ܏ܕܩܕ ܡܪܝ ܝܘܚܢܢ ܐܦܝ܏ܣܩ ܕܬܠܐ. ܕܫܐܠܗ ܣܪܓܢܣ ܩܫܝܫܐ. ܡܛܠ ܣܘܥܪ̈ܢܐ ܕܒܝܬ ܩܘܕܫܐ.</rubric>
                   <incipit xml:lang="syr">ܬܠܡܝܕܐ ܏ܐܡ̇ܪ ܐܢ ܐܝܬ ܡ̈ܐܢܐ ܕܡܫܬܡܫ ܒܗܘܢ ܩܘܕܫܐ ܘܡܛܠ ܙܥܘܪܘܬܗܘܢ ܝܘܡܢ ܠܐ ܚܫܚܝܢ. ܡܢܐ ܙܕܩ ܕܢܗܘܐ ܠܗܘܿܢ ܏ܪܒܐ ܏ܐܡ̇ܪ ܐܢ ܡܛܠ ܕܢܗܘܐ ܡܐܢܐ ܪܒܐ ܐܠܨܐ. ܢܛܪ ܡܢ ܩ̈ܕܡܝܐ ܕܢܗܘܘܢ ܠܚܫܚܬ ܕܐܘܠܨܢܐ ..</incipit>
@@ -593,8 +586,7 @@
                   <author ref="http://syriaca.org/person/50">
                     <persName xml:lang="en">John of Tellā</persName>
                   </author>
-                  <title xml:lang="en">Other Canons of <persName ref="http://syriaca.org/person/50">John of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                    </persName>
+                  <title xml:lang="en">Other Canons of <persName ref="http://syriaca.org/person/50">John of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܝܠܗ ܕܩܕܝܫܐ ܝܘܚܢܢ. ܩ̈ܢܘܢܐ ܐܚܪ̈ܢܐ ܕܠܐ ܐܝܬܝܗܘܢ ܒܫ̈ܐܘܠܐ</rubric>
                   <incipit xml:lang="syr">ܠܐ ܬܐܟܠܘܢ ܥܡ ܗܪ̈ܝܛܝܩܘ܀ ܘܕܠܐ ܬܣܒܘܢ ܒܘܪܟܬܐ ܡܢܗܘܢ .. ܡܛܠ ܕܝܡܝܢܗܘܢ ܝܡܝܢܐ ܗܝ ܕܥܘܼܠܐ .. ܘܕܠܐ ܬܬܠܘܢ ܠܗܘܢ ܒܘܪܟܬܐ. ܡܛܠ ܕܟܬܝܒ ܕܥܘܿܠܐ ܡ̇ܬܒܪܟ ܘܪܓܙ ܡܪܝܐ.܀. </incipit>
@@ -630,17 +622,14 @@
                 </msItem>
                 <msItem xml:id="c66" n="86">
                   <locus from="155a" to="155"/>
-                  <title xml:lang="en">Extracts from letters of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName>
-                    </persName> and <persName>Dionysius of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName>
-                    </persName>, quoting the canons of <persName ref="http://syriaca.org/person/2498">Cyprian</persName> and the Council of <persName>Carthage</persName> regarding the baptism of those who abjured heresies</title>
+                  <title xml:lang="en">Extracts from letters of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName></persName> and <persName>Dionysius of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName></persName>, quoting the canons of <persName ref="http://syriaca.org/person/2498">Cyprian</persName> and the Council of <persName>Carthage</persName> regarding the baptism of those who abjured heresies</title>
                   <rubric xml:lang="syr">ܩ̈ܢܘܢܐ ܥ̈ܕܬܢܝܐ ܕܐܬܟܬ݂ܒܘ ܡܢ ܐܒ̈ܗܬܐ ܩ̈ܕܝܫܐ ܒܙܒܢܐ ܕܪܘܦܝܐ(sic)</rubric>
                   <msItem xml:id="d14" n="87">
                     <locus from="155"/>
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">Extracts from letters of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">Extracts from letters of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d15" n="88">
@@ -648,15 +637,13 @@
                     <author>
                       <persName xml:lang="en">Dionysius of Alexandria</persName>
                     </author>
-                    <title xml:lang="en">Extracts from letters of <persName>Dionysius of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Extracts from letters of <persName>Dionysius of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
                 <msItem xml:id="c67" n="89">
                   <locus from="155b" to="156"/>
-                  <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName>
-                    </persName>, with his replies</title>
+                  <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName></persName>, with his replies</title>
                   <rubric xml:lang="syr">ܫ̈ܘܐܠܐ ܕܐܬܩܪܒܘ. ܠܩܕܝܫܐ ܛܝܡܬܐܘܣ. ܘܐܬܦܫܩܘ ܡܢܗ</rubric>
                   <incipit xml:lang="syr">ܐܢ ܐܢܫ ܟܕ ܐܝܬܘܗܝ ܫܡܘܥܐ ܡܣܬܩܒܠ ܒܕܘܟܬܐ ܕܡܬܩܪܒ ܒܗ̇ ܩܘܪܒܢܐ. ܘܢܣܒ ܒܠܐ ܝܕܥܬܐ. ܡ̣ܢ ܘ̇ܠܐ ܕܢܗܘܐ ܡܢܗ. ܏ܛܝܡܬܐܘܣ ܕܢܥܡܕ ܘ̇ܠܐ ܡܢ ܐܠܗܐ ܓܝܪ ܐܬܩܪܝ</incipit>
                   <note>See <bibl>Beveridge, Pandectae Canonum, t. ii., p. 165</bibl>.</note>
@@ -666,8 +653,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/2546">Antioch</placeName></persName>
                   </title>
                   <msItem xml:id="d16" n="91">
                     <locus from="156a" to="157"/>
@@ -714,8 +700,7 @@
                   <author ref="http://syriaca.org/person/430">
                     <persName xml:lang="en">Cyril, of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril, of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril, of <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܝܠܘܣ</rubric>
                 </msItem>
@@ -824,8 +809,7 @@
                 <author ref="http://syriaca.org/person/113">
                   <persName xml:lang="en">Jacob of Edessa</persName>
                 </author>
-                <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>
+                <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                 </title>
                 <msItem xml:id="c80" n="115">
                   <locus from="179b" to="181"/>
@@ -878,8 +862,7 @@
                 <author ref="http://syriaca.org/person/423">
                   <persName xml:lang="en">Clement, bishop of Rome</persName>
                 </author>
-                <title xml:lang="en">The Anaphora of <persName ref="http://syriaca.org/person/423">Clement, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName>
-                  </persName>
+                <title xml:lang="en">The Anaphora of <persName ref="http://syriaca.org/person/423">Clement, bishop of <placeName ref="http://syriaca.org/place/2360">Rome</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܩܕܝܫܐ ܡܪܝ ܩܠܡܝܣ. ܐܦ܏ܝܣܩ ܕܪܘܡܝ. ܬܠܡܝܕܗ ܕܫܡܥܘܢ</rubric>
               </msItem>

--- a/data/tei/184.xml
+++ b/data/tei/184.xml
@@ -199,8 +199,7 @@
                 </msItem>
                 <msItem xml:id="c8" n="15">
                   <locus from="73b" to="90">Foll. 73b-90</locus>
-                  <title>A sedrā of <persName ref="http://syriaca.org/person/109"> Athanasius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>
+                  <title>A sedrā of <persName ref="http://syriaca.org/person/109"> Athanasius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                   </title>
                   <author ref="http://syriaca.org/person/109">
                     <persName xml:lang="en">Athanasius II. (of Balad)</persName>

--- a/data/tei/185.xml
+++ b/data/tei/185.xml
@@ -155,8 +155,7 @@
                   <locus from="68b" to="83">Foll. 68b-83</locus>
                   
                   <title>The Order of Baptism of <persName>Severus</persName>,
-                    translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul
-                      of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
+                    translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
                     </persName>.</title>
                   <rubric xml:lang="syr">
                     <sic>ܛܟܣܐ ܕܥ̇ܡܕܐ ܡܢ ܦܘܠܐ ܕܬܠܐ ܩܕܝܫܐ. ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ. ܐܝܟ ܕܢܦܝ̣ܩ ܡܢ ܝܘܢܝܐ
@@ -196,8 +195,7 @@
                 <msItem xml:id="c11" n="14">
                   <locus from="91a">Fol. 91a</locus>
                   
-                  <title>Prooemia by <persName>John the
-                    patriarch</persName>.</title>
+                  <title>Prooemia by <persName>John the patriarch</persName>.</title>
                   <rubric xml:lang="syr">ܦܪ̈ܘܡܐܝܘܢ̣ ܕܩܕܝܫܐ ܡܪܝ ܝܘܚܢܢ ܦܛܪܝܪܟܐ: ܕܡܬܐܡܪܝܢ ܩܕܡ ܟܠ ܣܕܪܐ
                     ܕܒ̈ܣܡܐ <locus from="91a" to="91"/>
                   </rubric>
@@ -205,8 +203,7 @@
                 <msItem xml:id="c12" n="15">
                   <locus from="118b">Fol. 118b</locus>
                   
-                  <title>Sedras for Lent by <persName>John the
-                    patriarch</persName>.</title>
+                  <title>Sedras for Lent by <persName>John the patriarch</persName>.</title>
                   <rubric xml:lang="syr">ܣܕܪ̈ܐ ܕܒܣ̈ܡܐ: ܕܨܘܡܐ ܩܕܝܫܐ ܕܐܪܒܥܝܢ: ܕܣܝ̣ܡ ܠܝܘܚܢܢ ܦܛܪܝܪܟܐ
                       <locus from="118b" to="118"/>
                   </rubric>

--- a/data/tei/185.xml
+++ b/data/tei/185.xml
@@ -112,8 +112,7 @@
                   <locus from="11a" to="26">Foll. 11a-26</locus>
                   
                   <title>The Anaphora of <persName>S. James</persName>, as arranged
-                    by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>.</title>
+                    by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>.</title>
                   <finalRubric xml:lang="syr">ܫܠܡ̣ܬ ܐܢܦܘܪܐ. ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܐܚܘܗܝ ܕܡܪܢ܀ ܥܡ ܩܢܘ̈ܢܘܗܝ
                     ܘܨ̈ܠܘܬܗ. ܒܬܘܪܨܐ. ܕܡܪܝܥܩܘܒ. ܐܘܪܗܝܐ. <locus from="25b" to="25"/>
                   </finalRubric>
@@ -121,8 +120,7 @@
                 <msItem xml:id="c3" n="5">
                   <locus from="26a" to="41">Foll. 26a-41</locus>
                   
-                  <title>The Anaphora of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                    </persName>.</title>
+                  <title>The Anaphora of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܐܦܝܣܩܘܦܐ ܘܪܝܫܐ ܕܐܦܝ̈ܣ܏ܩܘ ܕܐܠܟܣܢܕܪܝܐ:
                     ܕܢܦܩ̣ܬ ܚܕܬܐܝܬ <locus from="26a" to="26"/>
                   </rubric>
@@ -130,8 +128,7 @@
                 <msItem xml:id="c4" n="6" defective="true">
                   <locus from="41a" to="43">Foll. 41a-43</locus>
                   
-                  <title>The benediction of the Chalice, of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>.</title>
+                  <title>The benediction of the Chalice, of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܪܫܡ ܟܣܐ ܕܩܕܝܫܐ: ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ: ܐܝܟ ܕܢܦܝ̣ܩ
                     ܚܕܬܐܝܬ: ܡܢ ܝܘܢܝܐ ܠܣܘܪܝܝܐ <locus from="41a" to="41"/>
                   </rubric>
@@ -155,8 +152,7 @@
                   <locus from="68b" to="83">Foll. 68b-83</locus>
                   
                   <title>The Order of Baptism of <persName>Severus</persName>,
-                    translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                    </persName>.</title>
+                    translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName></persName>.</title>
                   <rubric xml:lang="syr">
                     <sic>ܛܟܣܐ ܕܥ̇ܡܕܐ ܡܢ ܦܘܠܐ ܕܬܠܐ ܩܕܝܫܐ. ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ. ܐܝܟ ܕܢܦܝ̣ܩ ܡܢ ܝܘܢܝܐ
                       ܠܣܘܪܝܝܐ ܚܕܐܬܐܝܬ</sic>

--- a/data/tei/186.xml
+++ b/data/tei/186.xml
@@ -686,8 +686,7 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName>Severus</persName>
                 </author>
-                <title>The second part of the treatise of <persName ref="http://syriaca.org/person/51">Severus</persName> against <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus of <placeName>Caesarea</placeName>
-                  </persName>
+                <title>The second part of the treatise of <persName ref="http://syriaca.org/person/51">Severus</persName> against <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus of <placeName>Caesarea</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܣܐܘܪܐ̣. ܕܠܘܩܒܠ ܓܪܡܛܝܩܘܣ ܕܬܪ̈ܬܝܢ
                   <locus from="84b"/>

--- a/data/tei/189.xml
+++ b/data/tei/189.xml
@@ -154,8 +154,7 @@
                   <persName xml:lang="en">Philoxenos of Mabbug</persName>
                 </author>
                 <title>The lesser Order of the Consecration of Water for Baptism, by
-                    <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName>, to be used in
+                    <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>, to be used in
                   cases of necessity</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܩܘܕܫ ܡ̈ܝܐ ܐܝܟ ܕܒܙܥ̈ܘܪܝܬܐ̣. ܕܩܕܝܫܐ ܦܝܠܟܣܝܢܘܣ ܐܦܝܣܩܘܦܐ
                   ܕܡܒܘܓ܆ ܥܠ ܫܒܪܐ ܕܐܠܝܨ ܕܢܡܘܬ ܘܐܬ݁ܐ ܕܢܥܡ̣ܕ: ܏ܘܫ. <locus from="25a" to="25"/>
@@ -245,8 +244,7 @@
                   <persName xml:lang="en">Severus</persName>
                 </author>
                 <title>The Order of Baptism of <persName>Severus</persName>,
-                  translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                  </persName>
+                  translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܥܡܕܐ ܕܩ̇ܕܝܫܐ ܡܪܝ ܣܐܘ݊ܝܪܐ: ܐܝܟ ܕܢܦܝܩ ܚ̣ܕܬܐܝܬ. ܡܢ ܝܘܢܝܐ
                   ܠܣܘܪܝܝܐ. ܡܢ ܩ̇ܕܝܫܐ ܡܪܝ ܦܘ݊ܠܐ ܕܬܠܠܐ <locus from="65a" to="65"/>

--- a/data/tei/189.xml
+++ b/data/tei/189.xml
@@ -221,8 +221,7 @@
                   <author ref="http://syriaca.org/person/92">
                     <persName xml:lang="en">John the Patriarch</persName>
                   </author>
-                  <title>Two Sedras by <persName>John the
-                    Patriarch</persName>
+                  <title>Two Sedras by <persName>John the Patriarch</persName>
                   </title>
                   <rubric xml:lang="syr">ܣܕܪ̈ܐ ܕܥܡ̇ܕܐ ܩ̇ܕܝܫܐ <locus from="62a" to="62"/>
                   </rubric>
@@ -246,8 +245,7 @@
                   <persName xml:lang="en">Severus</persName>
                 </author>
                 <title>The Order of Baptism of <persName>Severus</persName>,
-                  translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of
-                    <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
+                  translated from the Greek by <persName ref="http://syriaca.org/person/82">Paul of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܥܡܕܐ ܕܩ̇ܕܝܫܐ ܡܪܝ ܣܐܘ݊ܝܪܐ: ܐܝܟ ܕܢܦܝܩ ܚ̣ܕܬܐܝܬ. ܡܢ ܝܘܢܝܐ

--- a/data/tei/191.xml
+++ b/data/tei/191.xml
@@ -270,8 +270,7 @@
                   <msItem xml:id="d2" n="24">
                     <locus from="140b" to="143">Foll. 140b-143</locus>
                     
-                    <title>Canticles on the Apostasy of <persName ref="http://syriaca.org/person/2008">Simon
-                        Peter</persName>
+                    <title>Canticles on the Apostasy of <persName ref="http://syriaca.org/person/2008">Simon Peter</persName>
                     </title>
                     <rubric xml:lang="syr">ܣܘ̈ܓܝܬܐ ܕܥܠ ܟܦܘܪܝܗ ܕܫܡܥܘܢ <locus from="140b" to="140"/>
                     </rubric>
@@ -279,8 +278,7 @@
                   <msItem xml:id="d3" n="25">
                     <locus from="143b" to="147">Foll. 143b-147</locus>
                     
-                    <title>Canticles on <persName>Judas the
-                      traitor</persName>
+                    <title>Canticles on <persName>Judas the traitor</persName>
                     </title>
                     <rubric xml:lang="syr">ܣܘ̈ܓܝܬܐ ܕܥܠ ܝܗܘܕܐ ܡܫ̣ܠܡܢܐ <locus from="143b" to="143"/>
                     </rubric>

--- a/data/tei/193.xml
+++ b/data/tei/193.xml
@@ -168,8 +168,7 @@
                 </msItem>
                 <msItem xml:id="c5" n="13">
                   <locus from="8b"/>
-                  <title xml:lang="en">The Nativity of <persName>S. John
-                                            the Baptist</persName>
+                  <title xml:lang="en">The Nativity of <persName>S. John the Baptist</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܥܠ ܡܘܠܕܗ ܕܝܘܚܢܢ</rubric>
                   <msItem xml:id="d7" n="14">
@@ -284,8 +283,7 @@
                 </msItem>
                 <msItem xml:id="c12" n="34">
                   <locus from="40a"/>
-                  <title xml:lang="en">The Decollation of <persName>S. John
-                                            the Baptist</persName>
+                  <title xml:lang="en">The Decollation of <persName>S. John the Baptist</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܦܣ̣ܩ ܪܝܫܗ ܕܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
                   <msItem xml:id="d21" n="35">
@@ -388,8 +386,7 @@
                 </msItem>
                 <msItem xml:id="c19" n="54">
                   <locus from="79b" to="88b"/>
-                  <title xml:lang="en">The Commemoration of <persName>the forty
-                                        Martyrs</persName>
+                  <title xml:lang="en">The Commemoration of <persName>the forty Martyrs</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܐܪ̈ܒܥܝܢ ܣܗ̈ܕܐ ܩ̈ܕܝܫܐ</rubric>
                 </msItem>
@@ -624,8 +621,7 @@
                 </msItem>
                 <msItem xml:id="c28" n="97">
                   <locus from="153a"/>
-                  <title xml:lang="en">Of <persName>S. John the
-                                                Evangelist</persName>
+                  <title xml:lang="en">Of <persName>S. John the Evangelist</persName>
                     </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܝܘܚܢܢ ܐܘܢܓܠܝܣܛܐ</rubric>
                 </msItem>
@@ -675,8 +671,7 @@
                 </msItem>
                 <msItem xml:id="c35" n="105">
                   <locus from="160b"/>
-                  <title xml:lang="en">Of the <persName>Maccabees
-                                                (<persName>Shamūnī</persName> and her sons)</persName>
+                  <title xml:lang="en">Of the <persName>Maccabees (<persName>Shamūnī</persName> and her sons)</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܫܡܘܢܝ ܘܒܢ̈ܝܗ</rubric>
                 </msItem>
@@ -689,8 +684,7 @@
                 </msItem>
                 <msItem xml:id="c37" n="107">
                   <locus from="162b"/>
-                  <title xml:lang="en">Of <persName>Simeon
-                                                Stylites</persName>
+                  <title xml:lang="en">Of <persName>Simeon Stylites</persName>
                     </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܡܪܝ ܫܡܥܘܢ ܕܐܣܛܘܢܗ</rubric>
                 </msItem>
@@ -717,8 +711,7 @@
                 </msItem>
                 <msItem xml:id="c41" n="111">
                   <locus from="167b"/>
-                  <title xml:lang="en">Of <persName>Mary
-                                                Magdalene</persName>
+                  <title xml:lang="en">Of <persName>Mary Magdalene</persName>
                     </title>
                   <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܡܪܝܡ ܡܓܕܠܝܬܐ</rubric>
                 </msItem>
@@ -731,8 +724,7 @@
                 </msItem>
                 <msItem xml:id="c43" n="113">
                   <locus from="169a"/>
-                  <title xml:lang="en">Of <persName>Elias the
-                                                Prophet</persName>
+                  <title xml:lang="en">Of <persName>Elias the Prophet</persName>
                     </title>
                   <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܡܪܝ ܐܠܝܐ ܢܒܝܐ</rubric>
                 </msItem>
@@ -751,8 +743,7 @@
                 </msItem>
                 <msItem xml:id="c46" n="116">
                   <locus from="172a"/>
-                  <title xml:lang="en">The Consecration of <persName>a
-                                            Bishop</persName>
+                  <title xml:lang="en">The Consecration of <persName>a Bishop</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܩܘܒܠ ܐܦܝ̈ܣܩܘܦܐ</rubric>
                 </msItem>
@@ -770,15 +761,13 @@
                 </msItem>
                 <msItem xml:id="c49" n="119">
                   <locus from="174b"/>
-                  <title xml:lang="en">The Commemoration of <persName>the
-                                            Dead</persName>
+                  <title xml:lang="en">The Commemoration of <persName>the Dead</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܥܢܝ̈ܕܐ ܓܘܢܐܝܬ</rubric>
                 </msItem>
                 <msItem xml:id="c50" n="120">
                   <locus from="176a"/>
-                  <title xml:lang="en">The Commemoration of <persName>all
-                                            Martyrs</persName>
+                  <title xml:lang="en">The Commemoration of <persName>all Martyrs</persName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܣܗ̈ܕܐ ܓܘܢܐܝܬ</rubric>
                 </msItem>

--- a/data/tei/194.xml
+++ b/data/tei/194.xml
@@ -288,8 +288,7 @@
               </msItem>
               <msItem xml:id="b33" n="34">
                 <locus from="130a"/>
-                <title xml:lang="en">The Dedication of the <placeName>church of Golgotha and of the
-                    Resurrection</placeName>, 13th of Ilūl</title>
+                <title xml:lang="en">The Dedication of the <placeName>church of Golgotha and of the Resurrection</placeName>, 13th of Ilūl</title>
                 <rubric xml:lang="syr">ܥܠ ܚܘܕܬܐ ܕܥܕܬܐ ܩܕܝܫܬܐ ܗ̇ܝ ܕܓܓܘܠܬܐ ܘܕܩܝܡܬܐ</rubric>
               </msItem>
               <msItem xml:id="b34" n="35">

--- a/data/tei/194.xml
+++ b/data/tei/194.xml
@@ -149,8 +149,7 @@
               <msItem xml:id="b7" n="8">
                 <locus from="37a"/>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, 8th of
+                  <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, 8th of
                   Shebat</title>
               </msItem>
               <msItem xml:id="b8" n="9">
@@ -253,8 +252,7 @@
               <msItem xml:id="b26" n="27">
                 <locus from="102a"/>
                 <title xml:lang="en">
-                  <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>, 7th of Ab</title>
+                  <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>, 7th of Ab</title>
               </msItem>
               <msItem xml:id="b27" n="28">
                 <locus from="105b"/>

--- a/data/tei/194.xml
+++ b/data/tei/194.xml
@@ -182,14 +182,12 @@
               </msItem>
               <msItem xml:id="b13" n="14">
                 <locus from="58a"/>
-                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>, 15th of Iyār</title>
+                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>, 15th of Iyār</title>
               </msItem>
               <msItem xml:id="b14" n="15">
                 <locus from="61a"/>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/1585">S. Andrew the Apostle </persName> and <persName>Andrew the
-                    martyr</persName>, 16th of Iyār</title>
+                  <persName ref="http://syriaca.org/person/1585">S. Andrew the Apostle </persName> and <persName>Andrew the martyr</persName>, 16th of Iyār</title>
               </msItem>
               <msItem xml:id="b15" n="16">
                 <locus from="66a"/>
@@ -244,8 +242,7 @@
               <msItem xml:id="b24" n="25">
                 <locus from="95a"/>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/744">Simeon
-                    Stylites</persName>, 27th of Tāmūz</title>
+                  <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName>, 27th of Tāmūz</title>
                 <rubric xml:lang="syr">ܫܡܥܘܢ ܕܐܣܛܘܢܐ</rubric>
               </msItem>
               <msItem xml:id="b25" n="26">
@@ -261,8 +258,7 @@
               </msItem>
               <msItem xml:id="b27" n="28">
                 <locus from="105b"/>
-                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>, full-moon of Ab</title>
+                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>, full-moon of Ab</title>
                 <rubric xml:lang="syr">ܕܥܐܕܐ ܗ̇ܘ ܕܗ̇ܘܐ ܒܟܣܐܐ ܒܐܒ</rubric>
               </msItem>
               <msItem xml:id="b28" n="29">
@@ -300,8 +296,7 @@
               </msItem>
               <msItem xml:id="b34" n="35">
                 <locus from="133b"/>
-                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>, 18th of Ilūl</title>
+                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>, 18th of Ilūl</title>
               </msItem>
               <msItem xml:id="b35" n="36">
                 <locus from="136b"/>

--- a/data/tei/195.xml
+++ b/data/tei/195.xml
@@ -146,8 +146,7 @@
               <msItem xml:id="b5" n="7">
                 <locus from="19a" to="25a">Foll. 19a-25a</locus>
                 
-                <title>[Canon on] <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName>
+                <title>[Canon on] <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                 </title>
               </msItem>
               <msItem xml:id="b6" n="8">
@@ -357,8 +356,7 @@
               <msItem xml:id="b39" n="41">
                 <locus from="168a" to="172a">Foll. 168a-172a</locus>
                 
-                <title>[Canon on] <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName>; 27th of the second Kānūn</title>
+                <title>[Canon on] <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>; 27th of the second Kānūn</title>
               </msItem>
               <msItem xml:id="b40" n="42">
                 <locus from="172a" to="179b">Foll. 172a-179b</locus>

--- a/data/tei/195.xml
+++ b/data/tei/195.xml
@@ -313,8 +313,7 @@
               <msItem xml:id="b32" n="34">
                 <locus from="136b" to="140b">Foll. 136b-140b</locus>
                 
-                <title>[Canon on] The Dedication of the <placeName>church of
-                    Golgotha and of the Resurrection</placeName>
+                <title>[Canon on] The Dedication of the <placeName>church of Golgotha and of the Resurrection</placeName>
                 </title>
               </msItem>
               <msItem xml:id="b33" n="35">

--- a/data/tei/195.xml
+++ b/data/tei/195.xml
@@ -158,8 +158,7 @@
               <msItem xml:id="b7" n="9">
                 <locus from="29a" to="33a">Foll. 29a-33a</locus>
                 
-                <title>[Canon on] <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title>[Canon on] <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
               </msItem>
               <msItem xml:id="b8" n="10">
@@ -278,8 +277,7 @@
               <msItem xml:id="b26" n="28">
                 <locus from="112b" to="116b">Foll. 112b-116b</locus>
                 
-                <title>[Canon on] <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>
+                <title>[Canon on] <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                 </title>
               </msItem>
               <msItem xml:id="b27" n="29">
@@ -447,8 +445,7 @@
               <msItem xml:id="b53" n="55">
                 <locus from="219a" to="222b">Foll. 219a-222b</locus>
                 
-                <title>[Canon on] <persName>Lucian of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title>[Canon on] <persName>Lucian of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܩܢܘܢܐ ܕܥܠ ܠܘܩܝܐܢܘܣ ܥܢܘܝܐ ܘܣܗܕܐ ܗ̇ܘ ܕܦܫ̇ܩ ܐܘܟܝܬ ܬܪܨ ܠܟ̈ܬܒܐ
                   ܩܕܝ̈ܫܐ ܘܐܫܠܡ ܠܐ̣ܚ̈ܐ ܟܪ̈ܣܛܝܢܐ ܘܡܬܥܗܕ ܠܗ ܩܕܝܫܐ ܣܐܘܝܪܘܣ ܒܡܐܡܪܐ ܗ̇ܘ ܩܕܡܝܐ ܕܢܘܗܪ̈ܐ.

--- a/data/tei/203.xml
+++ b/data/tei/203.xml
@@ -242,8 +242,7 @@
               <msItem xml:id="b15" n="16" defective="true">
                 <locus from="68a" to="71">Foll. 68a-71</locus>
                 
-                <title>The Commemoration of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title>The Commemoration of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܡܕܪ̈ܫܐ ܕܥܠ ܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ <locus from="68a" to="68"/>
                 </rubric>

--- a/data/tei/205.xml
+++ b/data/tei/205.xml
@@ -199,8 +199,7 @@
               </msItem>
               <msItem xml:id="b9" n="14">
                 <locus from="57b"/>
-                <title xml:lang="en">The Commemoration of <persName>S. Simeon the
-                    Aged</persName>
+                <title xml:lang="en">The Commemoration of <persName>S. Simeon the Aged</persName>
                 </title>
               </msItem>
               <msItem xml:id="b10" n="15">

--- a/data/tei/208.xml
+++ b/data/tei/208.xml
@@ -395,8 +395,7 @@
                     <persName xml:lang="en">John bar Aphtūnāyā</persName>
                   </author>
                   <title xml:lang="en">
-                    <persName>Zechariah the
-                                            prophet</persName>
+                    <persName>Zechariah the prophet</persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c32" n="50">
@@ -681,8 +680,7 @@
               </msItem>
               <msItem xml:id="b24" n="98">
                 <locus from="93b"/>
-                <title xml:lang="en">Of <persName>a woman who forsook the Arian heresy
-                                    and became a nun</persName>
+                <title xml:lang="en">Of <persName>a woman who forsook the Arian heresy and became a nun</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܐܢܬܬܐ ܕܡܢ ܗܪ̈ܣܝܣ ܕܒܝܬ ܐܪܝܘܣ ܦ̣ܢܬ ܘܗܘ̣ܬ ܕܝܪܝܬܐ</rubric>
               </msItem>

--- a/data/tei/208.xml
+++ b/data/tei/208.xml
@@ -184,8 +184,7 @@
                 </msItem>
                 <msItem xml:id="c7" n="16">
                   <locus from="25b"/>
-                  <title xml:lang="en">On <persName>the Wife of <persName>Pilate</persName>
-                    </persName>
+                  <title xml:lang="en">On <persName>the Wife of <persName>Pilate</persName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c8" n="17">
@@ -279,8 +278,7 @@
                 <msItem xml:id="c18" n="34">
                   <locus from="48b"/>
                   <title xml:lang="en">
-                    <persName>Peter of <placeName>Alexandria</placeName>
-                    </persName>
+                    <persName>Peter of <placeName>Alexandria</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c19" n="35">
@@ -333,15 +331,13 @@
                     <persName xml:lang="en">John bar Aphtūnāyā</persName>
                   </author>
                   <title xml:lang="en">
-                    <persName>Severus of <placeName>Antioch</placeName>
-                    </persName>
+                    <persName>Severus of <placeName>Antioch</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c27" n="43">
                   <locus from="53b"/>
                   <title xml:lang="en">
-                    <persName>Peter of <placeName>Antioch</placeName>
-                    </persName>
+                    <persName>Peter of <placeName>Antioch</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c28" n="44">
@@ -487,8 +483,7 @@
                 </msItem>
                 <msItem xml:id="c43" n="63">
                   <locus from="63a"/>
-                  <title xml:lang="en">The <persName>Maccabees, the sons of <persName>Shamūnī</persName>
-                    </persName>
+                  <title xml:lang="en">The <persName>Maccabees, the sons of <persName>Shamūnī</persName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c44" n="64">

--- a/data/tei/209.xml
+++ b/data/tei/209.xml
@@ -135,8 +135,7 @@
                 </msItem>
                 <msItem xml:id="c2" n="4">
                   <locus from="2b"/>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                                     </title>
                   <rubric xml:lang="syr">
                     <locus from="2b"/>ܕܥܠ ܙܟܪܝܐ ܟܕ
@@ -178,8 +177,7 @@
                     <persName xml:lang="en">Gregory
                                         Thaumaturgus</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="10b"/>ܬܘܪܓܡܐ ܕܩܕܝܫܐ
@@ -214,8 +212,7 @@
                     <persName xml:lang="en">Gregory
                                         Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/511">Gregory
-                                            Nazianzen</persName>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                   </title>
                   <note>See <bibl>Opera, ed. Par. 1778, t. i., p.
                                         663</bibl>
@@ -227,8 +224,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                   </title>
                   <note>See <bibl>Opera, t. vi., p. 459</bibl>
                   </note>
@@ -239,8 +235,7 @@
                     <persName xml:lang="en">Jacob of
                                         Batnae</persName>
                   </author>
-                  <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of
-                                            Batnae</persName>
+                  <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                   </title>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 304, no.
                                         8</bibl>, and <bibl>Zingerle, Sechs Homilien des heiligen
@@ -250,8 +245,7 @@
               </msItem>
               <msItem xml:id="b4" n="15">
                 <locus from="42b"/>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/624">the blessed
-                  Virgin</persName>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/624">the blessed Virgin</persName>
                 </title>
                 <rubric xml:lang="syr">
                   <locus from="42b"/>ܛܟܣܐ ܕܕܘܟܪܢܐ ܕܝܠ̣ܕܬ
@@ -266,8 +260,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                   </title>
                   <incipit xml:lang="syr">
                     <locus from="49a"/>ܠܥܐܕܐ ܚܕܘܬܢܝܐ
@@ -285,8 +278,7 @@
                     <persName xml:lang="en">Severus of
                                         Antioch</persName>
                   </author>
-                  <title xml:lang="en">Eighth homily of <persName ref="http://syriaca.org/person/51">Severus
-                                            of Antioch</persName>
+                  <title xml:lang="en">Eighth homily of <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="54b"/>ܬܘܪܓܡܐ ܕܬܡܢܝܐ
@@ -318,8 +310,7 @@
                     <persName xml:lang="en">Gregory
                                         Thaumaturgus</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName> generally ascribed to
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> generally ascribed to
                     <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܥܡ̇ܕܗ ܕܡܪܢ ܕܒܝܘܪܕܢܢ ܢܗܪܐ </rubric>
@@ -344,8 +335,7 @@
                     <persName xml:lang="en">Jacob of
                                         Batnae</persName>
                   </author>
-                  <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of
-                                            Batnae</persName>
+                  <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                   </title>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 304, no.
                                         9</bibl>, and <bibl>Zingerle, Sechs Homilien, p.
@@ -355,8 +345,7 @@
               </msItem>
               <msItem xml:id="b7" n="25">
                 <locus from="77a"/>
-                <title xml:lang="en">The Commemoration of S. <persName ref="http://syriaca.org/person/1808">John
-                                        the Baptist</persName>
+                <title xml:lang="en">The Commemoration of S. <persName ref="http://syriaca.org/person/1808">John the Baptist</persName>
                 </title>
                 <msItem xml:id="c18" n="26">
                   <locus from="78b"/>
@@ -366,8 +355,7 @@
               </msItem>
               <msItem xml:id="b8" n="27">
                 <locus from="79a"/>
-                <title xml:lang="en">The Nativity of S. <persName ref="http://syriaca.org/person/1808">John the
-                                        Baptist</persName>
+                <title xml:lang="en">The Nativity of S. <persName ref="http://syriaca.org/person/1808">John the Baptist</persName>
                 </title>
                 <msItem xml:id="c19" n="28">
                   <locus from="80a"/>
@@ -389,8 +377,7 @@
                                     ܠܗܝܟܠܐ </rubric>
                 <msItem xml:id="c20" n="31">
                   <locus from="85a"/>
-                  <title xml:lang="en">on S. <persName>Simeon the
-                                            Aged</persName>
+                  <title xml:lang="en">on S. <persName>Simeon the Aged</persName>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="85a"/>ܡ̈ܕܪܫܐ</rubric>
@@ -452,8 +439,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName> on Lent</title>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on Lent</title>
                   <incipit xml:lang="syr">ܙܒܢܐ ܗܘ ܕܚܘܣܝܐ ܙܒܢܐ ܗܢܐ. ܘܬܪܥܐ ܕܡ̇ܩܒܠ
                                         ܠܬܝ̈ܒܐ. ܘܦ̇ܬܚ ܓܙܐ ܩܕܡ ܣܢܝ̈ܩܐ<locus from="120a"/>
                   </incipit>
@@ -464,8 +450,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Second homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName> on the Contest of our Lord with
+                  <title xml:lang="en">Second homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the Contest of our Lord with
                     <persName ref="http://syriaca.org/person/3651">Satan</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܬܪܝܢܐ. ܕܥܠ ܬܟܬܘܫܗ ܕܡܪܢ ܥܡ
@@ -489,8 +474,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName> on the Ten Virgins</title>
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the Ten Virgins</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܣܪ̈ ܒ̈ܬܘܠܢ</rubric>
                   <note>See <bibl>Opera, t. viii., p. 666</bibl>
                   </note>
@@ -501,8 +485,7 @@
                     <persName xml:lang="en">John
                                         Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                            Chrysostom</persName> on the Paralytic and on
+                  <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the Paralytic and on
                                         Envy</title>
                   <rubric xml:lang="syr">
                     <locus from="137b"/>ܡܐܡܪܐ ܕܥܠ ܗ̇ܘ
@@ -517,8 +500,7 @@
                   <persName xml:lang="en">Gregory
                                     Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/511">Gregory
-                                        Nazianzen</persName> on the Epiphany</title>
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> on the Epiphany</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܢܘܗ̇ܪ̈ܐ ܐܘܟܝܬ ܒܝܬ ܕܢܚܐ. ܕܦ̣ܫ ܡܢ
                                     ܕܘܟܬܗ</rubric>
                 <note>See <bibl>Opera, t. i., p. 677</bibl>
@@ -529,8 +511,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/573">John
-                                        Chrysostom</persName> on the Decollation of S.
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the Decollation of S.
                   <persName ref="http://syriaca.org/person/1808">John the Baptist</persName>
                                 </title>
                 <rubric xml:lang="syr">
@@ -545,8 +526,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Festal sermons of <persName ref="http://syriaca.org/person/42">Jacob of
-                                        Batnae</persName>
+                <title xml:lang="en">Festal sermons of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                 <rubric xml:lang="syr">ܡ̈ܐܡܪܐ ܡ̈ܥܕܥܕܢܐ. ܕܩܕܝܫܐ ܘܠܒܝ̣ܫ ܠܐܠܗܐ ܡܪܝ
                                     ܝܥܩܘܒ ܡܠܦܢܐ. ܐܦܝܣܩܘܦܐ ܕܒܛܢܢ ܕܣܪܘܓ.</rubric>
@@ -620,8 +600,7 @@
                     <persName xml:lang="en">Jacob of
                                         Batnae</persName>
                   </author>
-                  <title xml:lang="en">On S. <persName ref="http://syriaca.org/person/1808">John the
-                                            Baptist</persName>
+                  <title xml:lang="en">On S. <persName ref="http://syriaca.org/person/1808">John the Baptist</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܩܘܠܣܗ ܕܝܘܚܢܢ ܡܥܡܕܢܐ <locus from="203a"/>
                   </rubric>

--- a/data/tei/21.xml
+++ b/data/tei/21.xml
@@ -212,8 +212,7 @@ to the metre in which they are composed.</note>
                   <msItem xml:id="d4" n="15">
                     <locus from="16a"/>
                     <title xml:lang="en">
-                      <persName>Diodorus (of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>)</persName>, <persName ref="http://syriaca.org/person/780">Theodore (of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName>)</persName>, <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName ref="http://syriaca.org/person/2299">Leo (the first, bishop of
-                      <placeName ref="http://syriaca.org/place/641">Rome</placeName>)</persName>, <persName ref="http://syriaca.org/person/616">Marcion</persName>, <persName ref="http://syriaca.org/person/482">Eutyches</persName>, <persName ref="http://syriaca.org/person/579">Julian (of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>)</persName>, <persName>Narses</persName>, and <persName ref="http://syriaca.org/person/370">Bar-saumā</persName>, are
+                      <persName>Diodorus (of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>)</persName>, <persName ref="http://syriaca.org/person/780">Theodore (of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName>)</persName>, <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName ref="http://syriaca.org/person/2299">Leo (the first, bishop of <placeName ref="http://syriaca.org/place/641">Rome</placeName>)</persName>, <persName ref="http://syriaca.org/person/616">Marcion</persName>, <persName ref="http://syriaca.org/person/482">Eutyches</persName>, <persName ref="http://syriaca.org/person/579">Julian (of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>)</persName>, <persName>Narses</persName>, and <persName ref="http://syriaca.org/person/370">Bar-saumā</persName>, are
                       cursed as <foreign xml:lang="syr">ܟ̈ܠܒܐ ܦܩܪ̈ܐ</foreign>
                     </title>
                     <rubric xml:lang="syr">ܟ̈ܠܒܐ ܦܩܪ̈ܐ</rubric>
@@ -297,8 +296,7 @@ to the metre in which they are composed.</note>
               </msItem>
               <msItem xml:id="b6" n="30">
                 <locus from="56a"/>
-                <title xml:lang="en">Order of the Nativity of <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>
+                <title xml:lang="en">Order of the Nativity of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܡ̇ܘܠܕܗ ܕܝܘܚܢܢ ܡ̇ܥܡܕܢܐ</rubric>
                 <msItem xml:id="c19" n="31">
@@ -472,8 +470,7 @@ to the metre in which they are composed.</note>
               </msItem>
               <msItem xml:id="b12" n="64">
                 <locus from="162a"/>
-                <title xml:lang="en">Order of the Decollation of <persName ref="http://syriaca.org/person/1808">S. John the
-                           Baptist</persName>
+                <title xml:lang="en">Order of the Decollation of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܥܠ ܦܣ̣ܳܩ ܪܝܫܗ ܕܝܘܚܢܢ ܡ̇ܥܡܕܢܐ</rubric>
                 <msItem xml:id="c40" n="65">
@@ -494,8 +491,7 @@ to the metre in which they are composed.</note>
               </msItem>
               <msItem xml:id="b13" n="68">
                 <locus from="173a"/>
-                <title xml:lang="en">Order of <persName>S. Stephen the first deacon
-                              and martyr</persName>
+                <title xml:lang="en">Order of <persName>S. Stephen the first deacon and martyr</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܥܠ ܐܣܛܦܢܘܣ ܪܝܫܐ ܕܡܫ̈ܡܫܢܐ ܘܩܕܡܝܐ ܕܣܗ̈ܕܐ</rubric>
                 <msItem xml:id="c43" n="69">

--- a/data/tei/21.xml
+++ b/data/tei/21.xml
@@ -137,8 +137,7 @@ to the metre in which they are composed.</note>
                 <title xml:lang="en">Part 1</title>
                 <msItem xml:id="c1" n="3">
                   <locus from="1b"/>
-                  <title xml:lang="en">Order of canons for the Dedication of <placeName>the
-                              Church</placeName>
+                  <title xml:lang="en">Order of canons for the Dedication of <placeName>the Church</placeName>
                   </title>
                   <rubric xml:lang="syr">ܛܟܣܐ ܕܩܢܘ̈ܢܐ ܕܚܘܕܬ ܥܕܬܐ. ܕܠܐ ܐܬܟ̣ܬܒ ܒܕܘܟܬܗ</rubric>
                   <note>Not written in its proper place.</note>

--- a/data/tei/210.xml
+++ b/data/tei/210.xml
@@ -205,8 +205,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                      </persName>
+                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -276,8 +275,7 @@
                     <author ref="http://syriaca.org/person/2796">
                       <persName xml:lang="en">Antipater of Bostra</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2796">Antipater of <persName>Bostra</persName>
-                      </persName>
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2796">Antipater of <persName>Bostra</persName></persName>
                     </title>
                     <rubric xml:lang="syr">ܕ܏ܩܕ ܐܢܛܝܦܐܛܪܘܣ ܐܦܝܣܩܘܦܐ ܕܒܘܣܛܪܐ: ܡܐܡܪܐ ܕܥܠ ܕܢܚܗ ܕܦܪܘܩܢ ܡܫܝܚܐ</rubric>
                     <incipit xml:lang="syr">ܡܐ ܫܒܝܚ ܚܓܐ: ܘܬܕܡܘܪܬܗ ܕܥܐܕܐ̣̇ ܛܒ ܪܒܐ. ܕܐܟ̈ܣܢܝܬܐ ܐܡ̇ܪ ܠܟܘܢ̣̇ ܣܠܩܬ
@@ -288,8 +286,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                      </persName>
+                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -337,8 +334,7 @@
                     <author ref="http://syriaca.org/person/2786">
                       <persName xml:lang="en">Atticus of Constantinople</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName>Atticus of <placeName>Constantinople</placeName>
-                      </persName>
+                    <title xml:lang="en">Homily of <persName>Atticus of <placeName>Constantinople</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܐܛܝܩܘܣ ܐܦܝܣܩܘܦܐ ܕܩܘܣܛܢܛܝܢܘܣ ܕܥܠ ܩܕܝܫܬܐ ܝܠܕܬ ܐܠܗܐ</rubric>
                     <incipit xml:lang="syr">ܟܠܗܘܢ ܡ̇ܢ ܗܟܝܠ ܚ̈ܓܐ ܕܣܗ̈ܕܐ ܒܢܨܝܚܘܬܐ
@@ -433,8 +429,7 @@
                     </author>
                     <title xml:lang="en">Part of a homily of
                       <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on
-                                                <persName>Lazarus of <placeName>Bethany</placeName>
-                      </persName>, being hom.
+                                                <persName>Lazarus of <placeName>Bethany</placeName></persName>, being hom.
                                             lxii. in <ref>Evang. Joannis.</ref>
                     </title>
                     <note>See <bibl>Opera, t. viii., p. 426, from the words <foreign xml:lang="grc">μέσον ἐποίησεν ἀναγκαίως τὸν λόγον, καὶ διὰ τῶν ἑξῆς δὲ ταῦτα ἅπερ εἶπον ᾐνίξατο</foreign>
@@ -463,8 +458,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Festal Sermons of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title xml:lang="en">Festal Sermons of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                   </title>
                   <msItem xml:id="d36" n="50" defective="true">
                     <locus from="133a"/>
@@ -542,8 +536,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">On <persName>Lazarus of <placeName>Bethany</placeName>
-                      </persName>
+                    <title xml:lang="en">On <persName>Lazarus of <placeName>Bethany</placeName></persName>
                     </title>
                     <note>See <bibl>Assem., p. 322, no. 134</bibl>.</note>
                   </msItem>
@@ -620,8 +613,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                      </persName>
+                    <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d52" n="70">
@@ -634,8 +626,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName> on Pentecost</title>
+                  <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on Pentecost</title>
                   <note>See <bibl>Assem., Bibl. Or., t. i., p. 328, no. 184</bibl>.</note>
                 </msItem>
                 <msItem xml:id="c17" n="72">
@@ -643,8 +634,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName> on <persName>all Martyrs</persName>
+                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on <persName>all Martyrs</persName>
                   </title>
                   <incipit xml:lang="syr">ܣ̈ܗܕܐ ܩ̈ܛܝܠܐ ܥܒ̣ܕܘ ܡܫܬܘܬܐ ܪܒܬܐ ܕܕܡܐ̣. ܘܬܒܥܘܢܝ ܐ̇ܡܪ ܢܨ̈ܚܢܝܗܘܢ ܒܟ̈ܠܝܠܝܗܘܢ</incipit>
                 </msItem>
@@ -667,8 +657,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName> on <persName>the Dead</persName>
+                  <title xml:lang="en">Fragment of a discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on <persName>the Dead</persName>
                   </title>
                   <note>See <bibl>Add. 17,190, fol. 118 a</bibl>.</note>
                 </msItem>

--- a/data/tei/210.xml
+++ b/data/tei/210.xml
@@ -387,8 +387,7 @@
                       <persName xml:lang="en">John Chrysostom</persName>
                     </author>
                     <title xml:lang="en">Fragment of the xxvth homily of
-                      <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref>the Gospel
-                                            of S. Matthew</ref>
+                      <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref>the Gospel of S. Matthew</ref>
                     </title>
                     <note>See <bibl>Opera, t. vii., p. 354, from the words <foreign xml:lang="grc">καὶ ὅσα ἂν πάθη, οὐδὲν ἡγήσεται ἀνάξιον πεπονθέναι</foreign>
                       </bibl>.</note>

--- a/data/tei/210.xml
+++ b/data/tei/210.xml
@@ -171,8 +171,7 @@
                     <author ref="http://syriaca.org/person/511">
                       <persName xml:lang="en">Gregory Nazianzen</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/511">Gregory
-                                                Nazianzen</persName>
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                     </title>
                     <note>See <bibl>Opera, t. i., p. 663</bibl>.</note>
                   </msItem>
@@ -185,8 +184,7 @@
                     <author ref="http://syriaca.org/person/573">
                       <persName xml:lang="en">John hrysostom</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                                Chrysostom</persName>
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                     </title>
                     <note>See <bibl>Opera, t. vi., p. 459</bibl>.</note>
                   </msItem>
@@ -207,8 +205,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob
-                                                of <placeName>Batnae</placeName>
+                    <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
                       </persName>
                     </title>
                   </msItem>
@@ -307,8 +304,7 @@
                       <persName xml:lang="en">John
                                             Chrysostom</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                      Chrysostom</persName> on the decollation of <persName>S. John the Baptist</persName>
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the decollation of <persName>S. John the Baptist</persName>
                     </title>
                     <note>See <bibl>Opera, t. viii., p. 986—8</bibl>, and <bibl>Add. 14,515, fol. 150 b</bibl>.</note>
                   </msItem>
@@ -406,8 +402,7 @@
                     <author ref="http://syriaca.org/person/573">
                       <persName xml:lang="en">John Chrysostom</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                                Chrysostom</persName> on <persName>the Paralytic</persName> and on Envy, or hom. xxxvii. in <ref>Evang. Joannis</ref>
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <persName>the Paralytic</persName> and on Envy, or hom. xxxvii. in <ref>Evang. Joannis</ref>
                     </title>
                     <note>See <bibl>Opera, t. viii., p. 243</bibl>.</note>
                   </msItem>
@@ -416,8 +411,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus</persName>
                     </author>
-                    <title xml:lang="en">Thirty-third homily of <persName>Severus</persName>, on <persName>the man who was
-                                            blind from his birth</persName>
+                    <title xml:lang="en">Thirty-third homily of <persName>Severus</persName>, on <persName>the man who was blind from his birth</persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d32" n="45">
@@ -427,8 +421,7 @@
                                             Chrysostom</persName>
                     </author>
                     <title xml:lang="en">Portions of the homily of
-                      <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <persName>the
-                                            Canaanite woman</persName>, <ref>S. Matth. ch. xv. 21—28</ref>
+                      <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <persName>the Canaanite woman</persName>, <ref>S. Matth. ch. xv. 21—28</ref>
                     </title>
                     <note>See <bibl>Opera, t. iii., p. 516</bibl>.</note>
                   </msItem>
@@ -599,8 +592,7 @@
                       <persName xml:lang="en">John
                                             Chrysostom</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                                Chrysostom</persName> for Monday in Passion
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> for Monday in Passion
                                             week</title>
                     <rubric xml:lang="syr">
                       <locus from="189a"/>ܡܐܡܪܐ ܕܩܕܝܫܐ ܐܝܘܐܢܝܣ ܕܥܠ ܬܪܝܢ ܒܫܒܐ. ܕܫܒܬܐ ܕܚܫܐ ܘܡܛܠ ܘܥܕܗ ܕܠܡܐܢܐ. ܐܡܪܗ ܕܝܢ ܒܥܕܬܐ ܕܐܣܝܐ ܟܕ ܗ̣ܘ ܒܐܟܣܘܪܝܐ</rubric>
@@ -612,8 +604,7 @@
                       <persName xml:lang="en">John
                                             Chrysostom</persName>
                     </author>
-                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John
-                                                Chrysostom</persName> on <ref>S.
+                    <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref>S.
                                                 Matthew, ch. xxi.-33—44</ref>, being
                                             hom. lxviii. in <ref>Evang. Matth</ref>
                     </title>

--- a/data/tei/211.xml
+++ b/data/tei/211.xml
@@ -467,16 +467,14 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Prayers of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">Prayers of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName>
                   </title>
                   <msItem xml:id="d27" n="67">
                     <locus from="74b"/>
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܥܠ ܟܪܝܗܐ ܕܐܠܝܨ ܘܒ̇ܥܐ ܫܪܝܐ ܡܢ ܚ̈ܝܐ ܗܠܝܢ ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ ܦܐܛܪܝܪܟܐ</rubric>
                   </msItem>
@@ -492,8 +490,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܥܠ ܐܝܢܐ ܕܟܪܝܗ</rubric>
                   </msItem>
@@ -502,8 +499,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܥܠ ܐܝ̇ܢܐ ܕܩܪܝܒ ܕܢܡܘܬ<note>Written marginally.</note>
                     </rubric>
@@ -513,8 +509,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A prayer of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܕܣܝܡ ܐܝܕܐ ܕܥܠ ܟܪ̈ܝܗܐ</rubric>
                   </msItem>

--- a/data/tei/211.xml
+++ b/data/tei/211.xml
@@ -139,8 +139,7 @@
                 <msItem xml:id="c5" n="7">
                   <locus from="6a"/>
                   <title xml:lang="en">The Presentation in <placeName>the Temple</placeName> and
-                                        the Commemoration of <persName>S. Simeon the
-                                        Aged</persName>
+                                        the Commemoration of <persName>S. Simeon the Aged</persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c6" n="8">
@@ -149,8 +148,7 @@
                                         arranged</title>
                   <msItem xml:id="d1" n="9">
                     <locus from="9b"/>
-                    <title xml:lang="en">On the Miracles of <persName>our
-                                            Lord</persName>
+                    <title xml:lang="en">On the Miracles of <persName>our Lord</persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -263,8 +261,7 @@
                 </msItem>
                 <msItem xml:id="c15" n="31">
                   <locus from="29a"/>
-                  <title xml:lang="en">The Commemoration of <persName>the blessed
-                                        Virgin</persName>
+                  <title xml:lang="en">The Commemoration of <persName>the blessed Virgin</persName>
                   </title>
                   <msItem xml:id="d15" n="32">
                     <locus from="29a"/>
@@ -297,19 +294,16 @@
                 </msItem>
                 <msItem xml:id="c16" n="37">
                   <locus from="35a"/>
-                  <title xml:lang="en">The Commemoration of <persName>the holy
-                                        Apostles</persName>
+                  <title xml:lang="en">The Commemoration of <persName>the holy Apostles</persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c17" n="38">
                   <locus from="36a"/>
-                  <title xml:lang="en">The Commemoration of <persName>the holy
-                                        Martyrs</persName>, in part alphabetical</title>
+                  <title xml:lang="en">The Commemoration of <persName>the holy Martyrs</persName>, in part alphabetical</title>
                 </msItem>
                 <msItem xml:id="c18" n="39">
                   <locus from="38a"/>
-                  <title xml:lang="en">The Commemoration of <persName>the holy
-                                        Teachers</persName>
+                  <title xml:lang="en">The Commemoration of <persName>the holy Teachers</persName>
                   </title>
                   <rubric xml:lang="syr">ܒܕܘܟܪܢܐ ܕܡ̈ܠܦܢܐ</rubric>
                 </msItem>

--- a/data/tei/213.xml
+++ b/data/tei/213.xml
@@ -125,14 +125,12 @@
               </msItem>
               <msItem xml:id="b5" n="6">
                 <locus from="11a"/>
-                <title xml:lang="en">The Nativity of <persName>S. John the
-                  Baptist</persName>
+                <title xml:lang="en">The Nativity of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="14a"/>
-                <title xml:lang="en">The Commemoration of <persName>S. John the
-                  Baptist</persName>
+                <title xml:lang="en">The Commemoration of <persName>S. John the Baptist</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܩܘ̈ܠܣ܏ܘ ܕܝ݊ܘܚ݊ܢܢ݊ ܕܡ̇ܫ̣ܬܡܠܐ ܒܟܣܐ ܒܟܢܘܢ ܩܕܝܡ</rubric>
               </msItem>
@@ -198,8 +196,7 @@
               </msItem>
               <msItem xml:id="b13" n="21">
                 <locus from="61b"/>
-                <title xml:lang="en">The Decollation of <persName>S. John the
-                  Baptist</persName>
+                <title xml:lang="en">The Decollation of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b14" n="22">
@@ -218,8 +215,7 @@
               </msItem>
               <msItem xml:id="b16" n="24">
                 <locus from="71a"/>
-                <title xml:lang="en">The Commemoration of <persName>Severus, patriarch of
-                    Antioch</persName>
+                <title xml:lang="en">The Commemoration of <persName>Severus, patriarch of Antioch</persName>
                 </title>
               </msItem>
               <msItem xml:id="b17" n="25">
@@ -355,8 +351,7 @@
               </msItem>
               <msItem xml:id="b27" n="53">
                 <locus from="158a"/>
-                <title xml:lang="en">The Commemoration of <persName>Elias the
-                  Prophet</persName>
+                <title xml:lang="en">The Commemoration of <persName>Elias the Prophet</persName>
                 </title>
               </msItem>
               <msItem xml:id="b28" n="54">

--- a/data/tei/214.xml
+++ b/data/tei/214.xml
@@ -146,10 +146,7 @@
                     <persName xml:lang="en">Deacon Simeon Kūkāyā ܓܐܫܝܪ</persName>
                   </author>
                   <title xml:lang="en">
-                    <foreign xml:lang="syr">ܡܥ̈ܢܝܬܐ</foreign> of the <persName>deacon
-                                            Simeon Kūkāyā (or "the
-                                            Potter") from the village called
-                    <placeName>ܓܐܫܝܪ</placeName>
+                    <foreign xml:lang="syr">ܡܥ̈ܢܝܬܐ</foreign> of the <persName>deacon Simeon Kūkāyā (or "the Potter") from the village called <placeName>ܓܐܫܝܪ</placeName>
                     </persName> hence termed Kūkāyāthā, 9 in number</title>
                   <rubric xml:lang="syr">ܡܥ̈ܢܝܬܐ ܕܒܝܬ ܝܠܕܗ ܕܡܪܢ̣ ܕܣܝ̈ܡ̣ܢ ܡ̇ܢ ܠܫܡܫܐ
                                         ܫܡܥܘܢ ܩܘܩܝܐ ܐܘ ܟܝܬ ܩ̇ܕܪܐ ܕܡܢ ܓܐܫܝܪ. ܘܡܛܠܗܕܐ̣ ܡܬܩܪ̈ܝܢ

--- a/data/tei/214.xml
+++ b/data/tei/214.xml
@@ -146,8 +146,7 @@
                     <persName xml:lang="en">Deacon Simeon Kūkāyā ܓܐܫܝܪ</persName>
                   </author>
                   <title xml:lang="en">
-                    <foreign xml:lang="syr">ܡܥ̈ܢܝܬܐ</foreign> of the <persName>deacon Simeon Kūkāyā (or "the Potter") from the village called <placeName>ܓܐܫܝܪ</placeName>
-                    </persName> hence termed Kūkāyāthā, 9 in number</title>
+                    <foreign xml:lang="syr">ܡܥ̈ܢܝܬܐ</foreign> of the <persName>deacon Simeon Kūkāyā (or "the Potter") from the village called <placeName>ܓܐܫܝܪ</placeName></persName> hence termed Kūkāyāthā, 9 in number</title>
                   <rubric xml:lang="syr">ܡܥ̈ܢܝܬܐ ܕܒܝܬ ܝܠܕܗ ܕܡܪܢ̣ ܕܣܝ̈ܡ̣ܢ ܡ̇ܢ ܠܫܡܫܐ
                                         ܫܡܥܘܢ ܩܘܩܝܐ ܐܘ ܟܝܬ ܩ̇ܕܪܐ ܕܡܢ ܓܐܫܝܪ. ܘܡܛܠܗܕܐ̣ ܡܬܩܪ̈ܝܢ
                                         ܩܘܩ̈ܝܬܐ</rubric>
@@ -158,8 +157,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                   </title>
                 </msItem>
               </msItem>
@@ -173,8 +171,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">
-                    <foreign xml:lang="syr">ܡܕܪ̈ܫܐ</foreign> of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName>, 18 in number</title>
+                    <foreign xml:lang="syr">ܡܕܪ̈ܫܐ</foreign> of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>, 18 in number</title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ ܡ̇ܠܦܢܐ</rubric>
                 </msItem>
                 <msItem xml:id="c5" n="9">
@@ -230,8 +227,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">
-                    <foreign xml:lang="syr">ܡܕܪ̈ܫܐ</foreign> of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName>, 13 in number</title>
+                    <foreign xml:lang="syr">ܡܕܪ̈ܫܐ</foreign> of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>, 13 in number</title>
                   <rubric xml:lang="syr">ܡܕܪ̈ܫܐ</rubric>
                   <msItem xml:id="d1" n="17">
                     <locus from="43b"/>
@@ -328,8 +324,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Two prayers of <persName>Isaac of <placeName>Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">Two prayers of <persName>Isaac of <placeName>Antioch</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c21" n="32">
@@ -406,8 +401,7 @@
                     <author ref="http://syriaca.org/person/2507">
                       <persName xml:lang="en">Theophilus of Alexandria</persName>
                     </author>
-                    <title xml:lang="en">Consolatory Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Consolatory Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName>Alexandria</placeName></persName>
                     </title>
                     <incipit xml:lang="syr">ܠܐ ܛ̇ܥܝܐ ܠܟܘܢ ܐܚ̈ܝ܇ ܐܝ̇ܕܐ ܕܚܠܬܐ
                                             ܘܙܘܥܬܐ ܘܐܢܢܩܐ ܐܝܬ ܠܡܚܙܐ̇. ܐܡܬܝ ܕܢܦܫܐ ܡܢ ܦܓܪܐ ܡܬܦܪܫܐ. ܏ܘܫ</incipit>
@@ -466,8 +460,7 @@
                     <author ref="http://syriaca.org/person/44">
                       <persName xml:lang="en">Philoxenus of Mabūg</persName>
                     </author>
-                    <title xml:lang="en">Consolatory Discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName>
-                      </persName>
+                    <title xml:lang="en">Consolatory Discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܕܥܠ ܐܚܐ ܕܥ̇ܢܕ. ܠܚ̇ܡ ܕܝ̣ܢ ܘܠܟܠܢܫ</rubric>
                     <incipit xml:lang="syr">ܚܒܝ̈ܒܝ: ܗܐ ܚܙܬܐ ܕܝܘܬܪ̈ܢܐ ܣܝܡ̣ܐ ܩܕ݂ܡ ܥܢ̈ܝܢ <foreign xml:lang="en">(sic)</foreign> ܦܓܪܗ ܕܐܚܘܢ ܕܐܬܚܛܦ ܡܢ ܡܘܿܬܐ. ܠܝܬ ܡܕܡ ܕܐܝܬܘܗܝ ܡ̇ܚܦܛܢܐ ܕܟܫܝܪ̈ܐ̇. ܐܝܟ ܚܙ̣ܬܐ ܕܡܐܬܝܬܗ ܕܡܘܿܬܐ. ܏ܘܫ</incipit>
@@ -505,8 +498,7 @@
                   <author ref="http://syriaca.org/person/2449">
                     <persName xml:lang="en">John (I.), patriarch of Antioch</persName>
                   </author>
-                  <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/2449">John (I.), patriarch of <placeName>Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/2449">John (I.), patriarch of <placeName>Antioch</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܣܕܪܐ ܕܒܣܡ̈ܐ ܕܡ̇ܥܠܬܐ ܕܡܕܒܚܐ</rubric>
                 </msItem>
@@ -515,8 +507,7 @@
                   <author ref="http://syriaca.org/person/792">
                     <persName xml:lang="en">Timothy of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">The Anaphora of <persName>Timothy of <placeName>Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">The Anaphora of <persName>Timothy of <placeName>Alexandria</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܩܕܝܫܐ ܛܝܡܬܐܘܣ ܦܛܪܝܪܟܐ ܕܐܠܟܣܢܕܪܝܐ̣. ܐܝܟ ܕܢ̇ܦܝܩ ܚܕܬܐܝܬ܇ ܡܢ ܝܘܢܝܐ ܠܣܘܪܝܝܐ</rubric>
                   <incipit xml:lang="syr">ܨܠܘܬܐ̣ ܕܩ̣ܕܡ ܫ̇ܠܡܐ. ܡܪܝܐ ܗ̇ܘ ܕܡܢ ܟܠܗ̇
@@ -529,8 +520,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">The Order of Baptism, of <persName>Severus of <placeName>Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">The Order of Baptism, of <persName>Severus of <placeName>Antioch</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܨ̈ܠܘܬܐ ܘܐܩܘܠܘܬܝܐ ܕܥܡ̇ܕܐ ܩܕܝܫܐ̣. ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ ܐ̇ܝܟ ܕܡ̇ܛܟܣ ܚܕܬܐܝܬ݂. ܕܐܝܟܢܐ ܙܕܩ ܠܗ ܠܟܗܢܐ ܕܢܬ݁ܚܫܚ</rubric>
                 </msItem>

--- a/data/tei/22.xml
+++ b/data/tei/22.xml
@@ -402,8 +402,7 @@
               </msItem>
               <msItem xml:id="b4" n="49">
                 <locus from="188b" to="299">Foll. 188b-299</locus>
-                <title xml:lang="en">Order of the redeeming Passion of <persName ref="http://syriaca.org/person/2245">our Lord and our God and our Saviour Jesus Christ</persName>; with lessons from <title>the Gospels
-                           (Peshitta version)</title> interspersed.</title>
+                <title xml:lang="en">Order of the redeeming Passion of <persName ref="http://syriaca.org/person/2245">our Lord and our God and our Saviour Jesus Christ</persName>; with lessons from <title>the Gospels (Peshitta version)</title> interspersed.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܚ̣ܫܐ ܦܪܘܩܝܐ. ܕܡܪܢ ܘܐܠܗܢ ܘܦܪܘܩܢ ܝܫܘܥ ܡܫܝܚܐ</rubric>
                 <msItem xml:id="c8" n="50">
                   <locus from="188b" to="201">Foll. 188b-201</locus>

--- a/data/tei/22.xml
+++ b/data/tei/22.xml
@@ -379,8 +379,7 @@
                   </msItem>
                   <msItem xml:id="d37" n="47">
                     <locus from="161b" to="166">Foll. 161b-166</locus>
-                    <title xml:lang="en">Order of <persName>Lazarus of <placeName>Bethany</placeName>
-                      </persName>, celebrated on the Saturday before Palm-Sunday.</title>
+                    <title xml:lang="en">Order of <persName>Lazarus of <placeName>Bethany</placeName></persName>, celebrated on the Saturday before Palm-Sunday.</title>
                     <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܠܥܙܪ ܕܡܢ ܒܝܬ ܥܢܝܐ ܕܡܫܬ݁ܡܠ̣ܐ ܒܫܒܬܐ
                                  ܕܩܕܡ ܐܘ̈ܫܥܢܐ</rubric>
                   </msItem>
@@ -633,8 +632,7 @@
               </msItem>
               <msItem xml:id="b10" n="68" defective="true">
                 <locus from="337a" to="338b">Foll. 337a-338b</locus>
-                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/2008">S. Peter, the chief of <persName ref="http://syriaca.org/person/1607">the Apostles</persName>
-                  </persName>.</title>
+                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/2008">S. Peter, the chief of <persName ref="http://syriaca.org/person/1607">the Apostles</persName></persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܦܛܪܘܣ ܪܝܫܐ ܕܫ̈ܠܝܚܐ</rubric>
                 <rubric xml:lang="syr">
                   <locus from="337b"/>

--- a/data/tei/22.xml
+++ b/data/tei/22.xml
@@ -167,10 +167,8 @@
                   </msItem>
                   <msItem xml:id="d6" n="9">
                     <locus from="24b" to="29">Foll. 24b-29</locus>
-                    <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/13">Mār Ephraim, the Syrian
-                                    Doctor</persName>, celebrated on Saturday in the first week of
-                                 Lent; and commemoration of <persName ref="http://syriaca.org/person/2107">Mār Theodore the
-                                    illustrious martyr</persName>.</title>
+                    <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/13">Mār Ephraim, the Syrian Doctor</persName>, celebrated on Saturday in the first week of
+                                 Lent; and commemoration of <persName ref="http://syriaca.org/person/2107">Mār Theodore the illustrious martyr</persName>.</title>
                     <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܩܕܝܫܐ ܡܪܝ ܐܦܪܝܡ ܡ̇ܠܦܢܐ ܏ܣܘܪ. ܕܡ̇ܫܬ݁ܡܠ̣ܐ ܒܝܘܡ ܫܒܬܐ. ܕܫܒܬܐ ܩܕܡܝܬܐ ܕܨܘܡܐ. ܘܕܘܟܪܢܗ ܕܡܪܝ ܬܐܘܕܘܪܘܣ ܣܗܕܐ ܢܨ̇ܝܚܐ</rubric>
                   </msItem>
                 </msItem>
@@ -405,8 +403,7 @@
               </msItem>
               <msItem xml:id="b4" n="49">
                 <locus from="188b" to="299">Foll. 188b-299</locus>
-                <title xml:lang="en">Order of the redeeming Passion of <persName ref="http://syriaca.org/person/2245">our Lord and
-                           our God and our Saviour Jesus Christ</persName>; with lessons from <title>the Gospels
+                <title xml:lang="en">Order of the redeeming Passion of <persName ref="http://syriaca.org/person/2245">our Lord and our God and our Saviour Jesus Christ</persName>; with lessons from <title>the Gospels
                            (Peshitta version)</title> interspersed.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܚ̣ܫܐ ܦܪܘܩܝܐ. ܕܡܪܢ ܘܐܠܗܢ ܘܦܪܘܩܢ ܝܫܘܥ ܡܫܝܚܐ</rubric>
                 <msItem xml:id="c8" n="50">
@@ -662,8 +659,7 @@
               </msItem>
               <msItem xml:id="b13" n="71" defective="true">
                 <locus from="341" to="344">Foll. 341-344</locus>
-                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/2123">S. Thomas the
-                           Apostle.</persName>
+                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/2123">S. Thomas the Apostle.</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܥܠ ܬܐܘܡܐ ܫܠܝܚܐ</rubric>
                 <rubric xml:lang="syr">
@@ -695,8 +691,7 @@
               </msItem>
               <msItem xml:id="b16" n="74" defective="true">
                 <locus from="350a" to="353">Foll. 350a-353</locus>
-                <title xml:lang="en">Order of <persName>Mār George, the illustrious and
-                              famous martyr</persName>.</title>
+                <title xml:lang="en">Order of <persName>Mār George, the illustrious and famous martyr</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܡܪܝ ܓܐܘܪܓܝܣ ܣܗܕܐ ܢܨ̇ܝ̣ܚܐ ܘܛܒܝ̣ܒܐ</rubric>
                 <rubric xml:lang="syr">
                   <locus from="351a"/>
@@ -705,16 +700,14 @@
               </msItem>
               <msItem xml:id="b17" n="75" defective="true">
                 <locus from="353b" to="353">Foll. 353b-353</locus>
-                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/1192">Mār Quiricus, or Cyriacus, the
-                              martyr</persName>, and of <persName ref="http://syriaca.org/person/1332">his mother Julitta</persName>.</title>
+                <title xml:lang="en">Order of <persName ref="http://syriaca.org/person/1192">Mār Quiricus, or Cyriacus, the martyr</persName>, and of <persName ref="http://syriaca.org/person/1332">his mother Julitta</persName>.</title>
                 <rubric xml:lang="syr">[ܛܟܣܐ] ܕܥܠ [ܡܪܝ ܩܘܪܝܩـ]ـܘܣ ܣܗܕܐ [ܘܥܠ ܝܘܠܝܛܐ]
                            ܐܡܗ</rubric>
               </msItem>
               <msItem xml:id="b18" n="76" defective="true">
                 <locus from="354a" to="354">Foll. 354a-354</locus>
                 <title xml:lang="en">Order of the <persName>Maccabees</persName>,
-                    <persName>Shamūnī</persName> and <persName>her seven
-                              sons</persName>.</title>
+                    <persName>Shamūnī</persName> and <persName>her seven sons</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܠ ܡܩ̈ܒܝܐ ܫܡܘܢܝ ܘܫܒ̈ܥܐ ܒܢܝ̈ܗ̇</rubric>
               </msItem>
               <msItem xml:id="b19" n="77" defective="true">
@@ -725,8 +718,7 @@
               </msItem>
               <msItem xml:id="b20" n="78" defective="true">
                 <locus from="356a" to="357">Foll. 356a-357</locus>
-                <title xml:lang="en">Order of the Decease of <persName ref="http://syriaca.org/person/624">Mary the Mother of
-                           God</persName>.</title>
+                <title xml:lang="en">Order of the Decease of <persName ref="http://syriaca.org/person/624">Mary the Mother of God</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܥܘܢܕܢܗ̇ ܕܝܳܠܕܳܬ (sic) ܐܠܗܐ ܡ݊ܪܝܡ</rubric>
               </msItem>
               <msItem xml:id="b21" n="79" defective="true">

--- a/data/tei/233.xml
+++ b/data/tei/233.xml
@@ -490,8 +490,7 @@
               <msItem xml:id="p4a1" n="1" defective="true">
                 <locus from="7"/>
                 <title xml:lang="en">A portion of the first part of a Choir-book,
-                        comprising <title ref="http://syriaca.org/work/19">Psalms xlvi. 5—lx. 6, according to the Peshitta
-                           version</title>.</title>
+                        comprising <title ref="http://syriaca.org/work/19">Psalms xlvi. 5—lx. 6, according to the Peshitta version</title>.</title>
                 <note>The Psalms are numbered, the <foreign xml:lang="syr">ܡܪ̈ܡܝܬܐ</foreign> and <foreign xml:lang="syr">ܫܘ̈ܒܚܐ</foreign> marked, and the versicles divided as usual by
                                        <foreign xml:lang="syr">ܗ</foreign>.</note>
               </msItem>

--- a/data/tei/24.xml
+++ b/data/tei/24.xml
@@ -152,8 +152,7 @@
               </msItem>
               <msItem xml:id="b7" n="8">
                 <locus from="79" to="83">Foll. 79-83</locus>
-                <title xml:lang="en">Fragments of the order of Pentecost, of <persName ref="http://syriaca.org/person/1983">S. Paul the
-                              Apostle</persName>, and others.</title>
+                <title xml:lang="en">Fragments of the order of Pentecost, of <persName ref="http://syriaca.org/person/1983">S. Paul the Apostle</persName>, and others.</title>
               </msItem>
             </msItem>
             <msItem xml:id="a2" n="9">

--- a/data/tei/242.xml
+++ b/data/tei/242.xml
@@ -604,8 +604,7 @@
                 </msItem>
                 <msItem xml:id="p4b3" n="6" defective="true">
                   <locus from="32a" to="33">Foll. 32a-33</locus>
-                  <title xml:lang="en">The Presentation of <persName>our Lord</persName> in <placeName>the
-                  Temple</placeName> and the Commemoration of <persName>S. Simeon the Aged</persName>
+                  <title xml:lang="en">The Presentation of <persName>our Lord</persName> in <placeName>the Temple</placeName> and the Commemoration of <persName>S. Simeon the Aged</persName>
                   </title>
                 </msItem>
                 <msItem xml:id="p4b4" n="7" defective="true">

--- a/data/tei/242.xml
+++ b/data/tei/242.xml
@@ -847,8 +847,7 @@
                   <author ref="http://syriaca.org/person/94">
                     <persName xml:lang="en">John, Bishop of Bosra</persName>
                   </author>
-                  <title xml:lang="en">The Anaphora of <persName>John, bishop of
-                <placeName>Bosra</placeName>
+                  <title xml:lang="en">The Anaphora of <persName>John, bishop of <placeName>Bosra</placeName>
                     </persName>
               </title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܚܣܝܐ ܘܩܕܝܫܐ ܝܘܚܢܢ ܒܘܨܪܝܐ</rubric>

--- a/data/tei/242.xml
+++ b/data/tei/242.xml
@@ -730,8 +730,7 @@
                 <msItem xml:id="p5b3" n="4">
                   <locus from="52b"/>
                   <title xml:lang="en">
-                    <persName>Lazarus of <placeName>Bethany</placeName>
-                    </persName>
+                    <persName>Lazarus of <placeName>Bethany</placeName></persName>
                 </title>
                 </msItem>
               </msItem>
@@ -847,8 +846,7 @@
                   <author ref="http://syriaca.org/person/94">
                     <persName xml:lang="en">John, Bishop of Bosra</persName>
                   </author>
-                  <title xml:lang="en">The Anaphora of <persName>John, bishop of <placeName>Bosra</placeName>
-                    </persName>
+                  <title xml:lang="en">The Anaphora of <persName>John, bishop of <placeName>Bosra</placeName></persName>
               </title>
                   <rubric xml:lang="syr">ܐܢܦܘܪܐ ܕܚܣܝܐ ܘܩܕܝܫܐ ܝܘܚܢܢ ܒܘܨܪܝܐ</rubric>
                   <note>See <bibl>Renaudot, Liturg. Orient., t. ii., p. 421</bibl>, and <bibl>Assemani, Bibl. Or., t. ii., p. 97</bibl>.</note>
@@ -868,8 +866,7 @@
                     <persName xml:lang="en">Cyriacus of Tellā</persName>
                   </author>
                   <title xml:lang="en">Prayers, in part alphabetical, ascribed to
-                  <persName>Cyriacus of <placeName>Tellā</placeName>
-                    </persName>
+                  <persName>Cyriacus of <placeName>Tellā</placeName></persName>
               </title>
                   <rubric xml:lang="syr">ܕܚܣܝܐ ܩܘܪܝܩܐ ܕܬܠܐ</rubric>
                 </msItem>

--- a/data/tei/249.xml
+++ b/data/tei/249.xml
@@ -282,8 +282,7 @@
                     <persName xml:lang="en">Constantine</persName>
                   </author>
                   <title xml:lang="en">The epistle of
-                        <persName>Constantine</persName>, summoning <persName>the bishops
-                        from <placeName>Ancyra</placeName>
+                        <persName>Constantine</persName>, summoning <persName>the bishops from <placeName>Ancyra</placeName>
                     </persName> to
                         <placeName>Nicaea</placeName>
                     </title>
@@ -423,8 +422,7 @@
                   <author ref="http://syriaca.org/person/792">
                     <persName xml:lang="en">Timothy of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Questions addressed to <persName>Timothy
-                                        of <placeName>Alexandria</placeName>
+                  <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName>Alexandria</placeName>
                     </persName>, with his replies</title>
                   <rubric xml:lang="syr">ܫܐܘ̈ܠܐ ܕܐ̇ܬܩܪ̈ܒܘ ܠܩܕܝܫܐ ܡܪܝ ܛܝܡܬܐܘܣ ܐܦܝܣܩܦܐ
                                     ܕܐܠܟܣܢܕܪܝܐ̣ ܡܢ ܩܠܝܪ̈ܝܩܘ ܕܝܠܗ.</rubric>

--- a/data/tei/249.xml
+++ b/data/tei/249.xml
@@ -282,8 +282,7 @@
                     <persName xml:lang="en">Constantine</persName>
                   </author>
                   <title xml:lang="en">The epistle of
-                        <persName>Constantine</persName>, summoning <persName>the bishops from <placeName>Ancyra</placeName>
-                    </persName> to
+                        <persName>Constantine</persName>, summoning <persName>the bishops from <placeName>Ancyra</placeName></persName> to
                         <placeName>Nicaea</placeName>
                     </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܘܣܛܢܛܝܢܘܣ ܪܒܐ ܐܒܘܗܝ ܕܩܘܣܛܢܛܝܢܣ ܙܥܘܪܐ ܕܩܪܝܐ ܠܐ̈ܦܝܣܩܦܐ ܡܢ ܐܢܩܘܪܐ ܠܢܝܩܝܐ</rubric>
@@ -422,8 +421,7 @@
                   <author ref="http://syriaca.org/person/792">
                     <persName xml:lang="en">Timothy of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName>Alexandria</placeName>
-                    </persName>, with his replies</title>
+                  <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName>Alexandria</placeName></persName>, with his replies</title>
                   <rubric xml:lang="syr">ܫܐܘ̈ܠܐ ܕܐ̇ܬܩܪ̈ܒܘ ܠܩܕܝܫܐ ܡܪܝ ܛܝܡܬܐܘܣ ܐܦܝܣܩܦܐ
                                     ܕܐܠܟܣܢܕܪܝܐ̣ ܡܢ ܩܠܝܪ̈ܝܩܘ ܕܝܠܗ.</rubric>
                   <note>See <bibl>Renaudot, Hist. Patr. Alexandria Jacob., p. 101</bibl>.</note>
@@ -434,8 +432,7 @@
                   <author ref="http://syriaca.org/person/26">
                     <persName xml:lang="en">Rabūlas, bishop of Edessa</persName>
                   </author>
-                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/26">Rabūlas, bishop of <placeName>Edessa</placeName>
-                    </persName>
+                  <title xml:lang="en">Canons of <persName ref="http://syriaca.org/person/26">Rabūlas, bishop of <placeName>Edessa</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܩ̈ܢܘܢܐ̣. ܕܡܪܝ ܪܒܘܠܐ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ</rubric>
                   <note>8 in number</note>
@@ -446,8 +443,7 @@
                   <author ref="http://syriaca.org/person/50">
                     <persName xml:lang="en">John, bishop of Tellā</persName>
                   </author>
-                  <title xml:lang="en">Canons of <persName>John, bishop of <placeName>Tellā</placeName>
-                    </persName>
+                  <title xml:lang="en">Canons of <persName>John, bishop of <placeName>Tellā</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܩ̈ܢܘܢܐ ܕܛܘܒܢܐ ܡܪܝ ܝܘܚܢܢ ܐܦܝܣܩܘܦܐ ܕܬ̇ܠ̣ܐ</rubric>
                   <note>Here are included Canons 2, 3, 4, 5, 6, 7, 9, 10, 12,

--- a/data/tei/249.xml
+++ b/data/tei/249.xml
@@ -163,8 +163,7 @@
                 <msItem xml:id="p1b2" n="4">
                   <locus from="1a"/>
                   <title xml:lang="en">A Synopsis, as it may be called, of the
-                                    <ref>Canons of the <persName>Apostles</persName>
-                    </ref> and of the principal Councils of the
+                                    <ref>Canons of the <persName>Apostles</persName></ref> and of the principal Councils of the
                                     Church</title>
                   <rubric xml:lang="syr">
                   <locus from="1a"/>ܟܘܢܫܐ ܕܩ̈ܢܘܢܐ ܟܠܗܘܢ ܕܫ̈ܠܝܚܐ ܩ̈ܕܝܫܐ ܘܕܣ̈ܘܢܗܕܘ ܩ̈ܕܝܫܬܐ ܕܐ̈ܒܗܬܐ ܚܝܣ̈ܝܐ. <foreign xml:lang="en">(sic)</foreign> ܕܡܟܢܫܝܢ
@@ -398,8 +397,7 @@
                 <msItem xml:id="p1b16" n="28">
                   <locus from="29a"/>
                   <title xml:lang="en">A single canon of the Council of
-                                        <placeName>Ephesus</placeName>, confirmatory of <ref>the Nicene
-                                    Creed</ref>
+                                        <placeName>Ephesus</placeName>, confirmatory of <ref>the Nicene Creed</ref>
                   </title>
                   <rubric xml:lang="syr">ܬܚܘܡܐ ܐܘ ܟܝܬ ܩܢܘܢܐ̣ ܕܣܘܢܗܕܘܣ ܩܕܝܫܬܐ ܕܒܐܦܣܘܣ
                                     ܐܬܟ̣ܢܫܬ. ܩܕܡ ܟܠܡܕܡ ܬ̇ܚܡ̣ܬ ܣܘܗܢܕܘܣ̣ <foreign xml:lang="en">(sic)</foreign> ܕܗܝܡܢܘܬܐ ܐܚܪܬܐ̣ ܠܐ ܗܘ̣ܬ
@@ -633,8 +631,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p2a1" n="1">
                 <locus from="40b"/>
-                <title xml:lang="en">A Synopsis of <ref>the Canons of <persName>the Apostles</persName>
-                  </ref> and the principal Councils, arranged under 51 heads</title>
+                <title xml:lang="en">A Synopsis of <ref>the Canons of <persName>the Apostles</persName></ref> and the principal Councils, arranged under 51 heads</title>
                 <note>The prefatory section is omitted.</note>
               </msItem>
               <msItem xml:id="p2a2" n="2">

--- a/data/tei/253.xml
+++ b/data/tei/253.xml
@@ -142,8 +142,7 @@
               <textLang mainLang="syr-Syre">Syriac</textLang>
               <msItem xml:id="p1a1" n="1">
                 <locus from="1a" to="3"/>
-                <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName>Alexandria</placeName>
-                  </persName>, with his
+                <title xml:lang="en">Questions addressed to <persName>Timothy of <placeName>Alexandria</placeName></persName>, with his
                       replies</title>
                 <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܕܐܬܩܪܒܘ ܠܩܕܝܫܐ ܛܝܡܬܐܘܣ ܪܒܐ ܦܛܪܝܪܟܐ ܕܐܠܟܣܢܕܪܝܐ</rubric>
                 <note>See <bibl>Add. 14,526, fol. 29 b</bibl>, and <bibl>14,527, fol. 23 b</bibl>.</note>
@@ -222,8 +221,7 @@
                 </msItem>
                 <msItem xml:id="p1b8" n="10">
                   <locus from="36b"/>
-                  <title xml:lang="en">The names of <persName>the bishops who were at <placeName>Ancyra</placeName> and <placeName>(Neo-) Caesarea</placeName>
-                    </persName>
+                  <title xml:lang="en">The names of <persName>the bishops who were at <placeName>Ancyra</placeName> and <placeName>(Neo-) Caesarea</placeName></persName>
                     </title>
                 </msItem>
                 <msItem xml:id="p1b9" n="11" defective="true">
@@ -248,8 +246,7 @@
                 </msItem>
                 <msItem xml:id="p1b11" n="13">
                   <locus from="50a"/>
-                  <title xml:lang="en">The letter of <persName>the bishops assembled at <placeName>Gangra</placeName>
-                    </persName>
+                  <title xml:lang="en">The letter of <persName>the bishops assembled at <placeName>Gangra</placeName></persName>
                         to <persName>the Armenians</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܣܘܢܗܕܣ ܕܒܓܢܓܪܐ ܩܢܘ̈ܢܐ ܥܣܪ̈ܝܢ. ܘ . ܗܠܝܢ
@@ -266,8 +263,7 @@
                 </msItem>
                 <msItem xml:id="p1b13" n="15" defective="true">
                   <locus from="57a"/>
-                  <title xml:lang="en">The list of <persName>the subscribing bishops of the Council of <placeName>Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">The list of <persName>the subscribing bishops of the Council of <placeName>Antioch</placeName></persName>
                     </title>
                   <note>Imperfect at the beginning.</note>
                 </msItem>
@@ -280,8 +276,7 @@
                 </msItem>
                 <msItem xml:id="p1b15" n="17">
                   <locus from="72b"/>
-                  <title xml:lang="en">The names of <persName>the subscribing bishops of the Council of <placeName>Laodicea</placeName>
-                    </persName>
+                  <title xml:lang="en">The names of <persName>the subscribing bishops of the Council of <placeName>Laodicea</placeName></persName>
                     </title>
                   <note>The names are prefixed to <ref>the Canons of the Council of
                         Laodicea</ref>.</note>
@@ -363,8 +358,7 @@
                     <title xml:lang="en">Letter of
                                             <persName>Theodosius</persName> and
                                             <persName>Valentinian</persName>, addressed to
-                                            <persName>Stephen, bishop of <placeName>Ephesus</placeName>
-                      </persName>, regarding the
+                                            <persName>Stephen, bishop of <placeName>Ephesus</placeName></persName>, regarding the
                                         administration of <placeName>the churches</placeName>
                     </title>
                     <rubric xml:lang="syr">ܣܐܩܪܐ ܕܬܐܘܕܣܝܣ ܘܕܘܠܢܛܢܝܢܘܣ ܡܛܘܠ ܦܘܪ̈ܢܣܐ
@@ -383,10 +377,8 @@
                     <author ref="http://syriaca.org/person/2299">
                       <persName xml:lang="en">Leo of Rome</persName>
                     </author>
-                    <title xml:lang="en">Letter of <persName>Leo of <placeName>Rome</placeName>
-                      </persName> to
-                                            <persName>Anatolius of <placeName>Constantinople</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName>Leo of <placeName>Rome</placeName></persName> to
+                                            <persName>Anatolius of <placeName>Constantinople</placeName></persName>
                   </title>
                     <rubric xml:lang="syr">ܠܐܘܢ ܪܫܐ ܕܐܦ̈ܣܩܦܐ ܕܪܗܘܡܐ ܩܫܝܫܬܐ: ܠܐܢܛܠ ܪܫܐ ܕܐܦ̈ܣܩܘܦܐ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ</rubric>
                     <note>Imperfect at the end.</note>
@@ -399,8 +391,7 @@
                     <author ref="http://syriaca.org/person/2299">
                       <persName xml:lang="en">Leo of Rome</persName>
                     </author>
-                    <title xml:lang="en">Letter of <persName>Leo of <placeName>Rome</placeName>
-                      </persName> to
+                    <title xml:lang="en">Letter of <persName>Leo of <placeName>Rome</placeName></persName> to
                                             <persName>Marcianus</persName>
                   </title>
                     <note>Imperfect at the beginning.</note>

--- a/data/tei/253.xml
+++ b/data/tei/253.xml
@@ -603,8 +603,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p2a1" n="1" defective="true">
                 <locus from="152a"/>
-                <title xml:lang="en">An Index to <ref>the Lessons proper
-                                for the Festivals of the whole year and other occasions</ref>
+                <title xml:lang="en">An Index to <ref>the Lessons proper for the Festivals of the whole year and other occasions</ref>
                 </title>
                 <incipit xml:lang="syr">ܦܘܪܫ ܩܪ̈ܝܢܐ</incipit>
                 <finalRubric xml:lang="syr">

--- a/data/tei/253.xml
+++ b/data/tei/253.xml
@@ -266,8 +266,7 @@
                 </msItem>
                 <msItem xml:id="p1b13" n="15" defective="true">
                   <locus from="57a"/>
-                  <title xml:lang="en">The list of <persName>the subscribing bishops
-                        of the Council of <placeName>Antioch</placeName>
+                  <title xml:lang="en">The list of <persName>the subscribing bishops of the Council of <placeName>Antioch</placeName>
                     </persName>
                     </title>
                   <note>Imperfect at the beginning.</note>
@@ -281,8 +280,7 @@
                 </msItem>
                 <msItem xml:id="p1b15" n="17">
                   <locus from="72b"/>
-                  <title xml:lang="en">The names of <persName>the subscribing bishops
-                        of the Council of <placeName>Laodicea</placeName>
+                  <title xml:lang="en">The names of <persName>the subscribing bishops of the Council of <placeName>Laodicea</placeName>
                     </persName>
                     </title>
                   <note>The names are prefixed to <ref>the Canons of the Council of
@@ -336,8 +334,7 @@
                   </msItem>
                   <msItem xml:id="p1c2" n="24" defective="true">
                     <locus from="119a"/>
-                    <title xml:lang="en">The list of <persName>the subscribing
-                                        bishops</persName>
+                    <title xml:lang="en">The list of <persName>the subscribing bishops</persName>
                     </title>
                     <rubric xml:lang="syr">ܐܪܡܝܘ ܐܝܕܐ ܐܝܠܝܢ ܕܐܫܟܚܘ ܡܢ ܐ̈ܦܝܣܩܘܦܐ . ܣܓ̈ܝܐܐ ܓܝܪ ܡܢ ܣܘܢܗܕܘܣ ܩܕܝܫܬܐ. ܐܘ ܡܛܠ ܣܝܒܘܬܐ ܢܓܝܪܬܐ. ܐܘ ܡܛܠ ܡܚܝܠܘܬܐ ܕܦܓܪܐ ܠܐ
                                         ܐܬܡܨܝܘ ܕܥܕܡܐ ܠܪܡܫܐ ܥܡܝܩܐ ܢܓܪܘܢ ܘܢܪܡܘܢ ܐܝܕܐ .. .. .. ܚܠܦ ܢܨܝܚܐ ܠܐܘܢ ܕܪܗܘܡܐ . ܘ . ܦܣܩܣܝܢܣ ܕܠܝܠܘܒܐܘܣ ܕܣܝܩܠܝܐ. ܏ܘܫ</rubric>
@@ -366,8 +363,7 @@
                     <title xml:lang="en">Letter of
                                             <persName>Theodosius</persName> and
                                             <persName>Valentinian</persName>, addressed to
-                                            <persName>Stephen, bishop of
-                                            <placeName>Ephesus</placeName>
+                                            <persName>Stephen, bishop of <placeName>Ephesus</placeName>
                       </persName>, regarding the
                                         administration of <placeName>the churches</placeName>
                     </title>
@@ -703,8 +699,7 @@
                 </msItem>
                 <msItem xml:id="p2b16" n="17">
                   <locus from="191a"/>
-                  <title xml:lang="en">The Apparition of <persName>the holy Cross</persName> to <persName>the
-                                    emperor Constantine</persName>
+                  <title xml:lang="en">The Apparition of <persName>the holy Cross</persName> to <persName>the emperor Constantine</persName>
                   </title>
                   <rubric xml:lang="syr">ܒܫܒܥܐ ܒܝܪܚ ܐܝܪ ܒܝܘܡܐ ܕܐܬܚܙܝ ܒܗ ܨܠܝܒܐ ܩܕܝܫܐ
                                     ܒܫܡܝܐ. ܠܛܘܒܢܐ ܩܘܣܛܢܛܝܢܘܣ ܡܠܟܐ ܡܗܝܡܢܐ. ܡܢ ܬܠܬ ܫܥ̈ܝܢ ܒܝܘܡܐ ܥܕܡܐ

--- a/data/tei/256.xml
+++ b/data/tei/256.xml
@@ -629,8 +629,7 @@
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
                 <title xml:lang="en">Letter to <persName>Abū Nafīr</persName>, <foreign xml:lang="grc">στρατηλύτης</foreign>, of <placeName ref="http://syriaca.org/place/219">al-Hīra</placeName>, giving
-                  some account of <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName ref="http://syriaca.org/person/780">Theodore of
-                    Mopsuestia</persName>, <persName ref="http://syriaca.org/person/482">Eutyches</persName>,
+                  some account of <persName ref="http://syriaca.org/person/655">Nestorius</persName>, <persName ref="http://syriaca.org/person/780">Theodore of Mopsuestia</persName>, <persName ref="http://syriaca.org/person/482">Eutyches</persName>,
                     <persName ref="http://syriaca.org/person/2432">Dioscorus</persName>, and the Councils of Ephesus and
                   Chalcedon</title>
                 <rubric xml:lang="syr">ܣܘܢܗܕܝܩܘܣ ܕܟܬ̣ܒ ܡܪܝ ܐܟܣܢܝܐ ܐܦܣܩܦܐ ܕܡܒܘܓ. ܠܐܒܘ ܢܝܦܝܪ<note type="footnote">Compare the form <foreign xml:lang="syr">ܥܒܕܠܡܝܣܝܚ</foreign>, <foreign xml:lang="ar">عبد المَسِيح</foreign>
@@ -646,10 +645,8 @@
                   (<persName ref="http://syriaca.org/person/608">Manes</persName>, <persName ref="http://syriaca.org/person/616">Marcion</persName>,
                   <persName ref="http://syriaca.org/person/482">Eutyches</persName>; <persName ref="http://syriaca.org/person/2779">Valentinus</persName>,
                   <persName ref="http://syriaca.org/person/3">Bardesanes</persName>; <persName ref="http://syriaca.org/person/2499">Apollinaris</persName>;
-                  <persName>Eunomius</persName>; <persName>Diodorus</persName>, <persName ref="http://syriaca.org/person/780">Theodore
-                    of Mopsuestia</persName>, <persName ref="http://syriaca.org/person/781">Theodoret</persName>,
-                  <persName ref="http://syriaca.org/person/655">Nestorius</persName>, etc.; <persName ref="http://syriaca.org/person/2486">Arius</persName>; <persName ref="http://syriaca.org/person/2469">Paul
-                    of Samosata</persName>; the council of Chalcedon; the Jews), concluding with the
+                  <persName>Eunomius</persName>; <persName>Diodorus</persName>, <persName ref="http://syriaca.org/person/780">Theodore of Mopsuestia</persName>, <persName ref="http://syriaca.org/person/781">Theodoret</persName>,
+                  <persName ref="http://syriaca.org/person/655">Nestorius</persName>, etc.; <persName ref="http://syriaca.org/person/2486">Arius</persName>; <persName ref="http://syriaca.org/person/2469">Paul of Samosata</persName>; the council of Chalcedon; the Jews), concluding with the
                   orthodox profession of faith</title>
                 <rubric xml:lang="syr">ܥܠ ܦܘܪܫܐ ܕܗܪ̈ܣܝܣ ܗܠܝܢ ܕܒܛܥܝܘܬܐ ܐܚܝܕܝܢ</rubric>
               </msItem>

--- a/data/tei/256.xml
+++ b/data/tei/256.xml
@@ -561,8 +561,7 @@
                     <ref target="http://syriaca.org/work/9607">to the Hebrews</ref>
                   </title>, fol. <locus from="34b">34 b</locus>.</p>
                 <p>
-                  <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܐܝܠܝܢ ܕܠܘܬ ܕܝܕܘܪܘܣ</quote>, fol. <locus from="27b">27 b</locus>; <title xml:lang="en">comment. on <ref target="http://syriaca.org/work/9641">the Gospel
-                  of S. John</ref>
+                  <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>: <quote xml:lang="syr">ܡܢ ܐܝܠܝܢ ܕܠܘܬ ܕܝܕܘܪܘܣ</quote>, fol. <locus from="27b">27 b</locus>; <title xml:lang="en">comment. on <ref target="http://syriaca.org/work/9641">the Gospel of S. John</ref>
                   </title>, foll. <locus from="27b">27 b</locus>, <locus from="28b">28 b</locus>, <locus from="36a" to="36b">36 a and b</locus>; <title xml:lang="en">Thesaurus</title>, foll. <locus from="30b">30 b</locus>, <locus from="31a">31 a</locus>, <locus from="32a">32 a</locus>; <quote xml:lang="syr">ܡܢ
                   ܫܪܝܐ ܕܦܣܩܐ ܕܨܝܕ ܫܘܐܠܐ ܕܐܢܫ ܛܝܒܪܝܘܣ ܡܫܡܫܢܐ ܘܕܐ̈ܚܐ ܕܥܡܗ</quote>, fol. <locus from="33a">33 a</locus>; <quote xml:lang="syr">ܐܓܪܬܐ ܕܠܘܬ ܐܩܩ
                   ܐܦܣܩܦܐ ܕܣܩܘܬܐܦܘܠܝܣ ܡܢ ܬܐܘܪ̈ܝܐ ܕܥܙܙܐܝܠ</quote>, fol. <locus from="37a">37 a</locus>.</p>

--- a/data/tei/257.xml
+++ b/data/tei/257.xml
@@ -177,8 +177,7 @@
                   representatives of <persName ref="http://syriaca.org/person/2299">Leo</persName> (<persName>Julian</persName> and
                     <persName>Hilarius</persName>), who refused to be present at its meetings,
                   after the conclusion of the case of <persName ref="http://syriaca.org/person/482">Eutyches</persName>; and regarding
-                  <persName ref="http://syriaca.org/person/2264">Domnus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, who was sick or
+                  <persName ref="http://syriaca.org/person/2264">Domnus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, who was sick or
                   pretended to be so</title>
                 <note type="footnote">
                   <quote xml:lang="syr">ܐܠܐ ܘܡܢ ܒܬܪ ܗܢܐ ܥܢܝܢܐ̣. ܬܘܒ ܠܨܦܪܗ ܕܝܘܡܐ ܕܐܝܬܘܗܝ ܚܕ ܒܫܒܐ̣.
@@ -191,8 +190,7 @@
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="8a"/>
-                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/534">Ibas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>
+                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/534">Ibas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘ̈ܦܡܢܡܛܐ ܕܗܘܘ ܠܘܩܒܠ ܗܝܒܐ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ ܡܕܝܢܬܐ</rubric>
                 <note>This title is given on fol. <locus from="2b">2 b</locus>, before the letter of <persName>the
@@ -256,8 +254,7 @@
                 <author ref="http://syriaca.org/person/2257">
                   <persName xml:lang="en">Daniel, bishop of Harran</persName>
                 </author>
-                <title xml:lang="en">Deposition (<foreign xml:lang="grc">καθαίρεσις</foreign>) of <persName ref="http://syriaca.org/person/2257">Daniel, bishop of <placeName ref="http://syriaca.org/place/216">Harran</placeName>
-                  </persName>
+                <title xml:lang="en">Deposition (<foreign xml:lang="grc">καθαίρεσις</foreign>) of <persName ref="http://syriaca.org/person/2257">Daniel, bishop of <placeName ref="http://syriaca.org/place/216">Harran</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܕܢܝܐܝܠ ܐܦܣܩܦܐ ܕܚܪܢ</rubric>
               </msItem>
@@ -266,8 +263,7 @@
                 <author ref="http://syriaca.org/person/2463">
                   <persName xml:lang="en">Irenaeus, bishop of Tyre</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/847">Irenaeus, bishop of <placeName ref="http://syriaca.org/place/195">Tyre</placeName>
-                  </persName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/847">Irenaeus, bishop of <placeName ref="http://syriaca.org/place/195">Tyre</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܐܝܪܝܢܐܘܣ ܐܦܣܩܦܐ ܕܛܘܪܘܣ</rubric>
               </msItem>
@@ -276,15 +272,13 @@
                 <author>
                   <persName xml:lang="en">Aquilinus, bishop of Byblos</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/844">Aquilinus, bishop of <placeName ref="http://syriaca.org/place/52">Byblos</placeName>
-                  </persName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/844">Aquilinus, bishop of <placeName ref="http://syriaca.org/place/52">Byblos</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܐܩܘܠܝܢܘܣ ܐܦܣܩܦܐ ܕܒܝܒܠܘܣ</rubric>
               </msItem>
               <msItem xml:id="b10" n="17">
                 <locus from="54a"/>
-                <title xml:lang="en">Action against <persName>Sophronius, bishop of <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or <placeName ref="http://syriaca.org/place/200">Constantina</placeName>
-                  </persName>
+                <title xml:lang="en">Action against <persName>Sophronius, bishop of <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or <placeName ref="http://syriaca.org/place/200">Constantina</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘܦܡ̈ܢܡܛܐ ܕܐܣܬܥܪܘ ܥܠ ܣܘܦܪܘܢ ܐܦܝܣܩܘܦܐ ܕܬܠܠܐ ܡܕܝܢܬܐ</rubric>
               </msItem>
@@ -293,8 +287,7 @@
                 <author ref="http://syriaca.org/person/781">
                   <persName xml:lang="en">Theodoret, bishop of Cyrus</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/781">Theodoret, bishop of <placeName ref="http://syriaca.org/place/65">Cyrus</placeName>
-                  </persName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/781">Theodoret, bishop of <placeName ref="http://syriaca.org/place/65">Cyrus</placeName></persName>
                 </title>
                 <rubric xml:lang="syr"> ܩܬܪܣܝܣ ܕܬܐܕܘܪܝܛܐ ܐܦܣܩܦܐ ܕܩܘܪܘܣ</rubric>
                 <msItem xml:id="c4" n="19">
@@ -319,21 +312,18 @@
                 <author>
                   <persName xml:lang="en">Domnus, bishop of Antioch</persName>
                 </author>
-                <title xml:lang="en">Adherence of <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, by message, to the above
+                <title xml:lang="en">Adherence of <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, by message, to the above
                   decisions</title>
               </msItem>
               <msItem xml:id="b13" n="22">
                 <locus from="79a"/>
                 <title xml:lang="en">The excommunication, laid on certain of the clergy by
-                  <persName ref="http://syriaca.org/person/2653">Flavian of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName>, is
+                  <persName ref="http://syriaca.org/person/2653">Flavian of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>, is
                   removed</title>
               </msItem>
               <msItem xml:id="b14" n="23" defective="true">
                 <locus from="79a"/>
-                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘܦܡ̈ܢܡܛܐ ܕܐܣܬܥܪܘ ܠܘܩܒܠ ܕܘܡܢܘܣ ܐܦܣܩܘܦܐ ܕܐܢܛܝܘܟܝܐ</rubric>
                 <msItem xml:id="c6" n="24">
@@ -376,8 +366,7 @@
                   <author ref="http://syriaca.org/person/2432">
                     <persName xml:lang="en">Dioscorus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                    </persName> to
+                  <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> to
                     <persName ref="http://syriaca.org/person/2264">Domnus</persName>
                   </title>
                 </msItem>
@@ -422,8 +411,7 @@
               </msItem>
               <msItem xml:id="b16" n="34">
                 <locus from="106a"/>
-                <title xml:lang="en">Part of an imperial letter to (<persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>)</title>
+                <title xml:lang="en">Part of an imperial letter to (<persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>)</title>
                 <note>It directs him to write encyclical letters (<quote xml:lang="syr">ܟܬܝ̈ܒܬܐ ܐܢܩ̈ܘܩܠܝܐ</quote>) containing the
                   imperial decree (against the Nestorians, <quote xml:lang="syr">ܢܡܘܣܢ ܗܢܐ</quote>), the Nicene Creed (
                     <quote xml:lang="syr">ܣܝܡܐ ܕܗܝܡܢܘܬܢ ܩܕܝܫܬܐ</quote>), and the definition (<quote xml:lang="syr">ܬܚܘܡܐ</quote>) of the two Councils (of <placeName ref="http://syriaca.org/place/623">Ephesus</placeName>), to
@@ -434,8 +422,7 @@
               <msItem xml:id="b17" n="35">
                 <locus from="106b"/>
                 <title xml:lang="en">Part of a letter of the emperor
-                    <persName ref="http://syriaca.org/person/1529">Theodosius</persName> to <persName>Juvenalis, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
-                  </persName>, to the same effect as no.
+                    <persName ref="http://syriaca.org/person/1529">Theodosius</persName> to <persName>Juvenalis, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName></persName>, to the same effect as no.
                   34<!--JA: item 16 in the catalogue-->
                 </title>
                 <rubric xml:lang="syr">ܥܢܝܢܐ ܕܐܓܪܬܐ ܕܡܗܝܡܢܐ ܘܕܚ̇ܠ ܠܐܠܗܐ ܡ̇ܠܟܐ ܕܝܠܢ ܬܐܘܕܘܣܝܘܣ ܘܠܘܬ
@@ -443,8 +430,7 @@
               </msItem>
               <msItem xml:id="b18" n="36">
                 <locus from="107a"/>
-                <title xml:lang="en">Part of a letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> to the various bishops, carrying
+                <title xml:lang="en">Part of a letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> to the various bishops, carrying
                   out the instructions contained in no. 34<!--JA: item 16 in the catlogue-->
                 </title>
                 <note>The following is the formula to be signed by the bishops and

--- a/data/tei/257.xml
+++ b/data/tei/257.xml
@@ -142,8 +142,7 @@
               <msItem xml:id="b2" n="3">
                 <locus from="2b"/>
                 <title xml:lang="en">Letter of the Emperors to
-                  <persName ref="http://syriaca.org/person/2432">Dioscorus</persName>, regarding <persName ref="http://syriaca.org/person/781">Theodoret of
-                   Cyrus</persName>
+                  <persName ref="http://syriaca.org/person/2432">Dioscorus</persName>, regarding <persName ref="http://syriaca.org/person/781">Theodoret of Cyrus</persName>
                 </title>
                 <note>See <bibl>Labbe, coll. 881—3</bibl>.
                 </note>
@@ -151,9 +150,7 @@
               <msItem xml:id="b3" n="4">
                 <locus from="3b"/>
                 <title xml:lang="en">Letter of the Emperors to the
-                  Council, regarding <persName ref="http://syriaca.org/person/534">Ibas of
-                    Edessa
-                  </persName>
+                  Council, regarding <persName ref="http://syriaca.org/person/534">Ibas of Edessa </persName>
                 </title>
               </msItem>
               <msItem xml:id="b4" n="5">
@@ -194,8 +191,7 @@
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="8a"/>
-                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/534">Ibas, bishop of
-                  <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/534">Ibas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘ̈ܦܡܢܡܛܐ ܕܗܘܘ ܠܘܩܒܠ ܗܝܒܐ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ ܡܕܝܢܬܐ</rubric>
@@ -248,8 +244,7 @@
                       <persName xml:lang="en">Ibas</persName>
                     </author>
                     <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/534">Ibas</persName> to <persName ref="http://syriaca.org/person/874">Mārī
-                    the Persian
-                    </persName>
+                    the Persian </persName>
                     </title>
                     <note>See <bibl>Labbe, t. iv., coll. 1573—80</bibl>.
                     </note>
@@ -261,8 +256,7 @@
                 <author ref="http://syriaca.org/person/2257">
                   <persName xml:lang="en">Daniel, bishop of Harran</persName>
                 </author>
-                <title xml:lang="en">Deposition (<foreign xml:lang="grc">καθαίρεσις</foreign>) of <persName ref="http://syriaca.org/person/2257">Daniel, bishop of
-                  <placeName ref="http://syriaca.org/place/216">Harran</placeName>
+                <title xml:lang="en">Deposition (<foreign xml:lang="grc">καθαίρεσις</foreign>) of <persName ref="http://syriaca.org/person/2257">Daniel, bishop of <placeName ref="http://syriaca.org/place/216">Harran</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܕܢܝܐܝܠ ܐܦܣܩܦܐ ܕܚܪܢ</rubric>
@@ -272,8 +266,7 @@
                 <author ref="http://syriaca.org/person/2463">
                   <persName xml:lang="en">Irenaeus, bishop of Tyre</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/847">Irenaeus, bishop of
-                  <placeName ref="http://syriaca.org/place/195">Tyre</placeName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/847">Irenaeus, bishop of <placeName ref="http://syriaca.org/place/195">Tyre</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܐܝܪܝܢܐܘܣ ܐܦܣܩܦܐ ܕܛܘܪܘܣ</rubric>
@@ -283,17 +276,14 @@
                 <author>
                   <persName xml:lang="en">Aquilinus, bishop of Byblos</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/844">Aquilinus, bishop of
-                  <placeName ref="http://syriaca.org/place/52">Byblos</placeName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/844">Aquilinus, bishop of <placeName ref="http://syriaca.org/place/52">Byblos</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܩܬܪܣܝܣ ܕܐܩܘܠܝܢܘܣ ܐܦܣܩܦܐ ܕܒܝܒܠܘܣ</rubric>
               </msItem>
               <msItem xml:id="b10" n="17">
                 <locus from="54a"/>
-                <title xml:lang="en">Action against <persName>Sophronius, bishop of
-                  <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or
-                  <placeName ref="http://syriaca.org/place/200">Constantina</placeName>
+                <title xml:lang="en">Action against <persName>Sophronius, bishop of <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or <placeName ref="http://syriaca.org/place/200">Constantina</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘܦܡ̈ܢܡܛܐ ܕܐܣܬܥܪܘ ܥܠ ܣܘܦܪܘܢ ܐܦܝܣܩܘܦܐ ܕܬܠܠܐ ܡܕܝܢܬܐ</rubric>
@@ -303,8 +293,7 @@
                 <author ref="http://syriaca.org/person/781">
                   <persName xml:lang="en">Theodoret, bishop of Cyrus</persName>
                 </author>
-                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/781">Theodoret, bishop of
-                  <placeName ref="http://syriaca.org/place/65">Cyrus</placeName>
+                <title xml:lang="en">Deposition of <persName ref="http://syriaca.org/person/781">Theodoret, bishop of <placeName ref="http://syriaca.org/place/65">Cyrus</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr"> ܩܬܪܣܝܣ ܕܬܐܕܘܪܝܛܐ ܐܦܣܩܦܐ ܕܩܘܪܘܣ</rubric>
@@ -330,8 +319,7 @@
                 <author>
                   <persName xml:lang="en">Domnus, bishop of Antioch</persName>
                 </author>
-                <title xml:lang="en">Adherence of <persName ref="http://syriaca.org/person/2264">Domnus, bishop of
-                  <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Adherence of <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>, by message, to the above
                   decisions</title>
               </msItem>
@@ -344,8 +332,7 @@
               </msItem>
               <msItem xml:id="b14" n="23" defective="true">
                 <locus from="79a"/>
-                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/2264">Domnus, bishop of
-                  <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Action against <persName ref="http://syriaca.org/person/2264">Domnus, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܗܘܦܡ̈ܢܡܛܐ ܕܐܣܬܥܪܘ ܠܘܩܒܠ ܕܘܡܢܘܣ ܐܦܣܩܘܦܐ ܕܐܢܛܝܘܟܝܐ</rubric>
@@ -389,8 +376,7 @@
                   <author ref="http://syriaca.org/person/2432">
                     <persName xml:lang="en">Dioscorus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of
-                    <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                  <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                     </persName> to
                     <persName ref="http://syriaca.org/person/2264">Domnus</persName>
                   </title>
@@ -448,8 +434,7 @@
               <msItem xml:id="b17" n="35">
                 <locus from="106b"/>
                 <title xml:lang="en">Part of a letter of the emperor
-                    <persName ref="http://syriaca.org/person/1529">Theodosius</persName> to <persName>Juvenalis, bishop of
-                      <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
+                    <persName ref="http://syriaca.org/person/1529">Theodosius</persName> to <persName>Juvenalis, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
                   </persName>, to the same effect as no.
                   34<!--JA: item 16 in the catalogue-->
                 </title>
@@ -458,8 +443,7 @@
               </msItem>
               <msItem xml:id="b18" n="36">
                 <locus from="107a"/>
-                <title xml:lang="en">Part of a letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of
-                  <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                <title xml:lang="en">Part of a letter of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                   </persName> to the various bishops, carrying
                   out the instructions contained in no. 34<!--JA: item 16 in the catlogue-->
                 </title>

--- a/data/tei/259.xml
+++ b/data/tei/259.xml
@@ -211,8 +211,7 @@
                       <title xml:lang="en">to the Monks</title>, beginning, <quote xml:lang="syr">ܐܬܘ̣ ܡ̇ܢ ܐܢܫ̈ܝܢ ܐܝܟ ܥܝܕܐ ܠܐܠܟܣܢܕܪܝܐ</quote>
                     fol. <locus from="28b">28 b</locus>; <title xml:lang="en">to Gennadius, <foreign xml:lang="syr">ܓܢܕ</foreign>
                     </title>, 
-                    fol. <locus from="31b">31 b</locus>; <title xml:lang="en">to <persName ref="http://syriaca.org/person/688">Proclus of
-                      Constantinople</persName>
+                    fol. <locus from="31b">31 b</locus>; <title xml:lang="en">to <persName ref="http://syriaca.org/person/688">Proclus of Constantinople</persName>
                     </title>, fol. <locus from="32a">32 a</locus>; <title xml:lang="en">to
                       <persName>Amphilochius of Side</persName>
                     </title>, <quote xml:lang="syr">ܡܛܠ ܐܘܟ̈ܝܛܐ ܗܠܝܢ ܕܡܬܩܪܝܢ
@@ -534,8 +533,7 @@
                     <quote xml:lang="syr">ܡܢ ܬܘܪܓܡܐ ܕܐܡ̣ܪ ܥܠ ܒܐܡܐ ܕܥܕܬܐ ܩܕܝܫܬܐ̣. ܟܕ ܣܡ
                             ܦܬܓܡܐ ܕܡܢ ܐܫܥܝܐ ܐܝܟ ܕܠܢܘܗ̇ܪܗ. ܕܐܝܬܘܗܝ ܒ̇ܠ̣ܥ ܡܘܬܐ ܟܕ ܐܬ̇ܚܝܠ</quote>,
                     fol. <locus from="36a">36 a</locus>;
-                    <title xml:lang="en">letter to <persName>Acacius of
-                      Scythopolis</persName>
+                    <title xml:lang="en">letter to <persName>Acacius of Scythopolis</persName>
                     </title>, fol. <locus from="44b">44 b</locus>;
                     <title xml:lang="en">1st letter
                         to <persName>Succensus</persName>
@@ -1098,8 +1096,7 @@
                 <msItem xml:id="c4" n="9">
                   <locus from="194a"/>
                   <title xml:lang="en">A chapter showing, in five sections, that the
-                    doctrines of <persName ref="http://syriaca.org/person/576">Joannes Grammaticus
-                      (or Philoponus)</persName> are opposed to Scripture and to the Fathers</title>
+                    doctrines of <persName ref="http://syriaca.org/person/576">Joannes Grammaticus (or Philoponus)</persName> are opposed to Scripture and to the Fathers</title>
                   <rubric xml:lang="syr">ܛܘܡܣܐ ܕܒܙܥܘܪ̈ܝܬܐ ܡ̇ܚܘܐ̇. ܣܩܒܠܝܘܬܐ ܕܝܘܚܢܢ ܓܪܡܛܝܩܘܣ ܘܕܒ̈ܢܝ
                     ܬܪܥܝܬܗ̇. ܠܘܬ ܟ̈ܬܒܐ ܐܠܗ̈ܝܐ̇. ܘܐܒ̈ܗܬܐ ܩܕ̈ܝܫܐ.</rubric>
                   <note>

--- a/data/tei/259.xml
+++ b/data/tei/259.xml
@@ -165,8 +165,7 @@
                     <persName ref="http://syriaca.org/person/573">Chrysostom</persName>: <quote xml:lang="syr">ܡܢ ܡ܏ܐ ܕܥܠ ܒܝܬ ܝܠܕܐ</quote>,
                     fol. <locus from="10a">10 a</locus>; <title xml:lang="en">hom. ii. on <ref target="http://syriaca.org/work/9641">the Gospel of S.
                       John</ref>
-                    </title>, fol. <locus from="10a">10 a</locus>; <title xml:lang="en">hom. i. on <ref target="http://syriaca.org/work/9594">the
-                      Epistle to the Romans</ref>
+                    </title>, fol. <locus from="10a">10 a</locus>; <title xml:lang="en">hom. i. on <ref target="http://syriaca.org/work/9594">the Epistle to the Romans</ref>
                     </title>, fol. <locus from="10a">10 a</locus>; <title xml:lang="en">hom. xxxvi ii. on <ref target="http://syriaca.org/work/9595">1 Corinthians</ref>
                     </title>, fol. <locus from="11b">11 b</locus>; <title xml:lang="en">hom. iii. on <ref target="http://syriaca.org/work/9600">the Epistle to the Colossians</ref>
                     </title>, fol.
@@ -607,8 +606,7 @@
                     </title>, foll. <locus from="42a">42 a</locus>, <locus from="50a">50 a</locus>, <locus from="62b">62 b</locus>.</p>
                   <p>
                     <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>:
-                    <title xml:lang="en">comment. on <ref>the Song
-                    of Songs</ref>
+                    <title xml:lang="en">comment. on <ref>the Song of Songs</ref>
                     </title>, foll. <locus from="37a">37 a</locus>, <locus from="93b">93 b</locus>, <locus from="94a">94 a</locus>;
                     <title xml:lang="en">homilies on the Beatitudes</title>, <quote xml:lang="syr">ܛܘ̈ܒܐ</quote>,
                     foll. <locus from="49b">49 b</locus>, <locus from="54b">54 b</locus>;
@@ -843,8 +841,7 @@
                     <title xml:lang="en">on <ref target="http://syriaca.org/work/9640">Isaiah</ref>
                     </title>, fol. <locus from="135a">135 a</locus>;
                     <title xml:lang="en">on the Gospel of S. John</title>, foll. <locus from="100b">100 b</locus>, <locus from="102a">102 a</locus>, <locus from="115b">115 b</locus>, <locus from="124a">124 a</locus>, <locus from="125a">125 a</locus>, <locus from="126a">126 a</locus>, <locus from="139b">139 b</locus>;
-                    <title xml:lang="en">on <ref target="http://syriaca.org/work/9607">the Epistle to
-                          the Hebrews</ref>
+                    <title xml:lang="en">on <ref target="http://syriaca.org/work/9607">the Epistle to the Hebrews</ref>
                     </title>, fol. <locus from="154a" to="b">154 a and b</locus>;
                     <title xml:lang="en">Thesaurus</title>, foll. <locus from="104a">104 a</locus>, <locus from="119a">119 a</locus>, <locus from="123a">123 a</locus>, <locus from="125b">125 b</locus>, <locus from="126b">126 b</locus>;
                     <quote xml:lang="syr">ܬܫܡܫܬܐ ܕܪܘܚ</quote>, foll. <locus from="96b">96 b</locus>, <locus from="156a">156 a</locus>;

--- a/data/tei/260.xml
+++ b/data/tei/260.xml
@@ -239,9 +239,7 @@
                     <quote xml:lang="syr">ܡܢ ܣܝܡ̇ܐ ܕܡܛܠ ܬܠܝܬܝܘܬܐ ܩܕܝܫܬܐ̣. ܘܡܛܠ ܡܬܒܪܢܫܢܘܬܗ ܕܡܠܬܐ. ܘܠܘܩܒܠ
                     ܐܦܘܠܘܢܝܪ̈ܣܛܐ.</quote>, foll. <locus from="25b">25 b</locus>, <locus from="26b">26 b</locus>;
                     <title xml:lang="en">letter to
-                      <persName ref="http://syriaca.org/person/2549">
-                        Adelphius, <foreign xml:lang="syr">ܐܕܠܦ</foreign>
-                      </persName>
+                      <persName ref="http://syriaca.org/person/2549">Adelphius, <foreign xml:lang="syr">ܐܕܠܦ</foreign></persName>
                     </title>,
                     fol. <locus from="26b">26 b</locus>.</p>
                   <p>
@@ -967,9 +965,7 @@
                 <p>
                   <persName ref="http://syriaca.org/person/51">Severus</persName>: 
                   <title xml:lang="en">letter to 
-                    <persName ref="http://syriaca.org/person/2681">
-                      John of Bostra, <foreign xml:lang="syr">ܝܘܚܢܢ ܒܘܨܪܐ</foreign>
-                    </persName>
+                    <persName ref="http://syriaca.org/person/2681">John of Bostra, <foreign xml:lang="syr">ܝܘܚܢܢ ܒܘܨܪܐ</foreign></persName>
                   </title>, fol. <locus from="167a">167 a</locus>; 
                   <title xml:lang="en">to <persName ref="http://syriaca.org/person/2443">Constantine of Laodicea</persName>
                     </title>, fol. <locus from="167b">167 b</locus>; 
@@ -1152,10 +1148,8 @@
                   <title xml:lang="en">to <persName ref="http://syriaca.org/person/2769">Theophanes</persName>
                     </title>, fol. <locus from="175b">175 b</locus>;
                   <title xml:lang="en">to the chamberlain 
-                    <persName>
-                      Amantius, <foreign xml:lang="syr">ܐܡܢܛܝܘܣ
-                        ܩܒܘܩܠܪܐ</foreign>
-                    </persName>
+                    <persName>Amantius, <foreign xml:lang="syr">ܐܡܢܛܝܘܣ
+                        ܩܒܘܩܠܪܐ</foreign></persName>
                     </title>, fol. <locus from="176a">176 a</locus>.</p>
                 <p>
                     <persName>
@@ -1175,9 +1169,7 @@
                 rebaptism of heretics, when they return to the orthodox faith</title>
                 <note>Here is cited 
                   <title>a letter of <persName>Cyprian</persName> to
-                    <persName ref="http://syriaca.org/person/2742">
-                      Quintus, <foreign xml:lang="syr">ܩܘܐܝܢܛܘܣ</foreign>
-                    </persName>
+                    <persName ref="http://syriaca.org/person/2742">Quintus, <foreign xml:lang="syr">ܩܘܐܝܢܛܘܣ</foreign></persName>
                   </title>.
                 </note>
               </msItem>

--- a/data/tei/260.xml
+++ b/data/tei/260.xml
@@ -1112,8 +1112,7 @@
                   <title xml:lang="en">of Antioch</title>, foll. <locus from="173b">173 b</locus>, <locus from="175a">175 a</locus>.</p>
                 <p>
                     <persName ref="http://syriaca.org/person/573">Chrysostom</persName>: 
-                    <title xml:lang="en">on <ref target="http://syriaca.org/work/9598">the Epistle to the
-                      Ephesians</ref>
+                    <title xml:lang="en">on <ref target="http://syriaca.org/work/9598">the Epistle to the Ephesians</ref>
                     </title>. Fol. <locus from="176b">176 b</locus>.</p>
                 <p>
                     <persName ref="http://syriaca.org/person/423">Clement of Rome</persName>: 

--- a/data/tei/260.xml
+++ b/data/tei/260.xml
@@ -130,15 +130,12 @@
                   <p>The following writers are cited:</p>
                 <p>
                     <persName>Alexander of Mabūg</persName>:
-                    <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/1557">Acacius of
-                      Aleppo</persName>
+                    <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/1557">Acacius of Aleppo</persName>
                     </title>, fol. <locus from="14a">14 a</locus>; <title xml:lang="en">letter to
-                      <persName>John of
-                    Antioch</persName>
+                      <persName>John of Antioch</persName>
                     </title>, fol. <locus from="15b">15 b</locus>.</p>
                 <p>
-                    <persName>Andrew of Samosata</persName>: <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/26">Rabūlas of
-                      Edessa</persName>
+                    <persName>Andrew of Samosata</persName>: <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/26">Rabūlas of Edessa</persName>
                     </title>. Fol. <locus from="13b">13 b</locus>.</p>
                 <p>
                     <persName ref="http://syriaca.org/person/354">Athanasius</persName>: 
@@ -429,8 +426,7 @@
                 <p>
                     <persName ref="http://syriaca.org/person/51">Severus</persName>: 
                     <title xml:lang="en">against
-                      <persName ref="http://syriaca.org/person/2688">Joannes
-                    Grammaticus</persName>
+                      <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus</persName>
                     </title>, foll. <locus from="89b">89 b</locus>, <locus from="90a" to="90b">90 a and b</locus>, <locus from="91a">91 a</locus>;
                     <quote xml:lang="syr">ܒܡܐܡܪܐ ܕܬܪ̈ܝܢ ܕܠܘܬ
                     ܢܦܠܝܘܣ</quote>, fol. <locus from="90b">90 b</locus>;
@@ -459,9 +455,7 @@
                 <author>
                   <persName xml:lang="en">Thomas, of the convent of Mār Bassus</persName>
                 </author>
-                <title xml:lang="en">Questions proposed to <persName ref="http://syriaca.org/person/2688">Joannes
-                  Grammaticus</persName> by <persName>Thomas, of the convent of Mār
-                    Bassus</persName>, when he was at <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                <title xml:lang="en">Questions proposed to <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus</persName> by <persName>Thomas, of the convent of Mār Bassus</persName>, when he was at <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                 </title>
                 <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܕܗܘ̣ܘ ܡܢ ܬܐܘܡܐ ܕܥܡ̣ܪ ܒܝܬ ܡܪܝ ܒܣ܆ ܟܕ ܗ̣ܘ ܒܐܠܟܣܢܕܪܝܐ̣ ܠܘܬ
                 ܝܘܚܢܢ ܓܪܡܛܝܩܣ.</rubric>
@@ -590,8 +584,7 @@
               </msItem>
               <msItem xml:id="b13" n="20">
                 <locus from="106a"/>
-                <title xml:lang="en">Questions addressed to the followers of <persName ref="http://syriaca.org/person/831">Joannes
-                  Barbūr</persName> and <persName>Probus</persName>
+                <title xml:lang="en">Questions addressed to the followers of <persName ref="http://syriaca.org/person/831">Joannes Barbūr</persName> and <persName>Probus</persName>
               </title>
                 <rubric xml:lang="syr">ܬܒ̈ܥܬܐ ܕܬܒ̇ܥ ܐܢܫ̣ ܠܕܒܝܬ ܒܪܒܘܪ ܘܦܪܘܒܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. ii., pp. 72, seqq.</bibl>
@@ -699,8 +692,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName>Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extract from <persName>Gregory Nazianzen</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܗ̇ܘ ܕܥܠ ܪܘܚܐ ܩܕܝܫܐ</rubric>
                 </msItem>
@@ -719,8 +711,7 @@
                   <author ref="http://syriaca.org/person/423">
                     <persName xml:lang="en">Clemens Stromateus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName>Clemens Stromateus of
-                    Alexandria</persName>
+                  <title xml:lang="en">Extracts from <persName>Clemens Stromateus of Alexandria</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܩܠܡܝܣ ܣܛܪܘܡܛܘܣ̣. ܫܘܠܡ ܡܐܡܪܐ ܕܬܡܢܝܐ</rubric>
                 </msItem>
@@ -774,15 +765,13 @@
               </msItem>
               <msItem xml:id="b24" n="46">
                 <locus from="140a"/>
-                <title xml:lang="en">Questions against <persName ref="http://syriaca.org/person/831">Joannes
-                Barbūr</persName>, with an extract from that writer
+                <title xml:lang="en">Questions against <persName ref="http://syriaca.org/person/831">Joannes Barbūr</persName>, with an extract from that writer
                 </title>
                 <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܕܐܪ̈ܬܕܘܟܣܘܼ ܠܘܩܒܠ ܬܪܥܝܬܐ ܕܒܪܒܘܪ.</rubric>
               </msItem>
               <msItem xml:id="b25" n="47">
                 <locus from="140a"/>
-                <title xml:lang="en">Objections to the views of <persName>Sergius the
-                Armenian</persName>, consisting of extracts from the Apology of <persName ref="http://syriaca.org/person/1330">Julian,
+                <title xml:lang="en">Objections to the views of <persName>Sergius the Armenian</persName>, consisting of extracts from the Apology of <persName ref="http://syriaca.org/person/1330">Julian,
                   patriarch of Antioch</persName>
                 </title>
                 <rubric xml:lang="syr">ܗܦܟ̈ܬܐ ܠܘܩܒܠ ܬܪܥܝܬܐ ܪܫܝܥܬܐ ܕܣܪܓܝܣ ܐܪܡܢܝܐ̣. ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܥܒ̣ܕ
@@ -805,9 +794,7 @@
               </msItem>
               <msItem xml:id="b28" n="50">
                 <locus from="147b"/>
-                <title xml:lang="en">Against the heresy of <persName ref="http://syriaca.org/person/1196">Damian of
-                Alexandria</persName>, being extracts from the treatise of <persName ref="http://syriaca.org/person/1414">Peter of
-                  Antioch</persName>
+                <title xml:lang="en">Against the heresy of <persName ref="http://syriaca.org/person/1196">Damian of Alexandria</persName>, being extracts from the treatise of <persName ref="http://syriaca.org/person/1414">Peter of Antioch</persName>
                 </title>
                 <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܘܗܦܟ̈ܬܐ̣ ܘܫܪܟܐ: ܕܠܘܩܒܠ ܗܪܣܝܣ ܪܫܝܥܬܐ ܕܕܡܝܢܐ̣. ܕܫܩܝܠܝ̣ܢ ܡܢ
                 ܡܟܬܒܢܘܬܐ ܕܠܩܘܒܠܗ̇. ܕܩܕܝܫܐ ܦܛܪܘܣ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ.</rubric>
@@ -817,8 +804,7 @@
                 <persName ref="http://syriaca.org/person/430">Cyril</persName>,
                     foll. <locus from="157a" to="157b">157 a and b</locus>, <locus from="159b">159 b</locus>;
                 <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>, fol. <locus from="157b">157 b</locus>;
-                and <persName ref="http://syriaca.org/person/51">Severus</persName>, <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/2513">Constantine of
-                      Seleucia</persName> in <placeName ref="http://syriaca.org/place/2799">Isauria</placeName>
+                and <persName ref="http://syriaca.org/person/51">Severus</persName>, <title xml:lang="en">letter to <persName ref="http://syriaca.org/person/2513">Constantine of Seleucia</persName> in <placeName ref="http://syriaca.org/place/2799">Isauria</placeName>
                     </title>, fol. <locus from="159b">159 b</locus>, and <title xml:lang="en">treatise against <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus</persName>
                     </title>, fol. <locus from="160b">160 b</locus>.</note>
               </msItem>
@@ -827,8 +813,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName>Gregory
-                Nazianzen</persName>
+                <title xml:lang="en">Extracts from <persName>Gregory Nazianzen</persName>
                 </title>
                 <rubric xml:lang="syr">ܟܪ̈ܣܝܣ ܡܛܠ ܬܐܘܠܘܓܝܐ</rubric>
                 <msItem xml:id="c20" n="52">
@@ -869,8 +854,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extracts from the discourse of <persName>Gregory
-                  Nazianzen</persName> on Baptism</title>
+                <title xml:lang="en">Extracts from the discourse of <persName>Gregory Nazianzen</persName> on Baptism</title>
                 <rubric xml:lang="syr">ܢܘܗܪܐ ܕܟܘ̈ܢܝܐ ܕܡܥܡܘܕܝܬܐ ܩܕܝܫܬܐ̣. ܘܡܠܦܢܘܬܐ ܠܘܬ ܗ̇ܘ
                 ܕܥܡ̇ܕ</rubric>
               </msItem>
@@ -961,8 +945,7 @@
               </msItem>
               <msItem xml:id="b40" n="66" defective="true">
                 <locus from="167a"/>
-                <title xml:lang="en">Against the followers of <persName ref="http://syriaca.org/person/72">Paul of
-                  Beth-Ukkāmē</persName>
+                <title xml:lang="en">Against the followers of <persName ref="http://syriaca.org/person/72">Paul of Beth-Ukkāmē</persName>
                 </title>
                 <rubric xml:lang="syr">ܟܘܢܫܐ̣ ܠܘܩܒܠ ܗܠܝܢ ܕܒܝܬ ܦܘܠܐ܀ ܫܪܝܐ ܡ̇ܢ ܕܡ̈ܠܝܗܘܢ ܕܗ̇ܢܘܢ ܕܒܝܬ
                 ܦܘܠܐ: ܘܩܛܪܓܐ ܕܝܠܢ ܕܠܘܩܒܠܗܘܢ̣. ܡܢܗ ܘܠܗ ܣܝܡ ܒܟܬܒܐ ܐܚܪܢܐ. ܫܘܪܪܐ ܕܝܢ ܕܫܪܝܐ ܕܡ̈ܠܝܗܘܢ
@@ -988,8 +971,7 @@
                       John of Bostra, <foreign xml:lang="syr">ܝܘܚܢܢ ܒܘܨܪܐ</foreign>
                     </persName>
                   </title>, fol. <locus from="167a">167 a</locus>; 
-                  <title xml:lang="en">to <persName ref="http://syriaca.org/person/2443">Constantine of
-                      Laodicea</persName>
+                  <title xml:lang="en">to <persName ref="http://syriaca.org/person/2443">Constantine of Laodicea</persName>
                     </title>, fol. <locus from="167b">167 b</locus>; 
                   <title xml:lang="en">to <persName>Dionysius of Tarsus</persName>
                     </title>, <quote xml:lang="syr">ܡܢ
@@ -1094,8 +1076,7 @@
                     <title xml:lang="en">to <persName>Eulogius</persName>
                     </title>, foll. <locus from="170b">170
                           b</locus>, <locus from="171b">171 b</locus>; 
-                    <title xml:lang="en">to <persName>John of
-                            Antioch</persName>
+                    <title xml:lang="en">to <persName>John of Antioch</persName>
                     </title>, fol. <locus from="171a">171 a</locus>; 
                     <title xml:lang="en">to
                       <persName>Valerian of Iconium</persName>
@@ -1108,8 +1089,7 @@
                       a</locus>.</p>
                 <p>
                     <persName ref="http://syriaca.org/person/51">Severus</persName>: 
-                    <title xml:lang="en">against <persName ref="http://syriaca.org/person/2688">Joannes
-                      Grammaticus</persName>
+                    <title xml:lang="en">against <persName ref="http://syriaca.org/person/2688">Joannes Grammaticus</persName>
                     </title>, foll. <locus from="170a" to="170b">170 a and b</locus>, <locus from="171b">171 b</locus>;
                     <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܩܣܝܢܐ ܘܩܘܣܛܢܛܝܢܐ
                     ܘܐܢܛܘܢܝܢܐ̇. ܘܕܫܪܟܐ ܐܦܣܩ̈ܘܦܐ ܕܬܚܝܬ ܟܘܪܣܝܐ ܫܠܝܚܝܐ ܕܐܢܛܝܘܟܝܐ. ܗܫܐ ܕܝܢ ܡܕܝܪܝ̣ܢ
@@ -1119,8 +1099,7 @@
               </msItem>
               <msItem xml:id="b43" n="69" defective="true">
                 <locus from="172a"/>
-                <title xml:lang="en">Charges made by the followers of <persName ref="http://syriaca.org/person/72">Paul of
-                  Beth-Ukkāmē</persName>, with replies to them</title>
+                <title xml:lang="en">Charges made by the followers of <persName ref="http://syriaca.org/person/72">Paul of Beth-Ukkāmē</persName>, with replies to them</title>
                 <rubric xml:lang="syr">ܥܕܠܝܐ ܕܒܝܬ ܦܘܠܐ ܘܫܪܝܗܘܢ̣ ܘܩ̈ܦܠܐܐ ܕܠܘܩܒܠܗܘܢ</rubric>
                 <incipit xml:lang="syr">ܕܟܠ ܡܠܬܐ ܡ̇ܢ ܕܬܪ̈ܬܝܢ ܐܝܬܝܗ̇: ܚܕܐ ܡ̇ܢ ܕܗ̇ܝ ܕܝܠܗ̇ ܣܝܡܐ: ܐܚܪܬܐ
                 ܕܝܢ ܕܗ̇ܝ ܕܠܩܘܒܠܐ ܗܦܟܐ̣. ܡܢ ܓܪܝܓܘܪܝܘܣ ܝܠܦܢܢ. ܚܢܢ ܗܟܝܠ ܩܕܡܐܝܬ݂. ܠܡ̈ܠܐ ܕܠܩܘܒܠܢ ܡܢ ܗܠܝܢ
@@ -1159,8 +1138,7 @@
                     <quote xml:lang="syr">ܒܐܓܪܬܐ ܕܥܒ̣ܕ ܨܝܕ ܡܪܝ
                     ܝܥܩܘܒ</quote>. Fol. <locus from="174a">174 a</locus>.</p>
                 <p>
-                    <persName ref="http://syriaca.org/person/688">Proclus of Constantinople</persName>: <title xml:lang="en">letter to <persName>John
-                      of Antioch</persName>
+                    <persName ref="http://syriaca.org/person/688">Proclus of Constantinople</persName>: <title xml:lang="en">letter to <persName>John of Antioch</persName>
                     </title>. Fol. <locus from="176b">176 b</locus>.</p>
                 <p>
                     <persName ref="http://syriaca.org/person/51">Severus</persName>: 
@@ -1228,8 +1206,7 @@
                   </title>
                   <rubric xml:lang="syr">ܡܛܠ ܩܘܒܠܗ ܕܐܘܛܝܟܐ̣ ܘܫܪܟܐ</rubric>
                   <note>Extracts from letters of
-                  <persName ref="http://syriaca.org/person/51">Severus</persName> <title xml:lang="en">to <persName>the priest and abbat
-                    Leo</persName>
+                  <persName ref="http://syriaca.org/person/51">Severus</persName> <title xml:lang="en">to <persName>the priest and abbat Leo</persName>
                     </title>; <title xml:lang="en">to the physician <persName>Sergius</persName>
                     </title>,
                     <quote xml:lang="syr">ܠܚܟܝܡܐ ܘܕܒܟܠܡܕܡ ܪܚܡ ܐܠܗܐ ܣܪܓܝܣ ܐܣܝܐ ܣܘܦܣܛܐ</quote>;
@@ -1284,8 +1261,7 @@
                 <author ref="http://syriaca.org/person/513">
                   <persName xml:lang="en">Gregory Thaumaturgus</persName>
                 </author>
-                <title xml:lang="en">Short extracts from <persName>Gregory
-                  Thaumaturgus</persName>
+                <title xml:lang="en">Short extracts from <persName>Gregory Thaumaturgus</persName>
                 </title>
                 <rubric xml:lang="syr">ܡ̈ܠܐ ܕܡܫ̈ܬܩܠܢ ܒ̈ܢܝܫܐ ܡܫܚ̈ܠܦܐ̣. ܕܓܪܝܓܘܪܝܘܣ ܥܒ̇ܕ ܬܕܡܪ̈ܬܐ</rubric>
                 <msItem xml:id="c26" n="80">
@@ -1339,8 +1315,7 @@
                 <author ref="http://syriaca.org/person/841">
                   <persName xml:lang="en">Damasus, bishop of Rome</persName>
                 </author>
-                <title xml:lang="en">The Synodicon of <persName>Damasus, bishop of
-                  Rome</persName>, against various heresies</title>
+                <title xml:lang="en">The Synodicon of <persName>Damasus, bishop of Rome</persName>, against various heresies</title>
                 <rubric xml:lang="syr">ܣܘܢܗܕܝܩܘܢ ܕܩܕܝܫܐ ܕܘܡܣܘܣ ܪܫܐ ܕܐܦܣܩ̈ܘܦܐ ܕܪܗܘܡܐ̣. ܠܘܩܒܠ ܟܠ ܗܪ̈ܣܝܣ
                 ܡܫܚ̈ܠܦܬܐ̣. ܠܘܬ ܦܠܘܝܢܐ ܐܦܣܩܦܐ ܕܗܘ̣ܐ ܒܬܣܠܘܢܝܩܐ.</rubric>
                 <note>See <bibl>Add. 14,529<ptr target="https://bl.syriac.uk/ms/256"/>, fol. <citedRange unit="fol">1 b</citedRange>

--- a/data/tei/263.xml
+++ b/data/tei/263.xml
@@ -614,8 +614,7 @@
               </msItem>
               <msItem xml:id="b20" n="71">
                 <locus from="45a"/>
-                <title xml:lang="en">The <ref>Acts of the <persName>Apostles</persName>
-                  </ref>, <ref>the Apostle (i.e. the epistles of <persName>S. Paul</persName>)</ref>, and <ref>the Gospel</ref>
+                <title xml:lang="en">The <ref>Acts of the <persName>Apostles</persName></ref>, <ref>the Apostle (i.e. the epistles of <persName>S. Paul</persName>)</ref>, and <ref>the Gospel</ref>
                 </title>
               </msItem>
               <msItem xml:id="b21" n="72">

--- a/data/tei/265.xml
+++ b/data/tei/265.xml
@@ -375,8 +375,7 @@
               <msItem xml:id="b8" n="10" defective="true">
                 <locus from="67a"/>
                 <title xml:lang="en">Exposition of the holy Mysteries of the Church,
-                  principally compiled from the works of <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName>
+                  principally compiled from the works of <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>
                 </title>
                 <rubric xml:lang="syr">ܦܘܫܩܐ ܕܪ̈ܐܙܐ ܩܕܝ̈ܫܐ ܕܥܕܬܐ̣. ܕܡ̇ܟܢܫ ܠܐܢܫ ܪܚ̇ܡ ܥܡ̈ܠܐ ܘܡܠܝ̣ܠܐ̣.
                   ܡܢ ܟܬܒܐ ܕܪܒܐ ܕܝܢܘܣܝܘܣ̣. ܕܥܒ̣ܝܕ ܒܙܥܘܪ̈ܝܬܐ. ܣܘܟܠܐ ܒܠܚܘܕ ܕܗ̇ܘ ܡܐ ܕܠܡܠܦܢܐ ܒܡܡܠܐ ܐܪܝܟܐ
@@ -428,8 +427,7 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus</persName>
                 </author>
-                <title xml:lang="en">On a passage of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                <title xml:lang="en">On a passage of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܣܐܘܪܐ ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܩܣܪܝܐ. ܡܛܠ ܗ̇ܝ ܕܐܡܝܪܐ ܠܓܪܝܓܪܝܘܣ
                   ܬܐܘܠܓܘܣ. ܒܡܐܡܪܐ ܕܬܪܝܢ ܡܫܝܢܢܐ. ܏ܘܫ</rubric>

--- a/data/tei/27.xml
+++ b/data/tei/27.xml
@@ -122,9 +122,7 @@
                 <persName xml:lang="en">George of Scythopolis</persName>
               </author>
               <title xml:lang="en">The works of <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>,
-                with the prefaces and notes of <persName ref="http://syriaca.org/person/130">Phocas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>, <persName ref="http://syriaca.org/person/2525">Joannes Scholasticus</persName> and <persName>George of <placeName ref="http://syriaca.org/place/180">Scythopolis</placeName>
-                </persName>
+                with the prefaces and notes of <persName ref="http://syriaca.org/person/130">Phocas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>, <persName ref="http://syriaca.org/person/2525">Joannes Scholasticus</persName> and <persName>George of <placeName ref="http://syriaca.org/place/180">Scythopolis</placeName></persName>
               </title>
               <colophon>See below.</colophon>
               <note>As in Add. 12,151.</note>

--- a/data/tei/277.xml
+++ b/data/tei/277.xml
@@ -213,8 +213,7 @@
                 <msItem xml:id="c8" n="12">
                   <locus from="97b" to="105">Foll. 97b-105</locus>
                   
-                  <title>On his own discourses, and on <persName>Julian the <foreign xml:lang="grc">ἐξισώτης</foreign>
-                    </persName>
+                  <title>On his own discourses, and on <persName>Julian the <foreign xml:lang="grc">ἐξισώτης</foreign></persName>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܡܐܡܪܐ ܘܥܠ ܝܘܠܝܢܐ ܐܘܟܣܣܘܛܘܣ<locus from="97b"/>
                   </rubric>

--- a/data/tei/278.xml
+++ b/data/tei/278.xml
@@ -370,10 +370,7 @@
                 <note>As an appendix there are added the following pieces:</note>
                 <msItem xml:id="c32" n="37">
                   <locus from="236b" to="240">Foll. 236b-240</locus>
-                  <title>Extracts from the writings of <persName>Severus, bishop of <supplied reason="illegible" resp="https://bl.syriac.uk/documentation/editors.xml#wwright">
-                        <placeName>Nisibis</placeName>
-                      </supplied>
-                    </persName>(?),<sic>ܢܨܝܒܢܝܐ</sic>ܐܦܝܣܩܘܐ</title>
+                  <title>Extracts from the writings of <persName>Severus, bishop of <supplied reason="illegible" resp="https://bl.syriac.uk/documentation/editors.xml#wwright"><placeName>Nisibis</placeName></supplied></persName>(?),<sic>ܢܨܝܒܢܝܐ</sic>ܐܦܝܣܩܘܐ</title>
                   <msItem xml:id="d3" n="38">
                     <locus from="236b" to="239">Foll. 236b-239</locus>
                     

--- a/data/tei/278.xml
+++ b/data/tei/278.xml
@@ -378,9 +378,7 @@
                       <persName>Sergius</persName>, abbat of 
                       <placeName><foreign xml:lang="syr">ܫܓܪ</foreign>, Singār</placeName> on the 
                       first discourse of <persName ref="http://syriaca.org/person/511">Gregory</persName>
-                      <title xml:lang="la">
-                        <quote xml:lang="la">de Filio</quote>
-                      </title>
+                      <title xml:lang="la"><quote xml:lang="la">de Filio</quote></title>
                     </title>
                     <rubric xml:lang="syr">ܩܫܝܫܐ ܘܪܝܫܕܝܪܐ ܕܟܢܘܫܝܐ ܩܕܝܫܐ ܕܫܓܪ ܡܪܝ ܣܪܓܝܣ<locus from="236b"/>
                     </rubric>
@@ -389,9 +387,7 @@
                     <locus from="239a" to="240">Foll. 239a-240</locus>
                     
                     <title>On the discourse of <persName ref="http://syriaca.org/person/511">Gregory</persName>
-                      <title>
-                        <quote xml:lang="la">de Spiritu Sancto</quote>
-                      </title>
+                      <title><quote xml:lang="la">de Spiritu Sancto</quote></title>
                     </title>
                   </msItem>
                 </msItem>

--- a/data/tei/288.xml
+++ b/data/tei/288.xml
@@ -283,8 +283,7 @@
                 <author ref="http://syriaca.org/person/354">
                   <persName xml:lang="en">Athanasius of Alexandria</persName>
                 </author>
-                <title>The epistle of Athanasius to <persName>Epictetus, bishop of <placeName>Corinth</placeName>
-                  </persName>
+                <title>The epistle of Athanasius to <persName>Epictetus, bishop of <placeName>Corinth</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܐܓܪܬܐ ܕܐܬܟܬܒܬ ܠܛܘܒܢܐ ܐܦܝܩܛܛܘܣ ܐܦܣܩܦܐ. ܕܩܘܪܢܬܘܣ̣. ܡܢ ܩܕܝܫܐ ܐܬܢܣܝܣ ܐܦܣܩܦܐ ܕܐܠܟܣܢܕܪܝܐ̣. ܗ̇ܘ ܕܡܢ ܐܪ̈ܝܢܘ ܥܠ ܐ̈ܦܝ ܗܝܡܢܘܬܐ ܫܪܝܪܬܐ̣. ܪܕܘܦܝܐ ܣܝܒܪ̣ ܘܐܬܢܨܚ ܒܡܘܕܝܢܘܬܐ.<locus from="154a"/>
                 </rubric>
@@ -297,9 +296,7 @@
                 <author>
                   <persName xml:lang="en">The bishops of Armenia</persName>
                 </author>
-                <title>Libellus sent by the bishops of <placeName ref="http://syriaca.org/place/576">Armenia</placeName> to <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName>, concerning the writings of <persName ref="http://syriaca.org/person/780">Theodore of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName>
-                  </persName>
+                <title>Libellus sent by the bishops of <placeName ref="http://syriaca.org/place/576">Armenia</placeName> to <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>, concerning the writings of <persName ref="http://syriaca.org/person/780">Theodore of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">
                   <sic>ܦܚܡܐ ܕܠܝܒܠܘܢ ܕܐܬܝܗܒ ܡܢ ܐܦܣܩ̈ܦܐ ܘܩܫ̈ܝܫܐ ܕܐܝܬ ܒܐܪܡܢܝܐ ܪܒܬܐ ܠܦܪܘܩܠܘܣ ܐܦܣܩܦܐ ܡܗܝܡܢܐ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ. ܡܛܠ ܟܬܒܘ̈ܗܝ ܕܬܐܕܘܪܘܣ ܕܡܦܣܝܣܣܛܐ</sic>

--- a/data/tei/29.xml
+++ b/data/tei/29.xml
@@ -1425,8 +1425,7 @@
                 </msItem>
                 <msItem xml:id="c59" n="132">
                   <locus from="153b"/>
-                  <title xml:lang="en">A short biography of <persName>Alexander the
-                    Great</persName>
+                  <title xml:lang="en">A short biography of <persName>Alexander the Great</persName>
                 </title>
                   <rubric xml:lang="syr">ܒܝܘܣ ܐܘ ܟܝܬ ܕܘܒܪܐ ܐܝܟ ܕܒܦܣ̈ܝܩܬܐ̣ ܕܐܠܟܣܢܕܪܘܣ ܡ̇ܠܟܐ
                   ܕܡܩ̈ܕܘܢܝܐ.</rubric>
@@ -1674,10 +1673,8 @@
                         <persName xml:lang="en">Andrew of Samosata</persName>
                       </author>
                       <title xml:lang="en">A letter written by <persName>Alexander of Mabūg</persName> and
-                      <persName>Andrew of Samosata</persName> to <persName ref="http://syriaca.org/person/2449">John of
-                        Antioch</persName> and <persName ref="http://syriaca.org/person/781">Theodoret of Cyrus</persName>,
-                      concerning <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName> and <persName>Jacob of
-                        Kaphrā Rěhīmā</persName>
+                      <persName>Andrew of Samosata</persName> to <persName ref="http://syriaca.org/person/2449">John of Antioch</persName> and <persName ref="http://syriaca.org/person/781">Theodoret of Cyrus</persName>,
+                      concerning <persName ref="http://syriaca.org/person/744">Simeon Stylites</persName> and <persName>Jacob of Kaphrā Rěhīmā</persName>
                     </title>
                       <rubric xml:lang="syr">ܬܘܒ ܐܓܪܬܐ ܕܟܬ̣ܒܘ ܐܠܟܣܢܪܘܣ ܕܡܒܘܓ ܘܐܢܕܪܝܐ ܕܫܡܝܫܛ: ܠܘܬ ܝܘܚܢܢ ܕܐܢܛܝܘܟܝܐ ܘܬܐܘܕܘܪܝܛܐ
                       ܕܩܘܪܘܣ̣. ܡܛܠܬܗ ܕܩܕܝܫܐ ܡܪܝ ܫܡܥܘܢ̣. ܘܡܛܠ ܡܪܝ ܝܥܩܘܒ ܕܟܦܪܐ ܪܚܝܡܐ.</rubric>
@@ -1687,8 +1684,7 @@
                       <author ref="http://syriaca.org/person/74">
                         <persName xml:lang="en">John of Asia</persName>
                       </author>
-                      <title xml:lang="en">An extract from the Ecclesiastical History of <persName ref="http://syriaca.org/person/74">John of
-                      Asia</persName>, concerning <persName ref="http://syriaca.org/person/781">Theodoret</persName>
+                      <title xml:lang="en">An extract from the Ecclesiastical History of <persName ref="http://syriaca.org/person/74">John of Asia</persName>, concerning <persName ref="http://syriaca.org/person/781">Theodoret</persName>
                     </title>
                       <rubric xml:lang="syr">ܡܢ ܐܩܠܣܝܣܛܝܩܐ ܕܝܘܚܢܢ ܕܐܣܝܐ̣ ܡܛܠ ܬܐܘܕܘܪܝܛܐ</rubric>
                       <note xml:lang="en">See <bibl>Land, Anecd. Syr., t. ii., p. 363</bibl>.</note>

--- a/data/tei/29.xml
+++ b/data/tei/29.xml
@@ -745,8 +745,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">on <ref target="http://syriaca.org/work/9594">Rom., ch. iii. 28</ref>, and the <ref target="http://syriaca.org/work/9702">Epistle
-                      of S. James, ch. ii. 17</ref>
+                  <title xml:lang="en">on <ref target="http://syriaca.org/work/9594">Rom., ch. iii. 28</ref>, and the <ref target="http://syriaca.org/work/9702">Epistle of S. James, ch. ii. 17</ref>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕ܏ܒ ܕܠܘܬ ܝܘܠܝܢܐ ܕܐܠܝܩܪܢܣܘܣ</rubric>
                 </msItem>

--- a/data/tei/29.xml
+++ b/data/tei/29.xml
@@ -1299,8 +1299,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">From a letter to <persName>Jacob</persName>, abbat of <placeName>the
-                  convent of Naphshāthā</placeName>
+                    <title xml:lang="en">From a letter to <persName>Jacob</persName>, abbat of <placeName>the convent of Naphshāthā</placeName>
                     </title>
                     <rubric xml:lang="syr">ܦܘܫܩܐ̣ ܕܡ̈ܠܐ ܕܝܘܚܢܢ ܐܘܢܓܠܣܛܐ ܗܠܝܢ
                     ܕܣܝ̈ܡܢ. ܐܢ ܐܢܫ ܢܚ̣ܛܐ ܚܛܗܐ ܕܡܘܬܐ̣. ܥܠ ܗܢܐ̣ ܠܐ ܐܢܫ ܢܒܥܐ</rubric>
@@ -1867,8 +1866,7 @@
                   <author ref="http://syriaca.org/person/127">
                     <persName xml:lang="en">John the Stylite</persName>
                   </author>
-                  <title xml:lang="en">Letter of John the Stylite, of the <placeName ref="http://syriaca.org/place/1513">convent of
-                  Litharb</placeName> (?), to <persName>Daniel</persName>, a priest of the Arab tribe of the <foreign xml:lang="syr">ܛܘ̈ܥܝܐ</foreign>, on
+                  <title xml:lang="en">Letter of John the Stylite, of the <placeName ref="http://syriaca.org/place/1513">convent of Litharb</placeName> (?), to <persName>Daniel</persName>, a priest of the Arab tribe of the <foreign xml:lang="syr">ܛܘ̈ܥܝܐ</foreign>, on
                   <ref target="http://syriaca.org/work/9628">Gen. xlix. 10</ref>
                 </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܘܫ̇ܪܝܐ ܕܫܘܐܠܐ ܕܟܬ݂ܒ ܝܘܚܢܢ ܐܣܛܘܢܝܐ ܕܒܕܝܪܐ ܕܠܝܬܐܪܒ̣. ܠܘܬ

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -3502,8 +3502,7 @@
                   Of <persName>Stephen</persName> the bishop and his quarrel with the 
                   monks of 
                   <placeName>the convent of Mar Isaac of 
-                    <placeName ref="http://syriaca.org/place/320">Gabula, <foreign xml:lang="syr">ܓܒܘܠܐ</foreign></placeName>
-                  </placeName>, 
+                    <placeName ref="http://syriaca.org/place/320">Gabula, <foreign xml:lang="syr">ܓܒܘܠܐ</foreign></placeName></placeName>, 
                   including the deposition (<date when-custom="0896" datingMethod="Seleucid">A. Gr. 896</date>, <date calendar="Gregorian" when="0585">A.D. 585</date>) of <persName>Daniel <foreign xml:lang="syr">ܩܦܘܚܝܐ</foreign></persName> and
                   <persName>George bar <foreign xml:lang="syr">ܥܒܫܝ</foreign></persName>, and a letter of <persName>Thomas</persName>, abbat of the said convent</title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܐ̇ܝܟܢܐ ܐܬ̇ܚܫܚ ܐܣܛܦܢܐ ܒܐܦܝܣܩܘܦܘܬܗ̇. ܥܡ ܗ̇ܢܘܢ ܕܡܢܗ

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -1812,8 +1812,7 @@
                 <locus from="136a"/>
                 <title xml:lang="en">Two tracts, numbered 7 and 8, written by the monks of
                   Antioch against <persName ref="http://syriaca.org/person/2025">Probus</persName>
-                   and his followers, in the <date datingMethod="Seleucid" when-custom="0907">year of the Greeks
-                    907</date>, <date calendar="Gregorian" when="0596">A.D. 596</date>
+                   and his followers, in the <date datingMethod="Seleucid" when-custom="0907">year of the Greeks 907</date>, <date calendar="Gregorian" when="0596">A.D. 596</date>
                 </title>
                 <note type="footnote">See <bibl>Assemani, Bibl. Or., t. ii., pp. 72, seqq., especially pp. 76 and
                   77</bibl>.</note>

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -178,8 +178,7 @@
                     ܐܬܥ̣ܨܝܬ</quote>, foll. <locus from="26a">26 a</locus>, <locus from="27a">27 a</locus>, <locus from="30b">30 b</locus>, <locus from="31b">31 b</locus>.</p>
                   <p>
                     <persName ref="http://syriaca.org/person/573">Chrysostom</persName>: 
-                    <title xml:lang="en">hom. iv. on <ref target="http://syriaca.org/work/9641">S. John's
-                    Gospel</ref>
+                    <title xml:lang="en">hom. iv. on <ref target="http://syriaca.org/work/9641">S. John's Gospel</ref>
                     </title>, fol. <locus from="16a">16 a</locus>; 
                     <title xml:lang="en">hom. vi. on the <ref target="http://syriaca.org/work/9600">Epist. to the Colossians</ref>
                     </title>, fol. <locus from="5b">5 b</locus>; 
@@ -3237,8 +3236,7 @@
               </msItem>
               <msItem xml:id="b44" n="185">
                 <locus from="261b"/>
-                <title xml:lang="en">Extracts from <ref>the Lives of the Egyptian
-                    Fathers</ref>
+                <title xml:lang="en">Extracts from <ref>the Lives of the Egyptian Fathers</ref>
                 </title>
                 <rubric xml:lang="syr">ܬܫ̈ܥܝܬܐ ܡܢ ܕܐ̈ܒܗܬܐ ܡܨܪ̈ܝܐ.</rubric>
               </msItem>
@@ -3250,8 +3248,7 @@
                   <author ref="http://syriaca.org/person/668">
                     <persName xml:lang="en">Palladius</persName>
                   </author>
-                  <title xml:lang="en">From <persName ref="http://syriaca.org/person/668">Palladius</persName>' <ref>history of the Egyptian
-                      Fathers</ref>
+                  <title xml:lang="en">From <persName ref="http://syriaca.org/person/668">Palladius</persName>' <ref>history of the Egyptian Fathers</ref>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܬܫܥܝܬܐ ܕܦܠܕ ܐ̇ܦܝܣܩܦܐ <sic>ܕܗܠܝܘܦܘܠܝܣ</sic>
                   </rubric>

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -1378,8 +1378,7 @@
                     ܕܠܡܛܥܝܘ.</rubric>
                   <note>It contains extracts from <title xml:lang="en">the letter of 
                     <persName ref="http://syriaca.org/person/534">Ibas</persName> to 
-                    <persName ref="http://syriaca.org/person/874">Mares, <foreign xml:lang="syr">ܡܐܪܝ</foreign>
-                     the Persian</persName>
+                    <persName ref="http://syriaca.org/person/874">Mares, <foreign xml:lang="syr">ܡܐܪܝ</foreign>the Persian</persName>
                     </title>, read before the synod at its
                     tenth session (<quote xml:lang="syr">ܒܦܪܟܣܝܣ ܕܥܣܪ̈</quote>).</note>
                 </msItem>
@@ -1614,8 +1613,7 @@
                   </author>
                   <title xml:lang="en">Extract from a treatise against the followers of
                     <persName ref="http://syriaca.org/person/72">Paul of Beth-Ukkame</persName>
-                     by <persName>Sergius, abbat of <placeName>the convent of the Arabs</placeName>
-                    </persName>
+                     by <persName>Sergius, abbat of <placeName>the convent of the Arabs</placeName></persName>
                   </title>
                   <note type="footnote">See 
                     <bibl>Assemani, Bibl. Or., t. ii., pp. 69, 331</bibl>.</note>
@@ -3506,10 +3504,8 @@
                   <placeName>the convent of Mar Isaac of 
                     <placeName ref="http://syriaca.org/place/320">Gabula, <foreign xml:lang="syr">ܓܒܘܠܐ</foreign></placeName>
                   </placeName>, 
-                  including the deposition (<date when-custom="0896" datingMethod="Seleucid">A. Gr. 896</date>, <date calendar="Gregorian" when="0585">A.D. 585</date>) of <persName>Daniel <foreign xml:lang="syr">ܩܦܘܚܝܐ</foreign>
-                  </persName> and
-                  <persName>George bar <foreign xml:lang="syr">ܥܒܫܝ</foreign>
-                  </persName>, and a letter of <persName>Thomas</persName>, abbat of the said convent</title>
+                  including the deposition (<date when-custom="0896" datingMethod="Seleucid">A. Gr. 896</date>, <date calendar="Gregorian" when="0585">A.D. 585</date>) of <persName>Daniel <foreign xml:lang="syr">ܩܦܘܚܝܐ</foreign></persName> and
+                  <persName>George bar <foreign xml:lang="syr">ܥܒܫܝ</foreign></persName>, and a letter of <persName>Thomas</persName>, abbat of the said convent</title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܐ̇ܝܟܢܐ ܐܬ̇ܚܫܚ ܐܣܛܦܢܐ ܒܐܦܝܣܩܘܦܘܬܗ̇. ܥܡ ܗ̇ܢܘܢ ܕܡܢܗ
                   ܗܘ̣ܘ ܐܣܛܦܢܐ ܐܦܝܣܩܘܦܐ̣. ܟܕ ܐܩܝܡ ܩܝܡܐ ܠܐܒܪܗܡ ܐܦܝܣܩܘܦܐ ܐܪܡܢܝܐ̣. ܝܡ̣ܐ ܗܘܐ ܩܕܡ ܕܝܪ̈ܝܐ
                   ܢܟ̈ܦܐ: ܕܗ̣ܘ ܒܠܚܘܕܘܗܝ̣ ܠܐ ܫܠܝܛ ܕܢܥܒܕ ܐܦܝܣܩܘܦܐ. ܓܢ̣ܒ ܢܦܫܗ̣ ܘܥܠ̣ ܠܟܘܪܚܐ̇. ܨܝܕ ܐܢܫ

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -1726,9 +1726,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the <title xml:lang="en">treatise of <persName ref="http://syriaca.org/person/51">Severus</persName> against
-                        <persName ref="http://syriaca.org/person/576">Joannes Grammaticus</persName>
-                    </title>, explanatory of certain passages in the writings
+                  <title xml:lang="en">Extracts from the <title xml:lang="en">treatise of <persName ref="http://syriaca.org/person/51">Severus</persName> against <persName ref="http://syriaca.org/person/576">Joannes Grammaticus</persName></title>, explanatory of certain passages in the writings
                     of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                   </title>
                   <note>He cites <persName ref="http://syriaca.org/person/430">Cyril</persName> (<title xml:lang="en">Thesaurus</title>) and
@@ -2527,9 +2525,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">From his treatise against <title xml:lang="en">the Additions, or
-                      Appendices, of <persName ref="http://syriaca.org/person/579">Julian</persName>
-                    </title>
+                  <title xml:lang="en">From his treatise against <title xml:lang="en">the Additions, or Appendices, of <persName ref="http://syriaca.org/person/579">Julian</persName></title>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܗ̇ܘ ܕܠܘܩܒܠ ܬܘ̈ܣܦܬܗ ܕܝܘܠܝܢܐ.</rubric>
                 </msItem>
@@ -3236,10 +3232,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril</persName>
                 </author>
-                <title xml:lang="en">Extracts from the <title xml:lang="en">
-                  Thesaurus, <foreign xml:lang="syr">ܣܝܡܬܐ</foreign>, of
-                  <persName ref="http://syriaca.org/person/430">Cyril</persName>
-                  </title>
+                <title xml:lang="en">Extracts from the <title xml:lang="en">Thesaurus, <foreign xml:lang="syr">ܣܝܡܬܐ</foreign>, of <persName ref="http://syriaca.org/person/430">Cyril</persName></title>
                 </title>
               </msItem>
               <msItem xml:id="b44" n="185">

--- a/data/tei/30.xml
+++ b/data/tei/30.xml
@@ -779,8 +779,7 @@
               <msItem xml:id="b5" n="7">
                 <locus from="62b"/>
                 <title xml:lang="en">A large collection of Demonstrations with the general
-                  title “against the Phantasiastae, or followers of <persName ref="http://syriaca.org/person/579">Julian of
-                    Halicarnassus</persName>"</title>
+                  title “against the Phantasiastae, or followers of <persName ref="http://syriaca.org/person/579">Julian of Halicarnassus</persName>"</title>
                 <rubric xml:lang="syr">ܩ̈ܦܠܐܐ ܕܐܒ̈ܗܬܐ ܩ̈ܕܝܫܐ̣. ܠܘܩܒܠ ܗ̇ܢܘܢ ܕܒܝܬ ܝܘܠܝܢܐ̇. ܐܡ̇ܪ ܐܢܐ
                   ܕܝܢ ܦܢ̈ܛܣܝܣܛܐ ܘܗ̈ܓܓܝܐ ܘܚ̣̈ܠܡܢܝܐ</rubric>
                 <note>These chapters are numbered from 250 to 348 and from 1 to 100 (read
@@ -1405,8 +1404,7 @@
                 </msItem>
                 <msItem xml:id="c9" n="20">
                   <locus from="113a"/>
-                  <title xml:lang="en">Chap. 396, against <persName ref="http://syriaca.org/person/579">Julian of
-                      Halicarnassus</persName> and his followers</title>
+                  <title xml:lang="en">Chap. 396, against <persName ref="http://syriaca.org/person/579">Julian of Halicarnassus</persName> and his followers</title>
                   <rubric xml:lang="syr">ܩ̈ܦܠܐܐ̣ ܠܘܩܒܠ ܗ̇ܢܘܢ ܕܒܝܬ ܝܘܠܝܢܐ܀ ܡܟܣܢܘܬܐ ܡܦܪܫܬܐ ܕܗܠܝܢ ܕܡܢ
                     ܠܥܠ ܐܬܣ̣ܝܡ ܟܢܝܫܐܝܬ.</rubric>
                   <note>
@@ -1616,8 +1614,7 @@
                   </author>
                   <title xml:lang="en">Extract from a treatise against the followers of
                     <persName ref="http://syriaca.org/person/72">Paul of Beth-Ukkame</persName>
-                     by <persName>Sergius, abbat of
-                    <placeName>the convent of the Arabs</placeName>
+                     by <persName>Sergius, abbat of <placeName>the convent of the Arabs</placeName>
                     </persName>
                   </title>
                   <note type="footnote">See 
@@ -1732,8 +1729,7 @@
                     <persName xml:lang="en">Severus</persName>
                   </author>
                   <title xml:lang="en">Extracts from the <title xml:lang="en">treatise of <persName ref="http://syriaca.org/person/51">Severus</persName> against
-                        <persName ref="http://syriaca.org/person/576">Joannes
-                      Grammaticus</persName>
+                        <persName ref="http://syriaca.org/person/576">Joannes Grammaticus</persName>
                     </title>, explanatory of certain passages in the writings
                     of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                   </title>
@@ -1745,8 +1741,7 @@
                   <author>
                     <persName xml:lang="en">Peter, patriarch of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the treatise of <persName>Peter, patriarch of
-                    Antioch</persName>, against <persName ref="http://syriaca.org/person/1196">Damian of Alexandria</persName>, bk. ii., chap.
+                  <title xml:lang="en">Extracts from the treatise of <persName>Peter, patriarch of Antioch</persName>, against <persName ref="http://syriaca.org/person/1196">Damian of Alexandria</persName>, bk. ii., chap.
                     1</title>
                 </msItem>
                 <msItem xml:id="c26" n="42">
@@ -2400,8 +2395,7 @@
                 <title xml:lang="en">Against various heresies</title>
                 <msItem xml:id="c58" n="93">
                   <locus from="187a"/>
-                  <title xml:lang="en">Against <persName>Sergius the
-                    Armenian</persName>
+                  <title xml:lang="en">Against <persName>Sergius the Armenian</persName>
                   </title>
                   <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܘܗ̈ܦܟܬܐ ܠܘܩܒܠ ܣܪܓܝܣ ܐܪܡܢܝܐ.</rubric>
                 </msItem>

--- a/data/tei/305.xml
+++ b/data/tei/305.xml
@@ -99,8 +99,7 @@
               <author ref="http://syriaca.org/person/13">
                 <persName xml:lang="en">Ephrem</persName>
               </author>
-              <title>A collection of Hymns for the <placeName>Church of <placeName>Nisibis</placeName>
-                </placeName>, composed and arranged by <persName>Ephraim</persName>.</title>
+              <title>A collection of Hymns for the <placeName>Church of <placeName>Nisibis</placeName></placeName>, composed and arranged by <persName>Ephraim</persName>.</title>
               <rubric xml:lang="syr">ܦܢܩܝܬܐ ܕܡܕܪ̈ܫܐ ܕܢܨܝܒܝܢ ܕܣܝܡܝܢ ܠܛܘܒܢܐ ܡܪܝ ܐܦܪܝܡ<locus from="2b"/>
               </rubric>
               <rubric xml:lang="syr">

--- a/data/tei/31.xml
+++ b/data/tei/31.xml
@@ -1206,8 +1206,7 @@
                   <author>
                     <persName xml:lang="en">Andrew of Samosata</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the reply of <persName>Andrew of
-                    Samosata</persName> to <persName ref="http://syriaca.org/person/26">Rabūlas</persName>
+                  <title xml:lang="en">Extracts from the reply of <persName>Andrew of Samosata</persName> to <persName ref="http://syriaca.org/person/26">Rabūlas</persName>
                   </title>
                   <note>See <bibl>Overbeck, p. 223</bibl>
                   </note>
@@ -1911,8 +1910,7 @@
                   <author ref="http://syriaca.org/person/451">
                     <persName xml:lang="en">Diodorus of Tarsus</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the works of <persName>Diodorus of
-                    Tarsus</persName>
+                  <title xml:lang="en">Extracts from the works of <persName>Diodorus of Tarsus</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܟܬ̈ܒܐ ܕܕܝܕܘܪܘܣ ܓܘ̈ܕܦܐ</rubric>
                   <note>See <bibl>de Lagarde, Analect. Syr., p. 91</bibl>.</note>

--- a/data/tei/31.xml
+++ b/data/tei/31.xml
@@ -880,8 +880,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9601">1
-                Thessalonians</ref>, hom. vii</title>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9601">1 Thessalonians</ref>, hom. vii</title>
                 <rubric xml:lang="syr">ܕܛܘܒܢܐ ܝܘܚܢܢ ܡܢ ܐܝܠܝܢ ܕܐܡܝܪܢ ܠܗ ܒܫܠܝܚܐ ܒܦܣܝ̈ܩܬܐ ܥܠ ܩܝܡܬܐ
                 ܕܡ̈ܝܬܐ</rubric>
                 <note>

--- a/data/tei/315.xml
+++ b/data/tei/315.xml
@@ -294,8 +294,7 @@
               <author ref="http://syriaca.org/person/548">
                 <persName xml:lang="en">Isaiah, abbat of Scete</persName>
               </author>
-              <title xml:lang="en">Extract from the writings of <persName ref="http://syriaca.org/person/548">Isaiah, abbat of
-                Scete</persName>
+              <title xml:lang="en">Extract from the writings of <persName ref="http://syriaca.org/person/548">Isaiah, abbat of Scete</persName>
               </title>
               <rubric xml:lang="syr">ܕܐܒܐ ܐܫܥܝܐ. ܦܘܩܕܢܐ ܘܙܘܗܪܐ ܠܐܝܠܝܢ ܕܡܬܪܚܩܝܢ ܡܢ ܥܠܡܐ ܘܐܬ̇ܝܢ ܠܘܬ
                 ܬܘܠܡܕܐ</rubric>

--- a/data/tei/315.xml
+++ b/data/tei/315.xml
@@ -356,8 +356,7 @@
                 <rubric xml:lang="syr">ܕܥܠ ܩܝܡܬܐ. ܡܢ ܦܘܿܫܩܐ ܕܐܓܪܬܐ ܕܬܪ̈ܬܝܢ ܕܠܘܬ ܩܘܪ̈ܢܬܝܐ</rubric>
                 <incipit xml:lang="syr"> ܫܡ̣ܥܬܘܢ ܝܘܡܢܐ ܕܩ̇ܥܝܐ ܫܠܝܚܐ ܘܐܡ̇ܪ. ܕܥܠ ܕܡ̈ܟ̣ܐ ܨ̇ܒܐ ܐܢܐ
                   ܕܬܕܥܘܢ ܐܚ̈ܝ ܕܠܐ ܬܗ̇ܘܐ ܟ̇ܪܝܐ ܠܟܘܢ̣ ܐܝܟ ܚ̈ܢܦܐ ܕܣܒܪܐ ܠܝܬ ܠܗܘܢ.</incipit>
-                <note>The passage is not, however, from the <title xml:lang="en">commentary on <ref target="http://syriaca.org/work/9596">the second Epistle to the
-                  Corinthians</ref>
+                <note>The passage is not, however, from the <title xml:lang="en">commentary on <ref target="http://syriaca.org/work/9596">the second Epistle to the Corinthians</ref>
                   </title>, but from the <title xml:lang="en">fifth homily on Lazarus</title>, <bibl>Opera, t. i., beginning with
                   the words, p. 935, <foreign xml:lang="grc">ἠκούσατε τοίνυν τοῦ Παύλου σήμερον Βοῶντος καὶ λέγοντος</foreign>
                   </bibl>.</note>

--- a/data/tei/316.xml
+++ b/data/tei/316.xml
@@ -247,8 +247,7 @@
               <author ref="http://syriaca.org/person/44">
                 <persName xml:lang="en">Philoxenus of Mabug</persName>
               </author>
-              <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabug</persName> to <persName>Patricius, a monk of
-                Edessa</persName>
+              <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabug</persName> to <persName>Patricius, a monk of Edessa</persName>
               </title>
             </msItem>
             <msItem xml:id="a4" n="15">
@@ -329,8 +328,7 @@
               <author ref="http://syriaca.org/person/548">
                 <persName xml:lang="en">Isaiah of Scete</persName>
               </author>
-              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah of
-                Scete</persName>
+              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah of Scete</persName>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܡܢ ܐܒܐ ܐܫܥܝܐ ܬܚ̈ܘܝܬܐ ܕܠܘܩܒܠ ܚ̈ܫܐ</rubric>
               <incipit xml:lang="syr">ܬܠܬ ܡ̈ܝܬܪܬܐ ܕܝܨܦܢ ܕܗܘܢܐ ܐܠܨܐܝܬ. ܘܣܢܝܩܝܢ ܚܢܢ ܥܠܝܗܝ̣ܢ. ܚܐܦܐ

--- a/data/tei/318.xml
+++ b/data/tei/318.xml
@@ -145,8 +145,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah of Scete</persName>
                 </author>
-                <title xml:lang="en">A long extract from <persName ref="http://syriaca.org/person/548">Isaiah of
-                  Scete</persName>
+                <title xml:lang="en">A long extract from <persName ref="http://syriaca.org/person/548">Isaiah of Scete</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܡܠܠܐ ܕܐܒܐ ܐܫܥܝܐ ܝܚܝܕܝܐ ܣܘܪܝܝܐ</rubric>
                 <incipit xml:lang="syr">ܐܡܬܝ ܕܡܬܢܣܐ ܐܢܬ ܒܦܢܛܣܝܐ ܕܙܘܘܓܐ ܒܠܠܝܐ̣. ܛܪ ܠܒܟ ܕܠܐ ܬܬܚܫ̇ܒ
@@ -192,8 +191,7 @@
               <author ref="http://syriaca.org/person/548">
                 <persName xml:lang="en">Isaiah of Scete</persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of
-                  Scete</persName>
+              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of Scete</persName>
               </title>
               <rubric xml:lang="syr">ܕܩܕܝܫܐ ܐܒܐ ܐܫܥܝܐ</rubric>
               <msItem xml:id="b5" n="9">
@@ -251,8 +249,7 @@
               <author ref="http://syriaca.org/person/3501">
                 <persName xml:lang="en">Macarius the Great</persName>
               </author>
-              <title xml:lang="en">Seven letters of <persName ref="http://syriaca.org/person/856">Macarius the
-                Great</persName>
+              <title xml:lang="en">Seven letters of <persName ref="http://syriaca.org/person/856">Macarius the Great</persName>
               </title>
               <finalRubric xml:lang="syr">ܫܠܡ ܐܓܪ̈ܬܐ ܕܛܘܒܢܐ ܐܒܐ ܡܩܪܝܣ: ܕܗܘܝܢ ܒܡܢܝܢܐ ܫ̈ܒܥ.<locus from="125a"/>
                 </finalRubric>
@@ -414,8 +411,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the monk</persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName>John the
-                  monk</persName>
+              <title xml:lang="en">Selections from the writings of <persName>John the monk</persName>
               </title>
               <rubric xml:lang="syr">ܕܝܘܚܢܢ ܝܚܝܕܝܐ</rubric>
               <msItem xml:id="b22" n="29">
@@ -461,8 +457,7 @@
               <author ref="http://syriaca.org/person/33">
                 <persName xml:lang="en">Isaac of Antioch</persName>
               </author>
-              <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/17">Isaac of
-                  Antioch</persName>
+              <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/17">Isaac of Antioch</persName>
               </title>
               <incipit xml:lang="syr">ܐܚܒ ܫܠܝܐ ܐܘ ܬܠܡܝܕܐ. ܕܒܗ ܬܫܟܚ ܬܚܐ ܢܦܫܟ. ܗܘܝ ܚܙܝܐ ܕܩܢܘܡܟ. ܘܠܒܪ
                 ܡܢܟ ܠܐ ܬܚܘܪ.</incipit>
@@ -476,8 +471,7 @@
               <author ref="http://syriaca.org/person/44">
                 <persName xml:lang="en">Philoxenus of Mabūg</persName>
               </author>
-              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  Mabūg</persName>
+              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName>
               </title>
               <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
               <msItem xml:id="b24" n="34">
@@ -548,8 +542,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/51">Severus of
-                Antioch</persName>
+              <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>
               </title>
               <rubric xml:lang="syr">ܗܝܡܢܘܬܐ ܕܩܕܝܫܐ ܡܪܝ ܣ݅ܐܘܪܐ</rubric>
               <incipit xml:lang="syr">ܡܗܝܡܢܝܢܢ ܒܬܘܕܝܬܐ ܕܚܕ ܐܠܗܐ ܫܪܝܪܐ. ܕܐܝܬܘܗܝ ܐܝܬܝܐ ܡܬܘܡܝܐ. ܕܗ̣ܘ
@@ -591,8 +584,7 @@
                 <author ref="http://syriaca.org/person/2507">
                   <persName xml:lang="en">Theophilus of Alexandria</persName>
                 </author>
-                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/2507">Theophilus of
-                    Alexandria</persName> to the monks of <placeName>the convent of Pachomius</placeName>
+                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/2507">Theophilus of Alexandria</persName> to the monks of <placeName>the convent of Pachomius</placeName>
                 </title>
                 <rubric xml:lang="syr">܏ܐܓܪܬܐ ܏ܕܫܕܪ ܏ܬܐܘ݊ܦܝܠܐ: ܏ܠܕܝܪܐ ܏ܕܒܝܬ ܏ܦܟܘܡ: ܘܟܕ ܫܡܥ ܬܐܘ݊ܦܝܠܐ
                   ܪܝܫ ܐܦܝܣܩ̈ܘܦܐ ܕܐܠܟܣܢܕܪܝܐ ܥܠ ܥܘܢܕܢܗ ܕܣܪܦܝܘܢ. ܟܬܒ ܫܠܚ ܐܓܪܬܐ ܕܒܘܝܐܐ ܠܕܝܪܐ ܕܒܝܬ ܦܟܘܡ
@@ -605,8 +597,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">A metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName> on the Dead</title>
+              <title xml:lang="en">A metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the Dead</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܢܝ̈ܕܐ ܕܡܪܝ <choice>
                   <orig>ܐܦܪܝܡ</orig>
                   <corr xml:lang="en">(corrected on the marg. into <foreign xml:lang="syr">ܝܥܩܘܒ</foreign>)</corr>
@@ -643,8 +634,7 @@
               <author ref="http://syriaca.org/person/430">
                 <persName xml:lang="en">Cyril of Alexandria</persName>
               </author>
-              <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/430">Cyril of
-                Alexandria</persName>
+              <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>
               </title>
               <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ</rubric>
               <incipit xml:lang="syr">ܫܡܥܐ ܓܝܪ ܕܠܐ ܥ̇ܒ̈ܕܐ ܡܕܡ ܠܐ ܡܗܢܐ. ܟܒܪ ܕܝܢ ܘܡܣܓܦ. ܒܗ̇ܝ ܕܡܥܒܕ ܠܗ̇

--- a/data/tei/319.xml
+++ b/data/tei/319.xml
@@ -311,8 +311,7 @@
               <author ref="http://syriaca.org/person/376">
                 <persName xml:lang="en">Basil</persName>
               </author>
-              <title xml:lang="en">An epistle of <persName>Basil</persName> to <persName>those who are entering on the
-                monastic life</persName>
+              <title xml:lang="en">An epistle of <persName>Basil</persName> to <persName>those who are entering on the monastic life</persName>
               </title>
               <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܕܝܫܐ ܡܪܝ ܒܣܝܠܝܘܣ: ܠܘܬ ܐܝܠܝܢ ܕܡܫܪܝܢ ܒܕܘܒܪ̈ܐ ܛ̇ܒ̈ܐ</rubric>
               <incipit xml:lang="syr">ܙܕܩ̇ ܠܗ ܠܕܝܪܝܐ̣. ܕܢܗܘܐ ܐܝܬ ܠܗ ܗܠܝܢ ܕܘܒܪ̈ܐ ܡܣܪ̈ܩܐ. ܘܫ</incipit>

--- a/data/tei/319.xml
+++ b/data/tei/319.xml
@@ -324,16 +324,14 @@
               <author ref="http://syriaca.org/person/22">
                 <persName xml:lang="en">Xystus, bishop of Rome</persName>
               </author>
-              <title xml:lang="en">Works of <persName>Xystus, bishop of <placeName>Rome</placeName>
-                </persName>
+              <title xml:lang="en">Works of <persName>Xystus, bishop of <placeName>Rome</placeName></persName>
               </title>
               <msItem xml:id="b3" n="27">
                 <locus from="153a"/>
                 <author ref="http://syriaca.org/person/22">
                   <persName xml:lang="en">Xystus, bishop of Rome</persName>
                 </author>
-                <title xml:lang="en">The Sayings of <persName>Xystus, bishop of <placeName>Rome</placeName>
-                  </persName>
+                <title xml:lang="en">The Sayings of <persName>Xystus, bishop of <placeName>Rome</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܡ̈ܠܐ ܡ̈ܓܒܝܬܐ ܕܩܕܝܫܐ ܟܣܘܣܛܘܣ ܐܦܝܣܩܘܦܐ ܕܪܗܘܡܐ</rubric>
               </msItem>
@@ -353,8 +351,7 @@
               <author ref="http://syriaca.org/person/44">
                 <persName xml:lang="en">Philoxenus of Mabūg</persName>
               </author>
-              <title xml:lang="en">A prayer of <persName>Philoxenus of <placeName>Mabūg</placeName>
-                </persName>
+              <title xml:lang="en">A prayer of <persName>Philoxenus of <placeName>Mabūg</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܨܠܘܬܐ ܕܩܕܝܫܐ ܦܠܟܣܝܢܘܣ</rubric>
               <incipit xml:lang="syr">ܠܟ ܕܐܝܬܝܟ ܐܠܗܐ ܫܪܝܪܐ ܘܡܪܐ ܕܚܝ̈ܠܘܬܐ ܩ̈ܕܝܫܐ. ܠܟ ܗܟܝܠ ܕܐܝܬܝܟ

--- a/data/tei/323.xml
+++ b/data/tei/323.xml
@@ -215,9 +215,7 @@
                   </author>
                   <title>Letter on the faith, sent to the monks at 
                     <placeName>Arzūn of the Persians</placeName>, 
-                    <placeName>
-                      <!-- Needs Persian/Arabic name -->
-                    </placeName>, <placeName>Erzerūm</placeName>
+                    <placeName><!-- Needs Persian/Arabic name --></placeName>, <placeName>Erzerūm</placeName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܗܝܡܢܘܬܐ ܕܐܫܬܕܪܬ ܠܘܬ ܛܘܒ̈ܢܐ ܕܐܝܬ ܒܐܪܙܘܢ ܕܦܪ̈ܣܝܐ
                         <locus from="9b"/>

--- a/data/tei/323.xml
+++ b/data/tei/323.xml
@@ -489,8 +489,7 @@
                   <title>Letter to 
                     <persName>
                       Maras, bishop of <placeName ref="http://syriaca.org/place/707">Amid</placeName>, 
-                      Maras III, consecrated A.D. 520
-                    </persName>
+                      Maras III, consecrated A.D. 520 </persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܫܕܪ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ ܠܡܪܝ ܡܪܐ ܐܦܣܩܦܐ ܕܐܡܕ
                     <locus from="80b"/>

--- a/data/tei/323.xml
+++ b/data/tei/323.xml
@@ -182,8 +182,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Serugh</persName>
                   </author>
-                  <title>Letter to <persName>Antonine, bishop of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
-                    </persName>
+                  <title>Letter to <persName>Antonine, bishop of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܠܘܬ ܡܪܝ ܐܢܛܘܢܝܢ ܐܦܣܩܦܐ ܕܚ̇ܠܒ
                       <locus from="7b"/>
@@ -430,8 +429,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Serugh</persName>
                   </author>
-                  <title>Letter to <persName>Jacob, abbat of the <placeName>convent of Naphshāthā</placeName>
-                    </persName>
+                  <title>Letter to <persName>Jacob, abbat of the <placeName>convent of Naphshāthā</placeName></persName>
                   </title>
                   <listBibl>
                     <bibl>Assemani, Bibl. Orient., t. i., p. 303, no. 5</bibl>
@@ -487,8 +485,7 @@
                     <persName xml:lang="en">Jacob of Serugh</persName>
                   </author>
                   <title>Letter to 
-                    <persName>
-                      Maras, bishop of <placeName ref="http://syriaca.org/place/707">Amid</placeName>, 
+                    <persName>Maras, bishop of <placeName ref="http://syriaca.org/place/707">Amid</placeName>, 
                       Maras III, consecrated A.D. 520 </persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܫܕܪ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ ܠܡܪܝ ܡܪܐ ܐܦܣܩܦܐ ܕܐܡܕ
@@ -585,8 +582,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Serugh</persName>
                   </author>
-                  <title>Letter to <persName>Paul, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>
+                  <title>Letter to <persName>Paul, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܝܠܗ ܕܡܪܝ ܝܥܩܘܒ ܠܘܬ ܦܘܠܐ ܐܦܣܩܦܐ ܕܐܘܪܗܝ
                     <locus from="88a"/>

--- a/data/tei/325.xml
+++ b/data/tei/325.xml
@@ -221,8 +221,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">
-                  <ref target="http://syriaca.org/work/8836">On the rich man and <persName>Lazarus</persName>
-                  </ref>
+                  <ref target="http://syriaca.org/work/8836">On the rich man and <persName>Lazarus</persName></ref>
                 </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܬܝܪܐ ܘܠܥܙܪ</rubric>
                   <note>See <bibl>Assemani, p. 316, no. 89</bibl>.</note>

--- a/data/tei/327.xml
+++ b/data/tei/327.xml
@@ -121,8 +121,7 @@
               <author ref="http://syriaca.org/person/33">
                 <persName xml:lang="en">Isaac of Antioch</persName>
               </author>
-              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of
-                Antioch</persName>
+              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName>
               </title>
               <rubric xml:lang="syr">ܡܪܝ ܐܝܣܚܩ ܛܘܒܢܐ</rubric>
               <msItem xml:id="b1" n="2">

--- a/data/tei/328.xml
+++ b/data/tei/328.xml
@@ -113,8 +113,7 @@
               <author ref="http://syriaca.org/person/33">
                 <persName xml:lang="en">Isaac of Antioch</persName>
               </author>
-              <title xml:lang="en">Metrical discourses by <persName ref="http://syriaca.org/person/33">Isaac of
-                Antioch</persName>
+              <title xml:lang="en">Metrical discourses by <persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName>
               </title>
               <rubric xml:lang="syr">ܡܪܝ ܐܝܣܚܩ ܡܠܦܢܐ ܕܥܕܬܐ</rubric>
               <msItem xml:id="b1" n="2" defective="true">
@@ -189,8 +188,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">On the Ascension of <persName ref="http://syriaca.org/person/2245">our
-                  Lord</persName>
+                <title xml:lang="en">On the Ascension of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܣܘܠܩܗ ܕܡܪܢ</rubric>
                 <incipit xml:lang="syr">ܒ̈ܟܬܒܐ ܐܝܟ ܕܒܝܡܐ ܣܚ̇ܐ ܘܥܒ̇ܪ ܪܥܝܢܐ. ܕܢܐܬܐ ܢܚܘܐ ܬܐܓܘܪܬܗ ܒܥܕܬܐ

--- a/data/tei/33.xml
+++ b/data/tei/33.xml
@@ -112,9 +112,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">Against <ref>the Additions, or Appendices, of
-                  <persName>Julian</persName>
-                </ref>, in 43 chapters</title>
+              <title xml:lang="en">Against <ref>the Additions, or Appendices, of <persName>Julian</persName></ref>, in 43 chapters</title>
               <rubric xml:lang="syr">ܠܘܩܒܠ ܬܘ̈ܣܦܬܐ ܕܝܘܠܝܢܐ</rubric>
               <finalRubric xml:lang="syr">
                 <locus from="49a"/>ܫܠܡ ܠܡܟܬܒ ܟܬܒܐ ܕܠܘܩܒܠ ܬܘܣ̈ܦܬܐ ܕܝܘܠܝܢܐ ܗܪܛܝܩܐ ܐܦܣܩܘܦܐ
@@ -149,9 +147,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">Against <ref>the last Apology of
-                <persName>Julian</persName>
-                </ref>
+              <title xml:lang="en">Against <ref>the last Apology of <persName>Julian</persName></ref>
               </title>
               <rubric xml:lang="syr">ܟܬܒܐ ܕܥܒܝܕ ܠܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ̣. ܠܘܩܒܠ ܡܦܩ ܒܪܘܚܗ
                 ܐܚܪܝܐ ܕܝܘܠܝܢܐ ܢܟܝܠܐ ܘܒܝ̣ܫ ܬܪܥܝܬܐ̇. ܕܫܚܠܦ ܒܗ ܠܫܪܪܐ ܕܚ̈ܫܐ ܨܒ̈ܝܢܝܐ ܘܦܪ̈ܘܩܝܐ ܕܥܡܢܘܐܝܠ܇

--- a/data/tei/330.xml
+++ b/data/tei/330.xml
@@ -113,8 +113,7 @@
               <author ref="http://syriaca.org/person/156">
                 <persName xml:lang="en">Nonnus of Nisibis</persName>
               </author>
-              <title>The works of <persName ref="http://syriaca.org/person/156"> Nonnus (<foreign xml:lang="syr">ܢܐܢܘܣ, ܢܘܢܘܣ , ܢܘܢܐ</foreign>), archdeacon of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                </persName> </title>
+              <title>The works of <persName ref="http://syriaca.org/person/156"> Nonnus (<foreign xml:lang="syr">ܢܐܢܘܣ, ܢܘܢܘܣ , ܢܘܢܐ</foreign>), archdeacon of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName> </title>
               <note>He [i.e. Nonnus] appears to have flourished towards  the middle of the ixth cent. (see no. 2), and held monophysite views regarding the nature of our Lord.</note>
               <msItem xml:id="b1" n="2">
                 <locus from="2b" to="20">Fol. 2b-20</locus>
@@ -131,8 +130,7 @@
                 <author ref="http://syriaca.org/person/156">
                   <persName xml:lang="en">Nonnus of Nisibis</persName>
                 </author>
-                <title>A controversial theological treatise, consisting of four discourses, composed by him, when in prison, against <persName ref="http://syriaca.org/person/796">Thomas the Nestorian, metropolitan of <placeName ref="http://syriaca.org/place/33">Beth-Garmai</placeName>
-                  </persName>. </title>
+                <title>A controversial theological treatise, consisting of four discourses, composed by him, when in prison, against <persName ref="http://syriaca.org/person/796">Thomas the Nestorian, metropolitan of <placeName ref="http://syriaca.org/place/33">Beth-Garmai</placeName></persName>. </title>
                 <rubric xml:lang="syr">
                     </rubric>
                 <note>Thomas the Nestorian = <persName ref="http://syriaca.org/person/796">Thomas, bishop of Marga and metropolitan of <placeName ref="http://syriaca.org/place/33">Beth-Garmai</placeName>

--- a/data/tei/331.xml
+++ b/data/tei/331.xml
@@ -113,8 +113,7 @@
               <author ref="http://syriaca.org/person/44">
                 <persName xml:lang="en">Philoxenus of Mabūg</persName>
               </author>
-              <title>The second volume of the discourses of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                </persName> on Christian life and character, comprising discourses 8—13</title>
+              <title>The second volume of the discourses of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName> on Christian life and character, comprising discourses 8—13</title>
               <msItem xml:id="b1" n="2">
                 <locus from="1b" to="16">Fol. 1b-16</locus>
                 <author ref="http://syriaca.org/person/44">

--- a/data/tei/333.xml
+++ b/data/tei/333.xml
@@ -192,8 +192,7 @@
               <author ref="http://syriaca.org/person/2163">
                 <persName xml:lang="en">Julius, bishop of Rome</persName>
               </author>
-              <title>The fifth epistle of <persName>Julius, bishop of <placeName>Rome</placeName>
-                </persName>, concerning the union (of the two natures) in Christ</title>
+              <title>The fifth epistle of <persName>Julius, bishop of <placeName>Rome</placeName></persName>, concerning the union (of the two natures) in Christ</title>
               <rubric xml:lang="syr">ܐܓܪܬܐ ܕܚܡܫ ܕܩܕܝܫܐ ܝܘܠܝܣ ܐܦܣܩܦܐ ܕܪܗܘܡܐ̣. ܡܛܘܠ ܚܕܝܘܬܐ ܕܒܡܫܝܚܐ ܘܕܦܓܪܐ ܡܪܟܒܐ ܨܝܕ ܐܠܗܘܬܗ ܕܐܠܗܐ ܡܠܬܐ. 
               	  <locus from="107b"/>
               	</rubric>

--- a/data/tei/334.xml
+++ b/data/tei/334.xml
@@ -521,8 +521,7 @@
                 <author>
                   <persName xml:lang="en">Isaac, abbat of Scete</persName>
                 </author>
-                <title>Discourse of <persName>Isaac, abbat of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>, addressed to his disciple Peter</title>
+                <title>Discourse of <persName>Isaac, abbat of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>, addressed to his disciple Peter</title>
                 <rubric xml:lang="syr">ܨܝܕ ܦܛܪܐ ܬܠܡܝܕܗ
                   <locus from="284a"/>
                 </rubric>

--- a/data/tei/336.xml
+++ b/data/tei/336.xml
@@ -138,24 +138,21 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title>To <persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
-                  </persName>.</title>
+                <title>To <persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName></persName>.</title>
               </msItem>
               <msItem xml:id="b4" n="5">
                 <locus from="3a" to="6a">Foll. 3a-6a</locus>
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title>To the same (<persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
-                  </persName>).</title>
+                <title>To the same (<persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName></persName>).</title>
               </msItem>
               <msItem xml:id="b5" n="6">
                 <locus from="6a" to="12">Foll. 6a-12a</locus>
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title>To the same (<persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
-                  </persName>).</title>
+                <title>To the same (<persName>Solon, bishop and metropolitan of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName></persName>).</title>
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="12a" to="14">Foll. 12a-14a</locus>

--- a/data/tei/337.xml
+++ b/data/tei/337.xml
@@ -170,10 +170,7 @@
                 <author ref="http://syriaca.org/person/376">
                   <persName xml:lang="en">Basil</persName>
                 </author>
-                <title xml:lang="en">Part of the Prooemium to the "<title xml:lang="la">
-                  Regulae fusius
-                    tractatae
-                </title>"</title>
+                <title xml:lang="en">Part of the Prooemium to the "<title xml:lang="la">Regulae fusius tractatae </title>"</title>
                 <rubric xml:lang="syr">ܡܡܠܠܐ ܕܡܪܬܝܢܘܬܐ ܕܥܒܝܕ ܠܩܕܝܫܐ ܒܣܝܠܝܘܣ. ܠܘܬ ܐܝܠܝܢ ܕܒܥܢܘܝܘܬܐ
                   ܨ̇ܒܝܢ ܠܡ̇ܕܪܫܘ ܢܦܫܗܘܢ ܒܟܢܘܫܝܐ ܕܕܝܪ̈ܝܐ ܐܘ ܒܥܘܡܪܐ ܕܐܚ̈ܘܬܐ.</rubric>
                 <note>See <bibl>Opera, t. ii., p. 457</bibl>.</note>

--- a/data/tei/337.xml
+++ b/data/tei/337.xml
@@ -401,8 +401,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Hom. viii. on <ref target="http://syriaca.org/work/9601">the first Epistle to the
-                    Thessalonians</ref>
+                <title xml:lang="en">Hom. viii. on <ref target="http://syriaca.org/work/9601">the first Epistle to the Thessalonians</ref>
                 </title>
                 <note>See <bibl>Opera, t. xi., p. 553</bibl>.</note>
               </msItem>
@@ -585,8 +584,7 @@
             </msItem>
             <msItem xml:id="a14" n="46">
               <locus from="158b"/>
-              <title xml:lang="en">A short account of the various Greek translations of <ref target="http://syriaca.org/work/9586">the
-                Old Testament</ref>, viz. the LXX., <persName>Aquila</persName>,
+              <title xml:lang="en">A short account of the various Greek translations of <ref target="http://syriaca.org/work/9586">the Old Testament</ref>, viz. the LXX., <persName>Aquila</persName>,
                   <persName>Symmachus</persName>, <persName>Theodotion</persName>, the Quinta, and
                 the Sexta; and also of the labours of <persName ref="http://syriaca.org/person/2728">Origen</persName>
               </title>

--- a/data/tei/337.xml
+++ b/data/tei/337.xml
@@ -154,8 +154,7 @@
               <author ref="http://syriaca.org/person/44">
                 <persName xml:lang="en">Philoxenus of Mabūg</persName>
               </author>
-              <title xml:lang="en">Part of a letter of <persName>Philoxenus of
-                  Mabūg</persName> to the Recluses</title>
+              <title xml:lang="en">Part of a letter of <persName>Philoxenus of Mabūg</persName> to the Recluses</title>
               <rubric xml:lang="syr">ܐܝܓܪܬܐ ܕܠܘܬ ܐܚ̈ܐ ܚܒ̈ܝܫܐ: ܕܩܕܝܫܐ <sic>ܡܢ</sic> ܐܟܣܢܝܐ</rubric>
               <note>Imperfect at the beginning</note>
             </msItem>
@@ -245,8 +244,7 @@
               <author ref="http://syriaca.org/person/511">
                 <persName xml:lang="en">Gregory Nazianzen</persName>
               </author>
-              <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/511">Gregory
-                Nazianzen</persName>
+              <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
               </title>
               <msItem xml:id="b8" n="14">
                 <locus from="37a"/>
@@ -449,8 +447,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">Letters and discourses of <persName ref="http://syriaca.org/person/51">Severus of
-                  Antioch</persName>
+              <title xml:lang="en">Letters and discourses of <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>
               </title>
               <msItem xml:id="b21" n="33">
                 <locus from="115b"/>
@@ -536,8 +533,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">The eighty-sixth, on <persName ref="http://syriaca.org/person/1594">Antony of
-                      Egypt</persName>
+                  <title xml:lang="en">The eighty-sixth, on <persName ref="http://syriaca.org/person/1594">Antony of Egypt</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܛܘܠ ܩܕܝܫܐ ܐܢܛܘܢܝܘܣ̇. ܗ̇ܘ ܕܒܡܨܪܝܢ ܫ̇ܪܝ ܩܕܡܝܐ ܕܢܗܘܐ ܪܝܫܐ
                     ܕܚ̈ܝܐ ܕܕܝܪܝܘܬܐ ܘܕܒܡܕܒܪܐ</rubric>
@@ -566,8 +562,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">The twenty-fourth, on the Ascension of <persName ref="http://syriaca.org/person/2245">our
-                      Lord</persName>
+                  <title xml:lang="en">The twenty-fourth, on the Ascension of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܛܠ ܣܘܠܩܗ ܕܡܫܝܚܐ̣. ܘܡܛܠ ܢܚܬܐ ܕܐܪܓܘܢܐ̇. ܗ̇ܘ ܕܐܬܝܗ̣ܒ ܡܢ ܡ̇ܠܟܢ
                     ܕܚ̇ܠ ܠܐܠܗܐ ܐܢܣܛܘܣ</rubric>
@@ -613,8 +608,7 @@
               <author ref="http://syriaca.org/person/477">
                 <persName xml:lang="en">Epiphanius of Cyprus</persName>
               </author>
-              <title xml:lang="en">Extracts from the treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of
-                  Cyprus</persName> on Weights and Measures</title>
+              <title xml:lang="en">Extracts from the treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of Cyprus</persName> on Weights and Measures</title>
               <note>See <bibl>Opera, t. ii., p. 158</bibl>.</note>
               <msItem xml:id="b23" n="48">
                 <locus from="159a"/>
@@ -641,14 +635,12 @@
             </msItem>
             <msItem xml:id="a16" n="50">
               <locus from="163b"/>
-              <title xml:lang="en">A section showing where and how each of <persName ref="http://syriaca.org/person/1605">the
-                  Apostles</persName> suffered death</title>
+              <title xml:lang="en">A section showing where and how each of <persName ref="http://syriaca.org/person/1605">the Apostles</persName> suffered death</title>
               <rubric xml:lang="syr">ܢܨܚܢܐ ܘܟܘܿܠܠܐ ܕܫ̈ܠܝܚܐ ܩܕܝܫ̈ܐ</rubric>
             </msItem>
             <msItem xml:id="a17" n="51">
               <locus from="164a"/>
-              <title xml:lang="en">A similar section on <persName ref="http://syriaca.org/person/1688">the seventy-two
-                  Disciples</persName>, and the false apostles in their time</title>
+              <title xml:lang="en">A similar section on <persName ref="http://syriaca.org/person/1688">the seventy-two Disciples</persName>, and the false apostles in their time</title>
               <rubric xml:lang="syr">ܡܛܠ ܗܠܝܢ ܫܒܥܝܢ ܘܬܪ̈ܝܢ ܫ̈ܠܝܚܐ ܩ̈ܕܝܫܐ̣. ܘܡܛܠ ܫ̈ܠܝܚܐ ܕܓ̈ܠܐ ܕܗܘ̣ܘ
                 ܒܙܒܢܗܘܢ</rubric>
             </msItem>

--- a/data/tei/338.xml
+++ b/data/tei/338.xml
@@ -120,9 +120,7 @@
                 <author ref="http://syriaca.org/person/784">
                   <persName xml:lang="en">Theodosius of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/784">Theodosius of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> to <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/784">Theodosius of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> to <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ <sic>ܣܘܗܘܕܝܩܐ</sic> ܕܚܣܝܐ ܘܩܕܝܫܐ ܪܝܫܐ ܕܐ̈ܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ
                   ܬܐܘܕܘܣܝܣ̣. ܕܠܘܬ ܛܘܒܬܢܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ ܒܐܝܪܚ ܚܙܝܪܢ.</rubric>
@@ -249,9 +247,7 @@
                 </author>
                 <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/784">Theodosius</persName> to the Eastern
                   bishops (<persName ref="http://syriaca.org/person/69">Jacob Baradæus</persName>,
-                    <persName ref="http://syriaca.org/person/1336">Conon of <placeName>Tarsus</placeName>
-                  </persName>, <persName>Eugenius of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
-                  </persName>,
+                    <persName ref="http://syriaca.org/person/1336">Conon of <placeName>Tarsus</placeName></persName>, <persName>Eugenius of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName></persName>,
                   etc.)</title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܦܛܪܝܪܟܐ ܡܪܝ ܬܐܘܕܘܣܝܘܣ ܕܐܠܟܣܢܕܪܝܐ̣. ܕܠܘܬ ܐܦܣ̈ܩܘܦܐ
                   ܡ̈ܕܢܚܝܐ܀ ܠܗ̇ܢܘܢ ܕܒܟܠܡܕܡ ܩ̈ܕܝܫܐ ܐܚ̈ܝܢ ܘܒ̈ܢܝ ܬܫܡܫܬܢ: ܝܥܩܘܒ ܩܘܢܘܢ ܐܘܓܢ: ܘܫܪܟܐ ܕܚ̈ܣܝܐ
@@ -265,8 +261,7 @@
                 </author>
                 <title xml:lang="en">Another letter of <persName ref="http://syriaca.org/person/784">Theodosius</persName> to the
                   same, <foreign xml:lang="syr">ܐܓܪܬܐ ܕܠܘܬ ܐ̈ܦܣܩܦܐ ܕܡܕܢܚܐ</foreign>, regarding the consecration of
-                    <persName ref="http://syriaca.org/person/72">Paul</persName> as successor to <persName>Sergius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                    <persName ref="http://syriaca.org/person/72">Paul</persName> as successor to <persName>Sergius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܡ̇ܢ ܕܒܝܕ ܕܚ̇ܠ ܠܐܠܗܐ ܪܝܫ ܕܝܪܐ ܠܐܝ̈ܕܝܗ̇ ܕܩܕܝܫܘܬܟܘܢ
                   ܡܬܝܗܒܐ̣. ܐܝܕܝܥܐ ܕܟܕܠܐ ܓܠܝ̣ܢܢ ܠܕܚܠܬ ܐܠܗܐ ܕܒܗ ܟܬܒܢܢ ܠܘܬܟܘܢ. ܒܕܓܘܢ̣ ܘܒܚܕܘܬܐ ܣܓܝܐܬܐ
@@ -283,8 +278,7 @@
                 <author>
                   <persName xml:lang="en">Eunomius</persName>
                 </author>
-                <title xml:lang="en">Letter of the bishops <persName ref="http://syriaca.org/person/69">Jacob Baradæus</persName>, <persName>Eugenius of <placeName>Seleucia</placeName>
-                  </persName>, and <persName>Eunomius</persName>,
+                <title xml:lang="en">Letter of the bishops <persName ref="http://syriaca.org/person/69">Jacob Baradæus</persName>, <persName>Eugenius of <placeName>Seleucia</placeName></persName>, and <persName>Eunomius</persName>,
                   to <persName ref="http://syriaca.org/person/784">Theodosius</persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܠܩܕܝܫܐ ܘܛܘܒܬܢܐ ܦܛܪܝܪܟܐ ܬܐܘܕܘܣܝܘܣ̣. ܡܢ ܐܦܣ̈ܩܦܐ
@@ -313,8 +307,7 @@
                   <persName xml:lang="en">Theodore</persName>
                 </author>
                 <title xml:lang="en">Letter of the bishop <persName>Theodore</persName> to
-                    <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                    <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܐܓܪܬܐ ܕܐܬܥ̣ܒܕܬ ܒܩܘܣܛܢܛܝܢܘܦܘܠܝܣ܇ ܡܢ ܚܣܝܐ ܡܪܝ ܬܐܘܕܘܪܐ̇.
                   ܡܛܠ ܕܠܐ ܐܫܬܟܚ ܐܦ ܠܐ ܐܪܡܝ ܐܝ̣ܕܐ̇. ܒܐܓܪܬܐ ܓܘܢܝܬܐ ܕܚ̈ܣܝܐ ܐܦܣ̈ܩܘܦܐ</rubric>
@@ -346,9 +339,7 @@
                 <author ref="http://syriaca.org/person/72">
                   <persName xml:lang="en">Paul, patriarch of Antioch</persName>
                 </author>
-                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/72">Paul, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, to <persName ref="http://syriaca.org/person/784">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>
+                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/72">Paul, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, to <persName ref="http://syriaca.org/person/784">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܐ ܣܘܢܗܘܕܝܩܘܢ ܕܚܣܝܐ ܘܪܝܫܐ ܕܐ̈ܦܣܩܘܦܐ ܕܐܢܛܝܟܝܐ ܡܪܝ ܦܘܠܐ̇. ܠܘܬ
                   ܩܕܝܫܐ ܬܐܘܕܘܣܝܘܣ ܪܝܫܐ ܕܐ̈ܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ.</rubric>
@@ -398,8 +389,7 @@
               </msItem>
               <msItem xml:id="b16" n="17">
                 <locus from="53a"/>
-                <title xml:lang="en">Letter of the abbats of the East to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">Letter of the abbats of the East to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܠܘܬ ܦܛܪܝܪܟܐ ܡܪܝ ܦܘܠܐ̣. ܡܢ ܪ̈ܝܫܝ ܥܘܡܪ̈ܐ
                   ܕܡܕܢܚܐ</rubric>
@@ -496,8 +486,7 @@
                   <persName xml:lang="en">Ḥareth (Aretas)</persName>
                 </author>
                 <title xml:lang="en">Letter of the patricius 
-                  <persName>
-                    Ḥareth (Aretas)
+                  <persName>Ḥareth (Aretas)
                   </persName> to 
                   <persName ref="http://syriaca.org/person/69">Jacob (Baradæus)</persName>
                 </title>
@@ -549,8 +538,7 @@
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
                 <title xml:lang="en">Copy of the second allocution or address (<foreign xml:lang="grc">προσφώνησις</foreign>),
-                  drawn up between us (<persName ref="http://syriaca.org/person/74">John of <placeName>Asia</placeName>
-                  </persName> and his followers) and the followers of
+                  drawn up between us (<persName ref="http://syriaca.org/person/74">John of <placeName>Asia</placeName></persName> and his followers) and the followers of
                     <persName ref="http://syriaca.org/person/1336">Conon</persName> and <persName>Eugenius</persName> at the place called <placeName xml:lang="syr">ܐܘܪܡܝܙܐ</placeName>.</title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܡܦ̣ܩ ܒܪܘܚܐ ܐܘ ܟܝܬ ܕܦܪܘܣܦܘܢܣܝܣ ܕܬܪ̈ܬܝܢ ܕܐܬܥܒܕ ܒܝܬ ܠܢ
                   ܘܠܗܠܝܢ ܕܒܝܬ ܚܣܝܐ ܩܘܢܘܢ ܘܐܘܓܢ ܒܐܘܪܡܝܙܐ܇ ܕܒܗ ܐܦ ܟܠܢ ܐܪܡܝܢ ܚܢܢ ܐܝܕܐ</rubric>
@@ -702,8 +690,7 @@
                 <author ref="http://syriaca.org/person/72">
                   <persName xml:lang="en">Paul of Antioch</persName>
                 </author>
-                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName> to the bishops
+                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName> to the bishops
                     <persName ref="http://syriaca.org/person/69">Jacob</persName> and <persName>Theodore</persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܚܣܝܐ ܘܛܘܒܬܢܐ ܦܘܠܐ ܦܛܪܝܪܟܐ ܕܐܢܛܝܘܟܝܐ̣. ܠܘܬ ܡܪܝ ܝܥܩܘܒ
@@ -968,8 +955,7 @@
                 </author>
                 <title xml:lang="en">Replies by one of the orthodox (viz.
                     <persName ref="http://syriaca.org/person/68">Sergius</persName>, or <persName ref="http://syriaca.org/person/68">Sergūnā</persName>, a recluse of the
-                  convent at <placeName ref="http://syriaca.org/place/621">Nicæa</placeName>), addressed to the priest <persName>John the Aged (<foreign xml:lang="syr">ܣܒܐ</foreign>), of <placeName>Rās'ain</placeName>
-                  </persName>, in answer to
+                  convent at <placeName ref="http://syriaca.org/place/621">Nicæa</placeName>), addressed to the priest <persName>John the Aged (<foreign xml:lang="syr">ܣܒܐ</foreign>), of <placeName>Rās'ain</placeName></persName>, in answer to
                   certain questions propounded to the latter by the priest <persName>John the Lame</persName> (<foreign xml:lang="syr">ܚܓܝܪܐ</foreign>), who had left <placeName ref="http://syriaca.org/place/2690">the convent of Mār Bassus</placeName>.</title>
                 <rubric xml:lang="syr">ܦܘܢܝ ܦܬܓܡܐ ܐܘ ܟܝܬ ܫܪܝܐ ܕܗܘ̣ܐ ܡܢ ܐܢܫ ܬܪܝܨ ܫܘܒܚܐ̣. ܠܘܩܒܠ ܬܒ̈ܥܬܐ
                   ܗܠܝܢ ܕܬܒ̣ܥ܇ ܩܫܝܫܐ ܝܘܚܢܢ ܗ̇ܘ ܕܢܦ̇ܝܩ ܡܢ ܥܘܡܪܐ ܩܕܝܫܐ ܕܡܪܝ ܒܣ܀ ܟܪܛܝܣܐ ܝܗܒ̣ܬ ܠܝ ܐܒܗܘܬܟ
@@ -1020,8 +1006,7 @@
                   <persName xml:lang="en">Theodore</persName>
                 </author>
                 <title xml:lang="en">Synodical letter of <persName>Theodore</persName> of
-                    <placeName ref="http://syriaca.org/place/572">Alexandria</placeName> to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                    <placeName ref="http://syriaca.org/place/572">Alexandria</placeName> to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܣܘܢܗܘܕܝܩܐ ܕܐܫ̣ܬܕܪܬ ܡܢ ܚܣܝܐ ܘܛܘܒܬܢܐ ܡܪܝ ܬܐܘܕܘܪܐ ܦܛܪܝܪܟܐ
                   ܕܥܕܬܐ ܬܪܝܨܬ ܫܘܒܚܐ ܕܒܐܠܟܣܢܕܪܝܐ̣. ܠܘܬ ܩܕܝܫܐ ܘܛܘܒܬܢܐ ܡܪܝ ܦܘܠܐ ܦܛܪܝܪܟܐ ܕܥܕܬܐ ܬܪܝܨܬ

--- a/data/tei/338.xml
+++ b/data/tei/338.xml
@@ -364,10 +364,8 @@
                 <author>
                   <persName xml:lang="en">Zenobius, abbat of the convent of Maār Biza</persName>
                 </author>
-                <title xml:lang="en">Letter of <persName>Eusebius</persName>, abbat of <placeName ref="http://syriaca.org/place/2690">the convent of
-                    Mār Bassus</placeName>, <persName>Bar-hab-be-shabbā</persName>, abbat of the Great Convent
-                    (of <placeName ref="http://syriaca.org/place/198">Teleda</placeName>), <persName>Zenobius</persName>, abbat of <placeName>the
-                    convent of Maār Biza</placeName>, and others, to
+                <title xml:lang="en">Letter of <persName>Eusebius</persName>, abbat of <placeName ref="http://syriaca.org/place/2690">the convent of Mār Bassus</placeName>, <persName>Bar-hab-be-shabbā</persName>, abbat of the Great Convent
+                    (of <placeName ref="http://syriaca.org/place/198">Teleda</placeName>), <persName>Zenobius</persName>, abbat of <placeName>the convent of Maār Biza</placeName>, and others, to
                   <persName ref="http://syriaca.org/person/784">Theodosius</persName>
                 </title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܐܓܪ̈ܬܐ ܕܐܫܬܕܪ ܒܝܕ ܚܣܝܐ ܡܪܝ ܝܥܩܘܒ̣. ܘܐܬܝܗܒ ܒܝܕ ܩܘܢܘܢ
@@ -402,8 +400,7 @@
                 <author>
                   <persName xml:lang="en">Jacob, abbat of the convent of Aphtuūnāyā</persName>
                 </author>
-                <title xml:lang="en">Letter of <persName>Jacob</persName>, abbat of <placeName>the convent of
-                    Aphtūnāyā</placeName>, to <persName ref="http://syriaca.org/person/784">Theodosius</persName>
+                <title xml:lang="en">Letter of <persName>Jacob</persName>, abbat of <placeName>the convent of Aphtūnāyā</placeName>, to <persName ref="http://syriaca.org/person/784">Theodosius</persName>
                 </title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܐܓܪܬܐ ܕܐܫܬ̣ܕܪܬ ܡܢ ܚܣܝܐ ܡܪܝ ܝܥܩܘܒ̣. ܘܐܬܝܗ̣ܒܬ ܒܝܕ ܚܣܝܐ
                   ܡܪܝ ܐܘܢܘܡܝܘܣ̇. ܠܩܕܝܫܐ ܦܦܐ ܬܐܘܕܘܣܝܘܣ.܀. ܠܡܪܐ ܕܝܠܢ ܩܕܝܫܐ ܘܛܘܒܬܢܐ ܘܡܝܩܪܐ: ܐܒܐ ܪܘܚܢܐ

--- a/data/tei/338.xml
+++ b/data/tei/338.xml
@@ -120,10 +120,8 @@
                 <author ref="http://syriaca.org/person/784">
                   <persName xml:lang="en">Theodosius of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/784">Theodosius of
-                      <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> to <persName ref="http://syriaca.org/person/51">Severus of
-                    <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/784">Theodosius of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                  </persName> to <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ <sic>ܣܘܗܘܕܝܩܐ</sic> ܕܚܣܝܐ ܘܩܕܝܫܐ ܪܝܫܐ ܕܐ̈ܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ
@@ -251,10 +249,8 @@
                 </author>
                 <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/784">Theodosius</persName> to the Eastern
                   bishops (<persName ref="http://syriaca.org/person/69">Jacob Baradæus</persName>,
-                    <persName ref="http://syriaca.org/person/1336">Conon of
-                      <placeName>Tarsus</placeName>
-                  </persName>, <persName>Eugenius of
-                      <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
+                    <persName ref="http://syriaca.org/person/1336">Conon of <placeName>Tarsus</placeName>
+                  </persName>, <persName>Eugenius of <placeName>Seleucia</placeName> in <placeName>Isauria</placeName>
                   </persName>,
                   etc.)</title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܦܛܪܝܪܟܐ ܡܪܝ ܬܐܘܕܘܣܝܘܣ ܕܐܠܟܣܢܕܪܝܐ̣. ܕܠܘܬ ܐܦܣ̈ܩܘܦܐ
@@ -269,8 +265,7 @@
                 </author>
                 <title xml:lang="en">Another letter of <persName ref="http://syriaca.org/person/784">Theodosius</persName> to the
                   same, <foreign xml:lang="syr">ܐܓܪܬܐ ܕܠܘܬ ܐ̈ܦܣܩܦܐ ܕܡܕܢܚܐ</foreign>, regarding the consecration of
-                    <persName ref="http://syriaca.org/person/72">Paul</persName> as successor to <persName>Sergius, patriarch of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                    <persName ref="http://syriaca.org/person/72">Paul</persName> as successor to <persName>Sergius, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܡ̇ܢ ܕܒܝܕ ܕܚ̇ܠ ܠܐܠܗܐ ܪܝܫ ܕܝܪܐ ܠܐܝ̈ܕܝܗ̇ ܕܩܕܝܫܘܬܟܘܢ
@@ -288,9 +283,7 @@
                 <author>
                   <persName xml:lang="en">Eunomius</persName>
                 </author>
-                <title xml:lang="en">Letter of the bishops <persName ref="http://syriaca.org/person/69">Jacob
-                    Baradæus</persName>, <persName>Eugenius of
-                    <placeName>Seleucia</placeName>
+                <title xml:lang="en">Letter of the bishops <persName ref="http://syriaca.org/person/69">Jacob Baradæus</persName>, <persName>Eugenius of <placeName>Seleucia</placeName>
                   </persName>, and <persName>Eunomius</persName>,
                   to <persName ref="http://syriaca.org/person/784">Theodosius</persName>
                 </title>
@@ -353,10 +346,8 @@
                 <author ref="http://syriaca.org/person/72">
                   <persName xml:lang="en">Paul, patriarch of Antioch</persName>
                 </author>
-                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/72">Paul, patriarch of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, to <persName ref="http://syriaca.org/person/784">Theodosius, patriarch
-                    of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                <title xml:lang="en">Synodical letter of <persName ref="http://syriaca.org/person/72">Paul, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                  </persName>, to <persName ref="http://syriaca.org/person/784">Theodosius, patriarch of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܐ ܣܘܢܗܘܕܝܩܘܢ ܕܚܣܝܐ ܘܪܝܫܐ ܕܐ̈ܦܣܩܘܦܐ ܕܐܢܛܝܟܝܐ ܡܪܝ ܦܘܠܐ̇. ܠܘܬ
@@ -407,8 +398,7 @@
               </msItem>
               <msItem xml:id="b16" n="17">
                 <locus from="53a"/>
-                <title xml:lang="en">Letter of the abbats of the East to <persName ref="http://syriaca.org/person/72">Paul of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Letter of the abbats of the East to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܠܘܬ ܦܛܪܝܪܟܐ ܡܪܝ ܦܘܠܐ̣. ܡܢ ܪ̈ܝܫܝ ܥܘܡܪ̈ܐ
@@ -559,8 +549,7 @@
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
                 <title xml:lang="en">Copy of the second allocution or address (<foreign xml:lang="grc">προσφώνησις</foreign>),
-                  drawn up between us (<persName ref="http://syriaca.org/person/74">John of
-                      <placeName>Asia</placeName>
+                  drawn up between us (<persName ref="http://syriaca.org/person/74">John of <placeName>Asia</placeName>
                   </persName> and his followers) and the followers of
                     <persName ref="http://syriaca.org/person/1336">Conon</persName> and <persName>Eugenius</persName> at the place called <placeName xml:lang="syr">ܐܘܪܡܝܙܐ</placeName>.</title>
                 <rubric xml:lang="syr">ܦܚܡܐ ܕܡܦ̣ܩ ܒܪܘܚܐ ܐܘ ܟܝܬ ܕܦܪܘܣܦܘܢܣܝܣ ܕܬܪ̈ܬܝܢ ܕܐܬܥܒܕ ܒܝܬ ܠܢ
@@ -713,8 +702,7 @@
                 <author ref="http://syriaca.org/person/72">
                   <persName xml:lang="en">Paul of Antioch</persName>
                 </author>
-                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/72">Paul of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName> to the bishops
                     <persName ref="http://syriaca.org/person/69">Jacob</persName> and <persName>Theodore</persName>
                 </title>
@@ -980,11 +968,9 @@
                 </author>
                 <title xml:lang="en">Replies by one of the orthodox (viz.
                     <persName ref="http://syriaca.org/person/68">Sergius</persName>, or <persName ref="http://syriaca.org/person/68">Sergūnā</persName>, a recluse of the
-                  convent at <placeName ref="http://syriaca.org/place/621">Nicæa</placeName>), addressed to the priest <persName>John
-                    the Aged (<foreign xml:lang="syr">ܣܒܐ</foreign>), of <placeName>Rās'ain</placeName>
+                  convent at <placeName ref="http://syriaca.org/place/621">Nicæa</placeName>), addressed to the priest <persName>John the Aged (<foreign xml:lang="syr">ܣܒܐ</foreign>), of <placeName>Rās'ain</placeName>
                   </persName>, in answer to
-                  certain questions propounded to the latter by the priest <persName>John the
-                    Lame</persName> (<foreign xml:lang="syr">ܚܓܝܪܐ</foreign>), who had left <placeName ref="http://syriaca.org/place/2690">the convent of Mār Bassus</placeName>.</title>
+                  certain questions propounded to the latter by the priest <persName>John the Lame</persName> (<foreign xml:lang="syr">ܚܓܝܪܐ</foreign>), who had left <placeName ref="http://syriaca.org/place/2690">the convent of Mār Bassus</placeName>.</title>
                 <rubric xml:lang="syr">ܦܘܢܝ ܦܬܓܡܐ ܐܘ ܟܝܬ ܫܪܝܐ ܕܗܘ̣ܐ ܡܢ ܐܢܫ ܬܪܝܨ ܫܘܒܚܐ̣. ܠܘܩܒܠ ܬܒ̈ܥܬܐ
                   ܗܠܝܢ ܕܬܒ̣ܥ܇ ܩܫܝܫܐ ܝܘܚܢܢ ܗ̇ܘ ܕܢܦ̇ܝܩ ܡܢ ܥܘܡܪܐ ܩܕܝܫܐ ܕܡܪܝ ܒܣ܀ ܟܪܛܝܣܐ ܝܗܒ̣ܬ ܠܝ ܐܒܗܘܬܟ
                   ܠܩܪܝܢܐ̣. ܘܟܕ ܐܫ̇ܬܐ̣ܠܬ ܡܢܝ: ܕܡܢ ܡܢ̣ܘ ܐܬܝܗܒ ܠܟ: ܘܒܐ̈ܝܕܝ ܡܢ̣ܘ ܟܬܝܒ̣. ܐܡ̣ܪܬ ܠܝ ܕܐܬܬܨܚ
@@ -1034,8 +1020,7 @@
                   <persName xml:lang="en">Theodore</persName>
                 </author>
                 <title xml:lang="en">Synodical letter of <persName>Theodore</persName> of
-                    <placeName ref="http://syriaca.org/place/572">Alexandria</placeName> to <persName ref="http://syriaca.org/person/72">Paul of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                    <placeName ref="http://syriaca.org/place/572">Alexandria</placeName> to <persName ref="http://syriaca.org/person/72">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܣܘܢܗܘܕܝܩܐ ܕܐܫ̣ܬܕܪܬ ܡܢ ܚܣܝܐ ܘܛܘܒܬܢܐ ܡܪܝ ܬܐܘܕܘܪܐ ܦܛܪܝܪܟܐ

--- a/data/tei/34.xml
+++ b/data/tei/34.xml
@@ -367,8 +367,7 @@
                 </msItem>
                 <msItem xml:id="c25" n="28">
                   <locus from="47a" to="51"/>
-                  <title>Hom. xxx. On <persName>Simeon
-                    Stylites</persName>
+                  <title>Hom. xxx. On <persName>Simeon Stylites</persName>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="47a" to="47a"/>ܥܠ ܩܕܝܫܐ ܫܡܥܘܢ
@@ -384,8 +383,7 @@
                 </msItem>
                 <msItem xml:id="c27" n="30">
                   <locus from="55a" to="58"/>
-                  <title>Hom, xxxii. On S.<persName>John the
-                      Baptist</persName>
+                  <title>Hom, xxxii. On S.<persName>John the Baptist</persName>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="55a" to="55a"/>ܕܥܠ ܝܘܚܢܢ

--- a/data/tei/340.xml
+++ b/data/tei/340.xml
@@ -216,8 +216,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName> on his brother <persName ref="http://syriaca.org/person/1640">Caesarius</persName>
+                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> on his brother <persName ref="http://syriaca.org/person/1640">Caesarius</persName>
               </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܓܘܪܝܘܣ ܡܡܠܠ ܐܠܗ̈ܝܬܐ. ܡܢ ܡܐܡܪܐ ܕܥܠ ܩܒܘܪܬܐ ܕܩܣܪܝܣ
                 ܐܚܘܗܝ.</rubric>
@@ -227,8 +226,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>
+                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
               </title>
                 <msItem xml:id="p1b1" n="9">
                   <locus from="69a"/>
@@ -267,8 +265,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName> on his sister <persName ref="http://syriaca.org/person/1757">Gorgonia</persName>
+                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> on his sister <persName ref="http://syriaca.org/person/1757">Gorgonia</persName>
               </title>
                 <rubric xml:lang="syr">ܕܝܠܗ̣ ܕܓܪܓܪܝܘܣ. ܡܢ ܡܐܡܪܐ ܕܥܠ ܓܘܪܓܘܢܝܐ ܚܬܗ</rubric>
               </msItem>
@@ -277,8 +274,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen </persName>
                 </author>
-                <title xml:lang="en">The second epistle of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName> to <persName>Cledonius</persName>
+                <title xml:lang="en">The second epistle of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> to <persName>Cledonius</persName>
               </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܢܗ ܕܩܕܝܫܐ ܓܪܝܓܘܪܝܣ ܠܗ ܠܩܠܝܕܢܝܣ</rubric>
                 <note>See <bibl>Opera, t. ii., p. 93, ep. cii</bibl>.</note>
@@ -356,8 +352,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName> on his father <persName>Gregory</persName>
+                <title xml:lang="en">Extract from the funeral sermon of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> on his father <persName>Gregory</persName>
               </title>
                 <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ̣ ܡܢ ܡܐܡܪܐ ܕܥܠ ܩܒܘܪܬܗ ܕܓܪܝܓܪܝܣ ܐܒܘܗܝ ܕܥܒܝܕ ܗܘܐ ܐܦ ܗ̣ܘ
                 ܐܦܣܩܘܦܐ ܒܢܙܝܢܙܘ</rubric>
@@ -378,8 +373,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
-                <title xml:lang="en">Seven chapters of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  Mabuūg</persName> against those who say, that what is bad in the doctrines of
+                <title xml:lang="en">Seven chapters of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabuūg</persName> against those who say, that what is bad in the doctrines of
                 heretics should be anathematized, but not themselves and their whole
                 doctrine</title>
                 <rubric xml:lang="syr">ܪ̈ܝܫܐ ܐܚܪ̈ܢܐ ܐܝ̈ܕܝܥܐ ܕܐܡܝܪܝܢ ܠܦܝܠܟܣܢܘܣ ܠܘܩܒܠ ܐܝܠܝܢ ܕܐܡܪܝܢ ܕܡܢܬܐ

--- a/data/tei/343.xml
+++ b/data/tei/343.xml
@@ -149,8 +149,7 @@
                 <persName xml:lang="en">Isaac of Antioch
               </persName>
               </author>
-              <title xml:lang="en"> Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>
+              <title xml:lang="en"> Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
               </title>
               <msItem xml:id="b3" n="6" defective="true">
                 <locus from="31a" to="38">Foll. 31a-38</locus>

--- a/data/tei/343.xml
+++ b/data/tei/343.xml
@@ -116,8 +116,7 @@
                 <persName xml:lang="en">John Chrysostom</persName>
               </author>
               <rubric xml:lang="syr">ܦܘܫܩܐ ܕܪܚܲܡ ܥܠܝ ܠܦܘܡܐ ܕܕܗܒܐ.</rubric>
-              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName> on Psalm li.</title>
+              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on Psalm li.</title>
               <finalRubric xml:lang="syr">ܫ̣ܠܡ ܦܘܫܩܐ ܕܥܠ ܪܚܡ ܥܠܝ ܐܠܗܐ ܐܝܟ ܛܝܒܘܬܟ. ܕܐܡܝܪ
                         ܠܩܕܝܫܐ ܝܘܚܢܢ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ.<locus from="14a" to="14"/>
               </finalRubric>
@@ -131,8 +130,7 @@
               </title>
               <msItem xml:id="b1" n="3">
                 <locus from="14a" to="20">Foll. 14a-20</locus>
-                <title xml:lang="en">On <persName>Zacchaeus the
-                           publican</persName>
+                <title xml:lang="en">On <persName>Zacchaeus the publican</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܙܟܝ ܡܟܣܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 317, no 95</bibl>.</note>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -138,8 +138,7 @@
               <author ref="http://syriaca.org/person/781">
                 <persName xml:lang="en">Theodoret</persName>
               </author>
-              <title xml:lang="en">The life of <persName>Jacob of <placeName>Nisibis</placeName>
-                </persName>, from <ref>the Philotheus or Historia Religiosa of <persName>Theodoret</persName>, no. i</ref>
+              <title xml:lang="en">The life of <persName>Jacob of <placeName>Nisibis</placeName></persName>, from <ref>the Philotheus or Historia Religiosa of <persName>Theodoret</persName>, no. i</ref>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܢܨܚ̈ܢܘܗܝ ܕܡܪܝ ܝܥܩܘܒ ܐܦܣܩܦܐ</rubric>
               <note>Very imperfect.</note>
@@ -149,8 +148,7 @@
               <author ref="http://syriaca.org/person/781">
                 <persName xml:lang="en">Theodoret</persName>
               </author>
-              <title xml:lang="en">The life of <persName>Abraham, bishop of <placeName>Ḥarrān</placeName>
-                </persName>, from <ref>the Philotheus or Historia Religiosa of <persName>Theodoret</persName>, no. xvii</ref>
+              <title xml:lang="en">The life of <persName>Abraham, bishop of <placeName>Ḥarrān</placeName></persName>, from <ref>the Philotheus or Historia Religiosa of <persName>Theodoret</persName>, no. xvii</ref>
               </title>
               <rubric xml:lang="syr">ܢܨܚ̈ܢܘܗܝ ܕܩܕܝܫܐ ܡܪܝ ܐܒܪܗܡ ܐܦܣܩܦܐ ܕܚܪܢ</rubric>
             </msItem>
@@ -194,8 +192,7 @@
                 <author ref="http://syriaca.org/person/668">
                   <persName xml:lang="en">Palladius</persName>
                 </author>
-                <title xml:lang="en">Of <persName>John of <placeName>Lycopolis</placeName>
-                  </persName>
+                <title xml:lang="en">Of <persName>John of <placeName>Lycopolis</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܝܘܚܢܢ ܛܘܒܢܐ [ܕܠܩܘ]</rubric>
               </msItem>
@@ -204,8 +201,7 @@
                 <author ref="http://syriaca.org/person/668">
                   <persName xml:lang="en">Palladius</persName>
                 </author>
-                <title xml:lang="en">Of <persName>the solitary brethren, who were tempted by <persName>Satan</persName>
-                  </persName>
+                <title xml:lang="en">Of <persName>the solitary brethren, who were tempted by <persName>Satan</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܐܚ̈ܐ ܝܚܝ̈ܕܝܐ ܕܐܬܢܣܝܘ ܡܢ ܣܛܢܐ</rubric>
               </msItem>
@@ -464,8 +460,7 @@
               <author ref="http://syriaca.org/person/431">
                 <persName xml:lang="en">Cyril, bishop of Jerusalem</persName>
               </author>
-              <title xml:lang="en">Letter of <persName>Cyril, bishop of <placeName>Jerusalem</placeName>
-                </persName>
+              <title xml:lang="en">Letter of <persName>Cyril, bishop of <placeName>Jerusalem</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܘܪܝܠܘܣ ܐܦܣܩܦܐ ܕܐܘܪܫܠܡ</rubric>
               <incipit xml:lang="syr">ܩܘܪܝܠܘܣ ܐܦܣܩܦܐ ܕܐܘܪܫܠܡ. ܠܐܚ̈ܝ
@@ -486,8 +481,7 @@
               <author ref="http://syriaca.org/person/423">
                 <persName xml:lang="en">Clement of Rome</persName>
               </author>
-              <title xml:lang="en">The Recognitiones of <persName>Clement of <placeName>Rome</placeName>
-                </persName>, the disciple of <persName>S. Peter</persName>
+              <title xml:lang="en">The Recognitiones of <persName>Clement of <placeName>Rome</placeName></persName>, the disciple of <persName>S. Peter</persName>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܩܠܝܡܝܣ ܐܝܢܐ ܕܢܩܝܦ ܗܘܐ ܠܫܡܥܘܢ ܟܐܦܐ</rubric>
               <note>See <bibl>Add. 12,150, fol. 1</bibl>.</note>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -470,8 +470,7 @@
             </msItem>
             <msItem xml:id="a11" n="39" defective="true">
               <locus from="123a"/>
-              <title xml:lang="en">A small portion of the conclusion of <ref>the doctrine of <persName>S. Peter</persName>
-                </ref>
+              <title xml:lang="en">A small portion of the conclusion of <ref>the doctrine of <persName>S. Peter</persName></ref>
               </title>
               <note>See <ref>additions</ref>.</note>
             </msItem>

--- a/data/tei/347.xml
+++ b/data/tei/347.xml
@@ -219,8 +219,7 @@
                 <author ref="http://syriaca.org/person/668">
                   <persName xml:lang="en">Palladius</persName>
                 </author>
-                <title xml:lang="en">Of <placeName>the convents of <placeName>Alexandria</placeName>
-                  </placeName>
+                <title xml:lang="en">Of <placeName>the convents of <placeName>Alexandria</placeName></placeName>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܕܝܪ̈ܬܐ</rubric>
               </msItem>

--- a/data/tei/348.xml
+++ b/data/tei/348.xml
@@ -224,9 +224,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Three discourses on <ref>
-                    <persName>the Prodigal Son</persName>
-                  </ref>
+                <title xml:lang="en">Three discourses on <ref><persName>the Prodigal Son</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܛܘܠ ܗ̇ܘ ܒܪܐ ܕܦܪܚ ܢܟ̈ܣܘܗܝ</rubric>
                 <note>See <bibl>Opera, t. viii., p. 650</bibl>.</note>

--- a/data/tei/348.xml
+++ b/data/tei/348.xml
@@ -169,8 +169,7 @@
                 <persName xml:lang="en">Proclus</persName>
               </author>
               <title xml:lang="en">Testimonies from the writings of
-                  <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus, <foreign xml:lang="en">ܓܪܝܓܪܝܘܣ ܐܦܝܣܩܦܐ ܕܢܐܩܣܪܝܐ</foreign>
-                </persName>, <persName>Basil</persName>, <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>, and <persName ref="http://syriaca.org/person/688">Proclus</persName>, read at the Council of <placeName>Ephesus</placeName>
+                  <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus, <foreign xml:lang="en">ܓܪܝܓܪܝܘܣ ܐܦܝܣܩܦܐ ܕܢܐܩܣܪܝܐ</foreign></persName>, <persName>Basil</persName>, <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>, and <persName ref="http://syriaca.org/person/688">Proclus</persName>, read at the Council of <placeName>Ephesus</placeName>
               </title>
               <rubric xml:lang="syr">
                 <locus from="50a"/>ܣܗܕܘܬܐ ܕܡܢ ܐܒ̈ܗܬܐ ܕܐܬܩܪ̈ܝ ܒܐܦܝܣܣ</rubric>
@@ -186,8 +185,7 @@
                 <author ref="http://syriaca.org/person/792">
                   <persName xml:lang="en">Timotheus of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Canons of <persName>Timotheus of <placeName>Alexandria</placeName>
-                  </persName>, six in number</title>
+                <title xml:lang="en">Canons of <persName>Timotheus of <placeName>Alexandria</placeName></persName>, six in number</title>
                 <rubric xml:lang="syr">ܬܘܒ ܩܢ̈ܘܢܐ ܕܣܝܡܝܢ ܠܡܪܝ ܛܝܡܬܐܘܣ</rubric>
               </msItem>
               <msItem xml:id="b2" n="8">
@@ -200,8 +198,7 @@
                 <author ref="http://syriaca.org/person/784">
                   <persName xml:lang="en">Theodosius of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Canons of <persName>Theodosius of <placeName>Alexandria</placeName>
-                  </persName>, five in number</title>
+                <title xml:lang="en">Canons of <persName>Theodosius of <placeName>Alexandria</placeName></persName>, five in number</title>
                 <rubric xml:lang="syr">ܩܢ̈ܘܢܐ ܕܣܝ̣ܡܝܢ ܠܩܕܝܫܐ ܘܛܘܒܬܢܐ ܪܫܐ ܕܐܦܝ̈ܣܩܦܐ ܡܪܝ ܬܐܘܕܣܝܣ. ܕܐܬܥܒܕܘ ܡܢܗ ܒܩܘܣܛܢܛܝܢܦܘܠܝܣ̣. ܟܕ ܪܕܝܦ ܡܢ ܟܘܪܣܝܐ ܕܪܚܡܬ ܠܡܫܝܚܐ ܐܠܟܣܢܕܪܝܐ</rubric>
               </msItem>
             </msItem>
@@ -240,8 +237,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">The Creed of <persName>Severus of <placeName>Antioch</placeName>
-                </persName>
+              <title xml:lang="en">The Creed of <persName>Severus of <placeName>Antioch</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܗܝܡܢܘܬܐ ܕܡܪܝ ܣܐܘܪܐ</rubric>
               <incipit xml:lang="syr">ܡܢ ܕܠܦܓܪܗ ܘܕܡܗ ܕܡܪܢ
@@ -254,8 +250,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">Metrical discourses of <persName>Jacob of <placeName>Batnae</placeName>
-                </persName>
+              <title xml:lang="en">Metrical discourses of <persName>Jacob of <placeName>Batnae</placeName></persName>
               </title>
               <msItem xml:id="b6" n="15">
                 <locus from="72a" to="75a"/>

--- a/data/tei/348.xml
+++ b/data/tei/348.xml
@@ -170,8 +170,7 @@
               </author>
               <title xml:lang="en">Testimonies from the writings of
                   <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus, <foreign xml:lang="en">ܓܪܝܓܪܝܘܣ ܐܦܝܣܩܦܐ ܕܢܐܩܣܪܝܐ</foreign>
-                </persName>, <persName>Basil</persName>, <persName ref="http://syriaca.org/person/573">John
-                      Chrysostom</persName>, and <persName ref="http://syriaca.org/person/688">Proclus</persName>, read at the Council of <placeName>Ephesus</placeName>
+                </persName>, <persName>Basil</persName>, <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>, and <persName ref="http://syriaca.org/person/688">Proclus</persName>, read at the Council of <placeName>Ephesus</placeName>
               </title>
               <rubric xml:lang="syr">
                 <locus from="50a"/>ܣܗܕܘܬܐ ܕܡܢ ܐܒ̈ܗܬܐ ܕܐܬܩܪ̈ܝ ܒܐܦܝܣܣ</rubric>

--- a/data/tei/349.xml
+++ b/data/tei/349.xml
@@ -206,8 +206,7 @@
                   <author ref="http://syriaca.org/person/44">
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
-                  <title xml:lang="en">Two extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                      Mabūg</persName> on prayer</title>
+                  <title xml:lang="en">Two extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName> on prayer</title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ ܕܥܠ ܨܠܘܬܐ</rubric>
                 </msItem>
                 <msItem xml:id="c4" n="13">
@@ -215,8 +214,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Two extracts from <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName>
+                  <title xml:lang="en">Two extracts from <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܫܠܝܚܐ</rubric>
                 </msItem>
@@ -300,8 +298,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the monk</persName>
                 </author>
-                <title xml:lang="en">Extract from a discourse of <persName>John the
-                    monk</persName> on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. v. 4</ref>
+                <title xml:lang="en">Extract from a discourse of <persName>John the monk</persName> on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. v. 4</ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܕܝܘܚܢܢ ܝܚܝܕܝܐ ܡܛܠ ܕܐܡ̣ܪ ܡܪܢ. ܛ̇ܘܒܝܗܘܢ ܠܐܒ̈ܝܠܐ ܕܗ̣ܢܘܢ
                   ܢܬܒܐܝܘܢ.</rubric>
@@ -614,8 +611,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Funeral sermons of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>
+                <title xml:lang="en">Funeral sermons of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                 <msItem xml:id="c30" n="51">
                   <locus from="76b"/>

--- a/data/tei/35.xml
+++ b/data/tei/35.xml
@@ -375,8 +375,7 @@
                 </msItem>
                 <msItem xml:id="p2b3" n="4">
                   <locus from="128b" to="134">Foll. 128b-134</locus>
-                  <title>The history of the <persName ref="http://syriaca.org/person/607">Man of God</persName> from the city of <placeName ref="http://syriaca.org/place/641">Rome</placeName> who lived in the time of <persName ref="http://syriaca.org/person/26">Rabulas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>
+                  <title>The history of the <persName ref="http://syriaca.org/person/607">Man of God</persName> from the city of <placeName ref="http://syriaca.org/place/641">Rome</placeName> who lived in the time of <persName ref="http://syriaca.org/person/26">Rabulas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܓܒܪܐ ܕܐܠܗܐ ܕܡܢ ܪܗܘܡܐ ܡܕܝܢܬܐ̣. ܕܐܬܢܨܚ ܘܐܬܟܠܠ ܒܡܣܪܩܘܬܐ ܘܒܥܡܠܐ ܕܡܛܠ ܡܫܝܚܐ̇. ܒܝ̈ܘܡܝ ܩܕܝܫܐ ܡܪܝ ܪܒܘܠܐ ܐܦܣܩܦܐ ܕܐܘܪܗܝ..<locus from="128b"/>
                   </rubric>

--- a/data/tei/351.xml
+++ b/data/tei/351.xml
@@ -354,8 +354,7 @@
                   <author ref="http://syriaca.org/person/430">
                     <persName xml:lang="en">Cyril of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Two extracts from the commentary on <ref target="http://syriaca.org/work/9607">the Epistle to the
-                  Hebrews</ref>
+                  <title xml:lang="en">Two extracts from the commentary on <ref target="http://syriaca.org/work/9607">the Epistle to the Hebrews</ref>
                   </title>
                   <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܡܢ ܦܘܫܩܐ ܕܐܓܪܬܐ ܕܫܠܝܚܐ ܕܠܘܬ ܥܒܪ̈ܝܐ.<locus from="132a"/>
                   </rubric>
@@ -619,8 +618,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Short extracts from tbe commentary of <persName ref="http://syriaca.org/person/430">Cyril</persName> on <ref target="http://syriaca.org/work/9648">the Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </ref>
+                <title xml:lang="en">Short extracts from tbe commentary of <persName ref="http://syriaca.org/person/430">Cyril</persName> on <ref target="http://syriaca.org/work/9648">the Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ</rubric>
               </msItem>

--- a/data/tei/351.xml
+++ b/data/tei/351.xml
@@ -288,8 +288,7 @@
                 <author ref="http://syriaca.org/person/21">
                   <persName xml:lang="en">Gregory the monk</persName>
                 </author>
-                <title xml:lang="en">Extract from the discourse of <persName ref="http://syriaca.org/person/21">Gregory the
-                  monk</persName> concerning the brethren who dwell in cells</title>
+                <title xml:lang="en">Extract from the discourse of <persName ref="http://syriaca.org/person/21">Gregory the monk</persName> concerning the brethren who dwell in cells</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܝܚܝܕܝܐ ܡܢ ܡܐܡܪܐ ܕܥܠ ܐܚ̈ܐ ܕܒܩ̈ܠܝܬܐ</rubric>
                 <incipit xml:lang="syr">
                   <locus from="107"/>ܐܝܟܢܐ ܕܡܠܚܐ ܡܩܢܝܐ ܛܥܡܐ ܗܢܝ ܠܚܟܐ̇. ܠܟܠܗܘܢ ܬܘܩ̈ܢܐ ܕܢܦܠܐ ܒܗܘܢ̣. ܗܟܢܐ ܘܐܦ ܡܟܝܟܘܬܐ ܕܒܝܬ ܡܪܢ̣. ܡܩܢܝܐ ܚܝܠܐ ܠܟܠܗܝܢ ܡܝܬܪ̈ܬܐ ܐܝܠܝܢ ܕܒܗ̇ ܡܬܦ̈ܠܚܢ. ܏ܘܫ.</incipit>
@@ -338,8 +337,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/430">Cyril of
-                  Alexandria</persName>
+                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>
                 </title>
                 <msItem xml:id="p1b23" n="29">
                   <locus from="130b"/>
@@ -378,8 +376,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                Mabūg</persName>
+                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName>
                 </title>
                 <msItem xml:id="p1b26" n="33">
                   <locus from="140b"/>
@@ -420,8 +417,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/33">Isaac of
-                Antioch</persName>
+                <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName>
                 </title>
                 <msItem xml:id="p1b28" n="37">
                   <locus from="144a"/>
@@ -479,8 +475,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Extract from a discourse on the <persName>prophet
-                    Elijah</persName>
+                  <title xml:lang="en">Extract from a discourse on the <persName>prophet Elijah</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܏ܡܐ ܕܥܠ ܐܠܝܐ ܢܒܝܐ</rubric>
                 </msItem>
@@ -490,8 +485,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Extract from the discourse of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName> on love of the poor</title>
+                <title xml:lang="en">Extract from the discourse of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> on love of the poor</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܬܐܠܘܓܘܣ ܡܢ ܏ܡܐ ܕܪܚܡܬ ܡܣ̈ܟܢܐ</rubric>
               </msItem>
               <msItem xml:id="p1a12" n="44">
@@ -499,8 +493,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
-                <title xml:lang="en">Extracts from the commentary of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  Mabug</persName> on <ref target="http://syriaca.org/work/9646">the Gospel of S. Matthew</ref>
+                <title xml:lang="en">Extracts from the commentary of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabug</persName> on <ref target="http://syriaca.org/work/9646">the Gospel of S. Matthew</ref>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܐܟܣܢܝܐ ܡܢ ܟܬܒܐ ܕܦܘܫܩܐ ܕܡܬܝ</rubric>
               </msItem>
@@ -569,8 +562,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Extract from the commentary of <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName> on <ref target="http://syriaca.org/work/9595">the first Epistle to the Corinthians</ref>, hom. xlii.</title>
+                <title xml:lang="en">Extract from the commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9595">the first Epistle to the Corinthians</ref>, hom. xlii.</title>
                 <rubric xml:lang="syr">ܡܢ ܏ܡܐ ܕ܏ܡܒ ܕܦܘܫܩܐ ܕܐܓܪܬܐ ܕܠܘܬ ܩܘܪ̈ܢܬܝܐ ܏ܩ</rubric>
               </msItem>
               <msItem xml:id="p1a18" n="52">
@@ -594,8 +586,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">Short extracts from the writings of <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                <title xml:lang="en">Short extracts from the writings of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                 <rubric xml:lang="syr">ܡ̈ܠܐ ܓܘ̈ܢܝܬܐ ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܬܐܘܠܘܓܘܣ</rubric>
                 <msItem xml:id="p1b35" n="55">
@@ -619,8 +610,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Short extracts from the commentaries of <persName ref="http://syriaca.org/person/573">John
-                Chrysostom</persName> on the <ref target="http://syriaca.org/work/9643">Epistles</ref> of <persName ref="http://syriaca.org/person/1983">S. Paul</persName>
+                <title xml:lang="en">Short extracts from the commentaries of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the <ref target="http://syriaca.org/work/9643">Epistles</ref> of <persName ref="http://syriaca.org/person/1983">S. Paul</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܘܐܢܝܣ ܡܢ ܦܘܫܩܐ ܕܫܠܝܚܐ</rubric>
               </msItem>
@@ -672,8 +662,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Short extracts from discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>
+                <title xml:lang="en">Short extracts from discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ</rubric>
               </msItem>
@@ -691,8 +680,7 @@
                 <author ref="http://syriaca.org/person/452">
                   <persName xml:lang="en">Dionysius the Areopagite</persName>
                 </author>
-                <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/452">Dionysius the
-                Areopagite</persName>, on prayer</title>
+                <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>, on prayer</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܕܝܢܣܝܘܣ ܠܘܬ ܛܝܡܬܐܘܣ. ܥܠ ܨܠܘܬܐ</rubric>
               </msItem>
               <msItem xml:id="p1a27" n="66">
@@ -700,8 +688,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Extracts from a prose homily of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>
+                <title xml:lang="en">Extracts from a prose homily of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ</rubric>
                 <incipit xml:lang="syr">ܥܕܠܐ ܥܡ̇ܕ ܠܗ ܝܘܡܐ ܐܬܟܫܪ ܥܠ ܥܒ̇ܕܟ ܠܐ ܬܠܐܐ ܒܕܠܐ ܕܝܠܟ̇. ܘܬܪܦܐ

--- a/data/tei/355.xml
+++ b/data/tei/355.xml
@@ -306,8 +306,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah Abbat of Scete</persName>
                 </author>
-                <title xml:lang="en">Selections and extracts from the writings of <persName ref="http://syriaca.org/person/548">
-                  Isaiah, abbat of Scete</persName>
+                <title xml:lang="en">Selections and extracts from the writings of <persName ref="http://syriaca.org/person/548">Isaiah, abbat of Scete</persName>
               </title>
               </msItem>
               <msItem xml:id="p1a9" n="18" defective="true">

--- a/data/tei/356.xml
+++ b/data/tei/356.xml
@@ -195,8 +195,7 @@
               <author ref="http://syriaca.org/person/22">
                 <persName xml:lang="en">Xystus</persName>
               </author>
-              <title xml:lang="en">The greater part of the first discourse of <persName ref="http://syriaca.org/person/22">Xystus of <placeName>Rome</placeName>
-                </persName>
+              <title xml:lang="en">The greater part of the first discourse of <persName ref="http://syriaca.org/person/22">Xystus of <placeName>Rome</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܡ̈ܠܐ ܡ̈ܓܒܝܬܐ ܡܢ ܟܣܘܣܛܘܣ ܐܦܣܩܘܦܐ ܕܪܗܘܡܐ</rubric>
               <note>see <bibl>de Lagarde's Analecta Syr., as far as p. 9, line 26</bibl>.</note>

--- a/data/tei/356.xml
+++ b/data/tei/356.xml
@@ -202,8 +202,7 @@
             </msItem>
             <msItem xml:id="a3" n="11">
               <locus from="95b"/>
-              <title xml:lang="en">Questions asked of <persName>the holy Fathers</persName>, being extracts from the <ref>Lives of the <persName>Egyptian Fathers</persName>
-                </ref>
+              <title xml:lang="en">Questions asked of <persName>the holy Fathers</persName>, being extracts from the <ref>Lives of the <persName>Egyptian Fathers</persName></ref>
               </title>
               <rubric xml:lang="syr">ܫܘܐ̈ܠܐ ܕܐܫܬܐܠܘ ܣܒ̈ܐ ܛܘܒ̈ܢܐ</rubric>
             </msItem>

--- a/data/tei/357.xml
+++ b/data/tei/357.xml
@@ -264,8 +264,7 @@
               <author ref="http://syriaca.org/person/548">
                 <persName xml:lang="en">Isaiah of Scete</persName>
               </author>
-              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>
+              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
               </title>
               <msItem xml:id="b9" n="20">
                 <locus from="63a"/>

--- a/data/tei/358.xml
+++ b/data/tei/358.xml
@@ -394,8 +394,7 @@
                 <persName xml:lang="en">Porphyry</persName>
               </author>
               <title xml:lang="en">Part of <persName>Porphyry</persName>'s Introduction to
-                <ref>the Categories of <persName>Aristotle</persName>
-                </ref>
+                <ref>the Categories of <persName>Aristotle</persName></ref>
               </title>
               <incipit xml:lang="syr">ܠܒܪܢܫܐ ܗ̇ܘ ܕܓܘܐ̇. ܘܠܦܘܪܫܢܐ ܬܘܒ ܗ̇ܘ ܕܡܠܝܠܘܬܐ</incipit>
               <finalRubric xml:lang="syr">

--- a/data/tei/358.xml
+++ b/data/tei/358.xml
@@ -139,8 +139,7 @@
               <author ref="http://syriaca.org/person/544">
                 <persName xml:lang="en">Ignatius of Antioch</persName>
               </author>
-              <title xml:lang="en">Three letters of <persName ref="http://syriaca.org/person/544">Ignatius of <placeName>Antioch</placeName>
-                </persName>
+              <title xml:lang="en">Three letters of <persName ref="http://syriaca.org/person/544">Ignatius of <placeName>Antioch</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܐܓܪ̈ܬܐ ܬܠܬ ܕܐܝܓܢܛܝܘܣ ܐܦܣܝܩܘܦܐ ܘܣܗܕܐ</rubric>
               <note>On these letters see <bibl>Cureton's Corpus Ignatianum, where this manuscript is
@@ -198,8 +197,7 @@
               <author ref="http://syriaca.org/person/33">
                 <persName xml:lang="en">Isaac of Antioch</persName>
               </author>
-              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
-                </persName>
+              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName></persName>
               </title>
               <msItem xml:id="b5" n="11">
                 <locus from="18a"/>
@@ -260,10 +258,7 @@
             </msItem>
             <msItem xml:id="a8" n="17">
               <locus from="27b"/>
-              <title xml:lang="en">Sayings of <persName>
-                  <foreign xml:lang="syr">ܦܢܕܪܘܣ</foreign>, Pindarus</persName>, <persName>Aristippus, <foreign xml:lang="syr">ܐܪܝܣܛܝܦܘܣ</foreign>
-                </persName>, and <persName>Kritus, <foreign xml:lang="syr">ܩܪܛܘܣ</foreign>
-                </persName>
+              <title xml:lang="en">Sayings of <persName><foreign xml:lang="syr">ܦܢܕܪܘܣ</foreign>, Pindarus</persName>, <persName>Aristippus, <foreign xml:lang="syr">ܐܪܝܣܛܝܦܘܣ</foreign></persName>, and <persName>Kritus, <foreign xml:lang="syr">ܩܪܛܘܣ</foreign></persName>
               </title>
               <note>The name <foreign xml:lang="syr">ܦܢܕܪܘܣ</foreign> is perhaps a mistake for <persName>
                   <foreign xml:lang="en">ܦܝܕܪܘܣ</foreign>, Phaedrus</persName>, or perhaps for <persName>

--- a/data/tei/358.xml
+++ b/data/tei/358.xml
@@ -188,8 +188,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of
-                <placeName>Batnae</placeName>, entitled parænesis</persName>
+              <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>, entitled parænesis</persName>
               </title>
               <rubric xml:lang="syr">ܕܡܪܬܝܢܘܬܐ</rubric>
               <note>See <bibl>Assemani, Bibl. Or., t. i., p. 316, no. 79, serm. i</bibl>.</note>

--- a/data/tei/360.xml
+++ b/data/tei/360.xml
@@ -131,9 +131,7 @@
                 <persName xml:lang="en">Secundus</persName>
               </author>
               <title xml:lang="en">Some account of 
-                <persName ref="http://syriaca.org/person/727">
-                  Secundus, <foreign xml:lang="syr">ܣܩܘܢܕܘܣ</foreign>, <foreign xml:lang="grc">Σεκοῦνδος</foreign>
-                </persName>, <quote xml:lang="en">the silent philosopher,</quote> and his interview with the emperor 
+                <persName ref="http://syriaca.org/person/727">Secundus, <foreign xml:lang="syr">ܣܩܘܢܕܘܣ</foreign>, <foreign xml:lang="grc">Σεκοῦνδος</foreign></persName>, <quote xml:lang="en">the silent philosopher,</quote> and his interview with the emperor 
                 <persName ref="http://syriaca.org/person/2657">Hadrian</persName>
               </title>
               <finalRubric xml:lang="syr">ܫܠܡ ܣܩܘܢܕܘܣ: ܦܝܠܣܘܦܐ ܫܬܝܩܐ<locus from="2a"/>

--- a/data/tei/360.xml
+++ b/data/tei/360.xml
@@ -157,8 +157,7 @@
             </msItem>
             <msItem xml:id="a5" n="5">
               <locus from="4b"/>
-              <title xml:lang="en">A short account of the various Greek translations of <ref target="http://syriaca.org/work/9586">the
-                Old Testament</ref>, and of the labours of <persName ref="http://syriaca.org/person/2728">Origen</persName>
+              <title xml:lang="en">A short account of the various Greek translations of <ref target="http://syriaca.org/work/9586">the Old Testament</ref>, and of the labours of <persName ref="http://syriaca.org/person/2728">Origen</persName>
               </title>
               <rubric xml:lang="syr">ܫܘܕܥܐ ܕܣܓܝ ܚ̇ܫܚ: ܡܛܠ ܡܫܠܡܢܘܬܐ: ܕܟܬܒ̈ܐ ܩܕܝ̈ܫܐ ܘܐܠܗ̈ܝܐ: ܘܕܐܝܟܢܐ
                 ܐܬܦܫܩܘ: ܡܢ ܠܫܢܐ ܥܒ̣ܪܝܐ ܠܝܘܢܝܐ</rubric>
@@ -355,8 +354,7 @@
               <author ref="http://syriaca.org/person/144">
                 <persName xml:lang="en">David of Beth-rabban</persName>
               </author>
-              <title xml:lang="en">A treatise on the <ref target="http://syriaca.org/work/9628">tenth chapter of
-                Genesis</ref>
+              <title xml:lang="en">A treatise on the <ref target="http://syriaca.org/work/9628">tenth chapter of Genesis</ref>
               </title>
               <rubric xml:lang="syr">ܡܛܠ ܫܪ̈ܒܬܐ܇ ܕܒ̈ܢܝ ܢܘܚ: ܕܡܬܪ̈ܨܢ ܘܡܢܗܪ̈ܢ̣. ܠܕܘܝܕ ܕܒܝܬ
                 ܪܒܢ</rubric>

--- a/data/tei/363.xml
+++ b/data/tei/363.xml
@@ -150,8 +150,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the monk</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName>John the
-                  monk</persName>
+                <title xml:lang="en">Selections from the writings of <persName>John the monk</persName>
               </title>
                 <msItem xml:id="p1b1" n="2">
                   <locus from="1a"/>
@@ -358,8 +357,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName>
+                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
               </title>
                 <rubric xml:lang="syr">ܬܚ̈ܘܝܬܐ ܡ̈ܓܒܝܬܐ ܕܡܪܝ ܝܘܗܢܝܣ ܡܠܦܢܐ</rubric>
                 <msItem xml:id="p1b18" n="23">
@@ -535,8 +533,7 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/51">Severus of
-                  Antioch</persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/51">Severus of Antioch</persName>
               </title>
                 <msItem xml:id="p1b33" n="42">
                   <locus from="46b"/>
@@ -595,8 +592,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Consolatory discourse for the Dead by <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName>
+                <title xml:lang="en">Consolatory discourse for the Dead by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
               </title>
                 <rubric xml:lang="syr">ܬܘܪܓܡܐ ܐܘܟܝܬ ܒܘܝܐܐ ܕܥܢ̈ܝܕܐ ܕܡܪܝ ܝܘܗܢܝܣ</rubric>
                 <incipit xml:lang="syr">ܚ̈ܒܝܒܝ ܡܦܣܝܢܢ ܕܩܫܝܐ ܟܪܝܘܬܐ ܕܚ̈ܒܝܒܝܗܘܢ ܕܒ̈ܢܝܢܫܐ ܥܠܝܗܘܢ.
@@ -685,8 +681,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName> to <persName>Patricius of
-                Edessa</persName>
+                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName> to <persName>Patricius of Edessa</persName>
               </title>
                 <rubric xml:lang="syr">ܐܝܓܪܬܐ ܕܡܪܝ ܐܟܣܢܝܐ ܠܘܬ ܦܛܪܝܩ ܐܝܚܝܕܐ ܐܘܪܗܝܐ. ܠܘܩܒܠ ܚ̈ܫܐ ܕܢܦܫܐ
                 ܘܥܠ ܕܟܝܘܬܐ ܕܝܠܗ̇. ܏ܘܫ.</rubric>
@@ -707,8 +702,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril of
-                Alexandria</persName>
+                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril of Alexandria</persName>
               </title>
                 <msItem xml:id="p1b44" n="61">
                   <locus from="81b"/>
@@ -733,8 +727,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Two penitential canticles of <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>
+                <title xml:lang="en">Two penitential canticles of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
               </title>
                 <rubric xml:lang="syr">ܣܘ̈ܓܝܬܐ ܕܥܠ ܬܘܬ ܢܦܫܐ ܕܣܝܡܢ ܠܡܪܝ ܝܥܩܘܒ</rubric>
                 <msItem xml:id="p1b46" n="64">

--- a/data/tei/364.xml
+++ b/data/tei/364.xml
@@ -154,8 +154,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">Three metrical discourses of <persName>Jacob of <placeName>Batnae</placeName>
-                </persName>
+              <title xml:lang="en">Three metrical discourses of <persName>Jacob of <placeName>Batnae</placeName></persName>
               </title>
               <msItem xml:id="b4" n="7">
                 <locus from="10a"/>
@@ -172,8 +171,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <persName>Alexander the son of <persName>Philip, the Macedonian</persName>
-                  </persName>, and on
+                <title xml:lang="en">On <persName>Alexander the son of <persName>Philip, the Macedonian</persName></persName>, and on
                   the gate in the north, which faces towards Gog and Magog</title>
                 <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܩܕܝܫܐ ܡܪܝܥܩܘܒ ܡܐܡܪܐ ܕܥܠ ܐܠܟܣܢܕܪܘܣ ܒܪ ܦܝܠܦܘܣ
                   ܡܩܕܘܢܝܐ ܘܥܠ ܗ̇ܘ ܬܪܥܐ ܕܓܪܒܝܐ ܕܒܐ̈ܦܝ ܓܘܓ ܘܡܓܘܓ</rubric>

--- a/data/tei/368.xml
+++ b/data/tei/368.xml
@@ -369,8 +369,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">Portions of a controversial treatise against <persName>the Nestorians</persName>, in the form of a dialogue between the Church (<foreign xml:lang="syr">ܥܕܬܐ</foreign>) and a Nestorian (<foreign xml:lang="syr">ܢܣܛܘܪ</foreign>), by <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                </persName>
+                <title xml:lang="en">Portions of a controversial treatise against <persName>the Nestorians</persName>, in the form of a dialogue between the Church (<foreign xml:lang="syr">ܥܕܬܐ</foreign>) and a Nestorian (<foreign xml:lang="syr">ܢܣܛܘܪ</foreign>), by <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>
               </title>
                 <note>Compare <bibl>Assemani, Bibl. Or., t. ii., p. 45, no. 15</bibl>.</note>
                 <note>We have here part of the introduction and the commencement of the disputation.</note>

--- a/data/tei/368.xml
+++ b/data/tei/368.xml
@@ -369,8 +369,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">Portions of a controversial treatise against <persName>the
-                        Nestorians</persName>, in the form of a dialogue between the Church (<foreign xml:lang="syr">ܥܕܬܐ</foreign>) and a Nestorian (<foreign xml:lang="syr">ܢܣܛܘܪ</foreign>), by <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">Portions of a controversial treatise against <persName>the Nestorians</persName>, in the form of a dialogue between the Church (<foreign xml:lang="syr">ܥܕܬܐ</foreign>) and a Nestorian (<foreign xml:lang="syr">ܢܣܛܘܪ</foreign>), by <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                 </persName>
               </title>
                 <note>Compare <bibl>Assemani, Bibl. Or., t. ii., p. 45, no. 15</bibl>.</note>

--- a/data/tei/371.xml
+++ b/data/tei/371.xml
@@ -163,8 +163,7 @@
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
                 <title xml:lang="en">The concluding portion of an abridgment
-                of the treatise of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                  </persName> against <persName>Joannes Grammaticus</persName>, comprising book iii., chapp. xxxix.—xli.</title>
+                of the treatise of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName> against <persName>Joannes Grammaticus</persName>, comprising book iii., chapp. xxxix.—xli.</title>
                 <finalRubric xml:lang="syr">
                   <locus from="5a"/>ܫܠ̣ܡ ܟܬܒܐ ܕܬܚܘ̈ܝܬܐ ܕܐܒܗ̈ܬܐ ܕܠܘܩܒܠ ܓܪܡܝܛܝܩܘܣ
                                 ܪܫܝܥܐ܀ ܟܠ ܕܩ̇ܪܐ ܡܢ ܟܠܗܘܢ ܡܗ̈ܝܡܢܐ ܕܐܪ̈ܬܕܘܟܣܘܼ. ܢܬܥܕܪ̣ ܒܨ̈ܠܘܬܗܘܢ
@@ -177,10 +176,8 @@
                   <persName xml:lang="en">John I., patriarch of Antioch</persName>
                 </author>
                 <title xml:lang="en">A Plerophoria, or Defence of the Faith,
-                                against the heresy of <persName>Julian of <placeName>Halicarnassus</placeName>
-                  </persName>, by
-                <persName ref="http://syriaca.org/person/2449">John I., patriarch of <placeName>Antioch</placeName>
-                </persName>
+                                against the heresy of <persName>Julian of <placeName>Halicarnassus</placeName></persName>, by
+                <persName ref="http://syriaca.org/person/2449">John I., patriarch of <placeName>Antioch</placeName></persName>
                             </title>
                 <rubric xml:lang="syr">ܦܠܪܦܘܪܝܐ ܕܗܝܡܢܘܬܐ ܬܪܝܨܬ ܫܘܒܚܐ ܘܫܠܝܚܝܬܐ̣. ܘܡܟܣܢܘܬܐ ܓܠܝܬܐ ܕܗܪܣܝܣ ܫܟܝܪܬܐ ܕܝܘܠܝܢܐ ܗܓܓܝܐ̣. ܘܕܗ̇ܢܘܢ ܕܒܚܫܘܟܐ ܕܛܥܝܘܬܗ ܐܚܝܕܝܢ</rubric>
                 <incipit xml:lang="syr">ܠܪ̈ܚܡܝ ܐܠܗܐ ܘܕܚ̈ܠܝ ܐܠܗܐ: ܒ̈ܢܝܐ ܕܝܠܢ ܪ̈ܘܚܢܐ
@@ -229,8 +226,7 @@
                   <locus from="21b"/>
                   <title xml:lang="en">
                   <persName>Stephen</persName> singly
-                  consecrated <persName>Barlaha, <foreign xml:lang="syr">ܒܪܠܗܐ</foreign>
-                    </persName>
+                  consecrated <persName>Barlaha, <foreign xml:lang="syr">ܒܪܠܗܐ</foreign></persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p1b3" n="7">
@@ -238,8 +234,7 @@
                   <title xml:lang="en">
                   <persName>Stephen</persName> and
                                         <persName>Barlaha</persName> together consecrated
-                  <persName>Cassianus, <foreign xml:lang="syr">ܩܣܝܢܐ</foreign>
-                    </persName>
+                  <persName>Cassianus, <foreign xml:lang="syr">ܩܣܝܢܐ</foreign></persName>
                 </title>
                 </msItem>
                 <msItem xml:id="p1b4" n="8">
@@ -257,9 +252,7 @@
                   <locus from="22a"/>
                   <title xml:lang="en">
                   <persName>Barlaha</persName> and
-                  <persName>Cassianus</persName> consecrated <persName>George bar 'Abshai, <foreign xml:lang="syr">ܓܝܘܪܓܝ ܒܪ ܥܒܫ</foreign>
-                    </persName>, and <persName>Daniel, <foreign xml:lang="syr">ܕܢܝܐܝܠ ܩܦܘܚܝܐ</foreign>
-                    </persName>
+                  <persName>Cassianus</persName> consecrated <persName>George bar 'Abshai, <foreign xml:lang="syr">ܓܝܘܪܓܝ ܒܪ ܥܒܫ</foreign></persName>, and <persName>Daniel, <foreign xml:lang="syr">ܕܢܝܐܝܠ ܩܦܘܚܝܐ</foreign></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="p1b6" n="10">

--- a/data/tei/371.xml
+++ b/data/tei/371.xml
@@ -247,12 +247,12 @@
                 <msItem xml:id="p1b4" n="8">
                   <locus from="22a"/>
                   <title xml:lang="en">
-                  <persName>Stephen</persName>'s refusal
-                                    to consecrate <persName>Zacharias</persName> as bishop of the
-                  <placeName>convent of <persName>Mar Isaac of <placeName>Gabula, <foreign xml:lang="syr">ܓܒܘܠܐ</foreign>
-                        </placeName>,</persName>
+                    <persName>Stephen</persName>'s refusal
+                    to consecrate <persName>Zacharias</persName> as bishop of the
+                    <placeName>convent of 
+                      <persName>Mar Isaac</persName> of <placeName>Gabula, <foreign xml:lang="syr">ܓܒܘܠܐ</foreign></placeName>,
                     </placeName>
-                                    produced a quarrel with <persName>the monks of that convent</persName>
+                    produced a quarrel with the monks of that convent
                   </title>
                 </msItem>
                 <msItem xml:id="p1b5" n="9">

--- a/data/tei/371.xml
+++ b/data/tei/371.xml
@@ -164,8 +164,7 @@
                 </author>
                 <title xml:lang="en">The concluding portion of an abridgment
                 of the treatise of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                  </persName> against <persName>Joannes
-                                    Grammaticus</persName>, comprising book iii., chapp. xxxix.—xli.</title>
+                  </persName> against <persName>Joannes Grammaticus</persName>, comprising book iii., chapp. xxxix.—xli.</title>
                 <finalRubric xml:lang="syr">
                   <locus from="5a"/>ܫܠ̣ܡ ܟܬܒܐ ܕܬܚܘ̈ܝܬܐ ܕܐܒܗ̈ܬܐ ܕܠܘܩܒܠ ܓܪܡܝܛܝܩܘܣ
                                 ܪܫܝܥܐ܀ ܟܠ ܕܩ̇ܪܐ ܡܢ ܟܠܗܘܢ ܡܗ̈ܝܡܢܐ ܕܐܪ̈ܬܕܘܟܣܘܼ. ܢܬܥܕܪ̣ ܒܨ̈ܠܘܬܗܘܢ
@@ -180,8 +179,7 @@
                 <title xml:lang="en">A Plerophoria, or Defence of the Faith,
                                 against the heresy of <persName>Julian of <placeName>Halicarnassus</placeName>
                   </persName>, by
-                <persName ref="http://syriaca.org/person/2449">John I., patriarch of
-                                    <placeName>Antioch</placeName>
+                <persName ref="http://syriaca.org/person/2449">John I., patriarch of <placeName>Antioch</placeName>
                 </persName>
                             </title>
                 <rubric xml:lang="syr">ܦܠܪܦܘܪܝܐ ܕܗܝܡܢܘܬܐ ܬܪܝܨܬ ܫܘܒܚܐ ܘܫܠܝܚܝܬܐ̣. ܘܡܟܣܢܘܬܐ ܓܠܝܬܐ ܕܗܪܣܝܣ ܫܟܝܪܬܐ ܕܝܘܠܝܢܐ ܗܓܓܝܐ̣. ܘܕܗ̇ܢܘܢ ܕܒܚܫܘܟܐ ܕܛܥܝܘܬܗ ܐܚܝܕܝܢ</rubric>

--- a/data/tei/371.xml
+++ b/data/tei/371.xml
@@ -303,8 +303,7 @@
                 <author>
                   <persName xml:lang="en">Thomas, abbat of the convent of Mar Isaac</persName>
                 </author>
-                <title xml:lang="en">Letter of Thomas, abbat of the <placeName>convent of <persName>Mar Isaac</persName>
-                  </placeName>
+                <title xml:lang="en">Letter of Thomas, abbat of the <placeName>convent of <persName>Mar Isaac</persName></placeName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܫܕܪ ܬܐܘܡܐ ܪܝܫܕܝܪܐ ܕܒܝܬ ܡܪܝ ܐܝܣܚܩ ܕܓܒܘܠܐ̣. ܠܘܬ ܒ̈ܢܝ ܬܪܥܝܬܗܘܢ ܕܒܡܕܢܚܐ</rubric>
                 <note>Imperfect at the end.</note>

--- a/data/tei/378.xml
+++ b/data/tei/378.xml
@@ -149,11 +149,7 @@
               <msItem xml:id="p1a1" n="1">
                 <locus from="1" to="14a">Fol. 1-14a</locus>
                 <title xml:lang="en">Part of a life of <persName ref="http://syriaca.org/person/2432">Dioscorus I</persName>., patriarch of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>, the successor of <persName ref="http://syriaca.org/person/430">Cyril</persName> written by his disciple <persName>Theopistus</persName>, 
-              <persName>
-                    <foreign xml:lang="grc">Θεόπιστος</foreign>
-                  </persName>, <persName>
-                    <foreign xml:lang="syr">ܬܐܘܒܝܣܛܘܣ</foreign>
-                  </persName> (fol. <locus from="1b" to="1b">1b</locus>., <locus from="12a" to="12a">12a</locus>) in the <placeName>Pentapolis</placeName> or <placeName>Cyrenaica</placeName>, shortly after the death of <persName ref="http://syriaca.org/person/2432">Dioscorus</persName>
+              <persName><foreign xml:lang="grc">Θεόπιστος</foreign></persName>, <persName><foreign xml:lang="syr">ܬܐܘܒܝܣܛܘܣ</foreign></persName> (fol. <locus from="1b" to="1b">1b</locus>., <locus from="12a" to="12a">12a</locus>) in the <placeName>Pentapolis</placeName> or <placeName>Cyrenaica</placeName>, shortly after the death of <persName ref="http://syriaca.org/person/2432">Dioscorus</persName>
               </title>
                 <note type="footnote">See <bibl>Renaudot, Hist. Patr. Alexandrin. Jacobit., p. 114</bibl>, and <bibl>Le Quien, Oriens Christ., t. ii., col. 409</bibl>
                 </note>

--- a/data/tei/38.xml
+++ b/data/tei/38.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/573">
                 <persName xml:lang="en">John Chrysostom</persName>
               </author>
-              <title xml:lang="en">Third part of the Commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <title>the Gospel according to <persName>S. John</persName>
-                </title>, homm. lx.—lxxxviii</title>
+              <title xml:lang="en">Third part of the Commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <title>the Gospel according to <persName>S. John</persName></title>, homm. lx.—lxxxviii</title>
               <finalRubric xml:lang="syr">
                 <locus from="183b"/>ܫܠ̣ܡ ܠܡܟܬܒܐ ܒܦܢܩܝܬܐ ܗܕܐ̣. ܡܐܡܪ̈ܐ ܕܡܪܝ ܝܘܗܢܝܣ ܐܦܣܩܦܐ
                         ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ̣. ܕܗ̇ܘܝܢ ܒܡܢܝܢܐ̇ ܥܣܪ̈ܝ̣ܢ ܘܬܫܥܐ. ܘ ܘ ..

--- a/data/tei/39.xml
+++ b/data/tei/39.xml
@@ -508,8 +508,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en"> Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Metrical homilies of <persName>Jacob of
-                              Batnae</persName>
+                  <title xml:lang="en">Metrical homilies of <persName>Jacob of Batnae</persName>
                 </title>
                   <msItem xml:id="p2c1" n="3">
                     <locus from="216a" to="219">Foll. 216a-219</locus>

--- a/data/tei/39.xml
+++ b/data/tei/39.xml
@@ -552,8 +552,7 @@
                 <msItem xml:id="p2b3" n="8" defective="true">
                   <locus from="230a" to="230">Foll. 230a-230</locus>
                   <title xml:lang="en">An account of the miracles of <persName>Basil,
-                              bishop of <placeName>Caesarea</placeName>
-                    </persName>, by his successor <persName>Helladius</persName>.</title>
+                              bishop of <placeName>Caesarea</placeName></persName>, by his successor <persName>Helladius</persName>.</title>
                   <incipit xml:lang="syr">ܬܫܥܝܬܐ ܕܥܒ̣ܝܕܐ ܠܚܣܝܐ ܗܠܕܝܘܣ ܐܦܝܣܩܘܦܐ ܕܩܣܪܝܐ ܩܦܕܘܩܝܐ.
                            ܥܠ ܬܕܡܪ̈ܬܐ ܕܩܕܝܫܐ ܒܣܝܠܝܘܣ ܗ̇ܘ ܕܗ̣ܘܐ ܪܝܫ ܐܦܝ̈ܣܩܘܦܐ ܕܝܠܗ̇ ܕܡܕܝܢܬܐ</incipit>
                   <note>Imperfect, and very much soiled and torn.</note>

--- a/data/tei/395.xml
+++ b/data/tei/395.xml
@@ -237,8 +237,7 @@
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
                   <title xml:lang="en">from the commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9646">the Gospel of <persName>S.
-                                        Matthew</persName>
-                    </ref>, hom. xxxi</title>
+                                        Matthew</persName></ref>, hom. xxxi</title>
                   <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܡܬܝ</rubric>
                   <note>See <bibl>Opera, ed. Par. 1837, t. vii., p. 407, penult line</bibl>,
                                         <foreign xml:lang="grc">καὶ μετὰ τοῦτο κἀκεῖνο μάνθανε, κ.τ.λ.</foreign>

--- a/data/tei/395.xml
+++ b/data/tei/395.xml
@@ -236,8 +236,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">from the commentary of <persName ref="http://syriaca.org/person/573">John
-                                        Chrysostom</persName> on <ref target="http://syriaca.org/work/9646">the Gospel of <persName>S.
+                  <title xml:lang="en">from the commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9646">the Gospel of <persName>S.
                                         Matthew</persName>
                     </ref>, hom. xxxi</title>
                   <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܡܬܝ</rubric>

--- a/data/tei/399.xml
+++ b/data/tei/399.xml
@@ -176,8 +176,7 @@
                 <author ref="http://syriaca.org/person/3501">
                   <persName xml:lang="en">Macarius the Great</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/856">Macarius the
-                  Great</persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/856">Macarius the Great</persName>
               </title>
                 <msItem xml:id="p1b3" n="6">
                   <locus from="21b"/>

--- a/data/tei/399.xml
+++ b/data/tei/399.xml
@@ -319,8 +319,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                  </persName>
+                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܝܓܪܬܐ ܕܡܪܝ ܝܥܩܘܒ ܐܦܣ܏ܩܘ ܕܒܛܢܢ</rubric>
                 <incipit xml:lang="syr">ܡܐ ܕܐܚܝܕܐ ܢܦܫܐ ܒܦܓܥ̈ܘܗܝ ܡ̈ܟܝܢܐ̇ ܕܥܠܡܐ. ܗܢ̣ܘܢ ܦܓ̈ܥܐ ܗܘܝܢ ܠܗ̇ ܫܦܝܐ. ܏ܘܫ</incipit>

--- a/data/tei/406.xml
+++ b/data/tei/406.xml
@@ -605,8 +605,7 @@
                   </author>
                   <title xml:lang="en">The commencement of an extract from
                     <persName ref="http://syriaca.org/person/573">Chrysostom</persName> on a passage of <ref target="http://syriaca.org/work/9648">the Gospel of <persName>S.
-                      Luke</persName>
-                  </ref>
+                      Luke</persName></ref>
                 </title>
                   <incipit xml:lang="grc">......ΛΟΥΚΑ ΕΥΑΓΓΕΛΙΟΥ. ΕΡΜΗΝΙΑ......ΧΡΥϹΟϹΤΟΜΟΥ.<locus from="17b"/>
                   </incipit>

--- a/data/tei/408.xml
+++ b/data/tei/408.xml
@@ -175,8 +175,7 @@
                 <author ref="http://syriaca.org/person/2008">
                   <persName xml:lang="en">Simon Peter</persName>
                 </author>
-                <title xml:lang="en">The Doctrine, or Teaching, of <persName ref="http://syriaca.org/person/2008">Simon
-                Peter</persName> at <placeName ref="http://syriaca.org/place/641">Rome</placeName>
+                <title xml:lang="en">The Doctrine, or Teaching, of <persName ref="http://syriaca.org/person/2008">Simon Peter</persName> at <placeName ref="http://syriaca.org/place/641">Rome</placeName>
                 </title>
                 <rubric xml:lang="syr">ܡܠܦܢܘܬܗ ܕܫܡܥܘܢ ܟܐܦܐ ܒܪܗܘܡܐ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Add. 14,609<ptr target="https://bl.syriac.uk/ms/347"/>, fol. <citedRange unit="fol">16 a</citedRange>
@@ -186,8 +185,7 @@
               </msItem>
               <msItem xml:id="p1a4" n="4">
                 <locus from="18a"/>
-                <title xml:lang="en">The Finding, or Invention, of <persName ref="http://syriaca.org/person/1661">the
-                  Cross</persName> for the second time, by the empress <persName ref="http://syriaca.org/person/1265">Helene</persName>
+                <title xml:lang="en">The Finding, or Invention, of <persName ref="http://syriaca.org/person/1661">the Cross</persName> for the second time, by the empress <persName ref="http://syriaca.org/person/1265">Helene</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܝܟܢܐ ܐܫܬܟܚ ܩܝܣܐ ܕܨܠܝܒܐ ܕܬܪ̈ܬܝܢ ܙܒ̈ܢܝܢ. ܒܝܘ̈ܡܝ ܛܘܒܢܝܬܐ
                 ܗܠܢܐ ܡܠܟܬܐ. ܐܡܗ ܕܢܨܝܚܐ ܘܪܚܡ ܐܠܗܐ ܩܘܣܛܢܛܝܢܘܣ ܡܠܟܐ ܟܪܣܛܝܢܐ. ܕܐܫܬܟܚ ܒܐܘܪܫܠܡ.</rubric>

--- a/data/tei/409.xml
+++ b/data/tei/409.xml
@@ -171,8 +171,7 @@
                   <author ref="http://syriaca.org/person/2123">
                     <persName xml:lang="en">Judas Thomas the Apostle</persName>
                   </author>
-                  <title xml:lang="en">Madrāshā of <persName>Judas Thomas the
-                      Apostle</persName> in the country of the Indians</title>
+                  <title xml:lang="en">Madrāshā of <persName>Judas Thomas the Apostle</persName> in the country of the Indians</title>
                   <rubric xml:lang="syr">ܡܕܪܫܐ ܕܝܗܘܕܐ ܬܐܘܡܐ ܫܠܝܚܐ ܕܒܐܬܪܐ ܕܗ̈ܢܕܘܝܐ</rubric>
                   <incipit xml:lang="syr">
                     <locus from="30b"/>ܟܕ ܐܢܐ ܫܒܪ ܝܠܘܕ. ܘܥܡ̇ܪ ܒܡ̇ܠܟܘܬܝ
@@ -229,8 +228,7 @@
                 <author ref="http://syriaca.org/person/2797">
                   <persName xml:lang="en">Leontius</persName>
                 </author>
-                <title xml:lang="en">The life of <persName>Simeon Salus</persName> and <persName>John
-                  his brother</persName>, written by <persName>Leontius</persName>, bishop of
+                <title xml:lang="en">The life of <persName>Simeon Salus</persName> and <persName>John his brother</persName>, written by <persName>Leontius</persName>, bishop of
                     <placeName>Neapolis</placeName> in <placeName>Cyprus</placeName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܕܘܒܪ ܚ̈ܝܐ ܘܦܘܠܝܛܝܐ ܕܚܣܝܐ ܘܛܘܒܬܢܐ ܡܪܝ ܫܡܥܘܢ ܗ̇ܘ
@@ -250,8 +248,7 @@
                 <author ref="http://syriaca.org/person/855">
                   <persName xml:lang="en">Ammonius</persName>
                 </author>
-                <title xml:lang="en">Narrative of the massacre of <persName>the monks of
-                    <placeName>Mount Sinai</placeName> and of <placeName>Raithū</placeName>
+                <title xml:lang="en">Narrative of the massacre of <persName>the monks of <placeName>Mount Sinai</placeName> and of <placeName>Raithū</placeName>
                   </persName>, by the
                   <persName>Arab barbarians</persName>, written by the monk <persName>Ammonius</persName>
                 </title>
@@ -271,8 +268,7 @@
                 <author ref="http://syriaca.org/person/2797">
                   <persName xml:lang="en">Leontius</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>John, archbishop of
-                    <placeName>Alexandria</placeName>
+                <title xml:lang="en">The history of <persName>John, archbishop of <placeName>Alexandria</placeName>
                   </persName>, in 48 chapters, written by
                   <persName>Leontius</persName>, bishop of <placeName>Neapolis</placeName> in
                   <placeName>Cyprus</placeName>
@@ -297,8 +293,7 @@
                 <author>
                   <persName xml:lang="en">John, a Syrian monk</persName>
                 </author>
-                <title xml:lang="en">A story of <persName>a man who robbed a grave</persName>, and took away <persName>a
-                  woman</persName>'s garments, narrated by one <persName>John, a Syrian monk</persName>
+                <title xml:lang="en">A story of <persName>a man who robbed a grave</persName>, and took away <persName>a woman</persName>'s garments, narrated by one <persName>John, a Syrian monk</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܐܢܫ ܕܚܠܨ ܒܝܬ ܩܒܘܪ̈ܐ ܘܢܣ̣ܒ ܠܒܘܫܗ̇ ܕܐܢܬܬܐ</rubric>
                 <finalRubric xml:lang="syr">ܫܠ̤ܡܬ ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܝܘܚܢܢ ܝܚܝܕܝܐ ܥܠ ܓܒܪܐ ܚܕ ܕܚ̇ܠ̣ܨ ܩܒܪܐ</finalRubric>
@@ -320,8 +315,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>Mār Ḥannīnā (or
-                  Ḥananyā, Ananias)</persName>, written by <persName>Jacob of <placeName>Batnae</placeName>
+                <title xml:lang="en">The history of <persName>Mār Ḥannīnā (or Ḥananyā, Ananias)</persName>, written by <persName>Jacob of <placeName>Batnae</placeName>
                   </persName> in the form of a letter to <persName>Philotheus</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܢܨ̈ܚܢܐ ܕܩܕܝܫܐ ܡܪܝ ܚܢܢܝܐ: ܕܟܬ̣ܒ ܫܕܪ ܡܠܦܢܐ ܡܪܝ ܝܥܩܘܒ ܠܪܚ̇ܡ ܐܠܗܐ ܦܝܠܘܬܐܘܣ</rubric>
@@ -391,16 +385,14 @@
               </msItem>
               <msItem xml:id="b22" n="30">
                 <locus from="257b"/>
-                <title xml:lang="en">The martyrdom of <persName>Tharbū</persName>, <persName>her
-                  sister</persName>, and <persName>her maid</persName>
+                <title xml:lang="en">The martyrdom of <persName>Tharbū</persName>, <persName>her sister</persName>, and <persName>her maid</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܣܗܕܘܬܐ ܕܬܪܒܘ ܘܕܚܬܗ̇ ܘܕܒܪܬ ܒܝܬܗ̇</rubric>
                 <note>See <bibl>Add. 12,174, no. 64</bibl>.</note>
               </msItem>
               <msItem xml:id="b23" n="31">
                 <locus from="259b"/>
-                <title xml:lang="en">The martyrdom of <persName>Paphnutius</persName> and <persName>his
-                  546 disciples</persName>, under <persName>Diocletian</persName>
+                <title xml:lang="en">The martyrdom of <persName>Paphnutius</persName> and <persName>his 546 disciples</persName>, under <persName>Diocletian</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܣܗܕܘܬܐ ܕܡܪܝ ܦܦܢܘܛ ܩܕܝܫܐ ܘܕܚܡܫܡ̈ܐܐ ܘܐܪ̈ܒܥܝܢ ܘܫ̈ܬܐ ܬܠ̈ܡܝܕܘܗܝ. ܕܐܣ̣ܗܕܘ ܒܐܝ̣ܕܗ ܘܐܬܟ̇ܠ̣ܠ ܒܝܘ̈ܡܬܗ ܕܕܘܩܠܛܝܢܣ</rubric>
                 <note>Compare the <bibl>Acta Sanctt. for Sept., t. vi., p. 683</bibl>.</note>
@@ -549,8 +541,7 @@
                 <author ref="http://syriaca.org/person/2820">
                   <persName xml:lang="en">Zachariah</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>John the less, or
-                  the younger, of <placeName>Scete</placeName>
+                <title xml:lang="en">The history of <persName>John the less, or the younger, of <placeName>Scete</placeName>
                   </persName>, translated from the Arabic by
                   <persName>Zachariah, bishop of <placeName>Sakhā</placeName>
                   </persName>

--- a/data/tei/409.xml
+++ b/data/tei/409.xml
@@ -150,8 +150,7 @@
                 <msItem xml:id="c2" n="5">
                   <locus from="4b"/>
                   <title xml:lang="en">Second act, entitled "when <persName>Thomas the Apostle</persName> entered
-                    into <placeName>India</placeName>, and built <placeName>the palace for <persName>the king</persName> in <placeName>heaven</placeName>
-                    </placeName>"</title>
+                    into <placeName>India</placeName>, and built <placeName>the palace for <persName>the king</persName> in <placeName>heaven</placeName></placeName>"</title>
                   <rubric xml:lang="syr">ܦܪܟܣܝܣ ܕܬܪ̈ܬܝܢ ܟܕ ܥܠ̣ ܬܐܘܡܐ ܫܠܝܚܐ ܠܗܢܕܘ ܘܒܢ̣ܐ ܒܝܪܬܐ ܠܡ̇ܠܟܐ ܒܫܡܝܐ</rubric>
                   <note>
                     <bibl>Gr. text, capp. 17—29</bibl>.</note>

--- a/data/tei/409.xml
+++ b/data/tei/409.xml
@@ -217,8 +217,7 @@
               </msItem>
               <msItem xml:id="b4" n="12">
                 <locus from="60a"/>
-                <title xml:lang="en">Narrative concerning the image of <persName>the Messiah</persName>, which <persName>the chief priests of <persName>the Jews</persName>
-                  </persName> made at <placeName>Tiberias</placeName>
+                <title xml:lang="en">Narrative concerning the image of <persName>the Messiah</persName>, which <persName>the chief priests of <persName>the Jews</persName></persName> made at <placeName>Tiberias</placeName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܨܠܡܗ ܕܡܫܝܚܐ ܕܥ̣ܒܕܘ ܪ̈ܒܝ ܟܗ̈ܢܐ ܕܝ̈ܘܕܝܐ ܒܛܝܒܪܝܘܣ</rubric>
                 <note>See <bibl>Add. 12,174, no. 35</bibl>.</note>
@@ -248,8 +247,7 @@
                 <author ref="http://syriaca.org/person/855">
                   <persName xml:lang="en">Ammonius</persName>
                 </author>
-                <title xml:lang="en">Narrative of the massacre of <persName>the monks of <placeName>Mount Sinai</placeName> and of <placeName>Raithū</placeName>
-                  </persName>, by the
+                <title xml:lang="en">Narrative of the massacre of <persName>the monks of <placeName>Mount Sinai</placeName> and of <placeName>Raithū</placeName></persName>, by the
                   <persName>Arab barbarians</persName>, written by the monk <persName>Ammonius</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܘܣܗܕܘܬܐ ܕܐܒ̈ܗܬܐ ܩ̈ܕܝܫܐ ܘܛܘ̈ܒܬܢܐ: ܗ̇ܢܘܢ ܕܐܬܪܕܦܘ ܡܢ ܒܪ̈ܒܪܝܐ ܒܛܘܪܐ ܩܕܝܫܐ ܕܣܝܢܝ ܘܒܪܐܝܬܘ ܐܬܟܬ̤ܒܬ ܕܝܢ ܡܢ ܛܘܒܢܐ ܐܡܘܢܝܘܣ ܝܚܝܕܝܐ</rubric>
@@ -268,8 +266,7 @@
                 <author ref="http://syriaca.org/person/2797">
                   <persName xml:lang="en">Leontius</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>John, archbishop of <placeName>Alexandria</placeName>
-                  </persName>, in 48 chapters, written by
+                <title xml:lang="en">The history of <persName>John, archbishop of <placeName>Alexandria</placeName></persName>, in 48 chapters, written by
                   <persName>Leontius</persName>, bishop of <placeName>Neapolis</placeName> in
                   <placeName>Cyprus</placeName>
                 </title>
@@ -315,8 +312,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>Mār Ḥannīnā (or Ḥananyā, Ananias)</persName>, written by <persName>Jacob of <placeName>Batnae</placeName>
-                  </persName> in the form of a letter to <persName>Philotheus</persName>
+                <title xml:lang="en">The history of <persName>Mār Ḥannīnā (or Ḥananyā, Ananias)</persName>, written by <persName>Jacob of <placeName>Batnae</placeName></persName> in the form of a letter to <persName>Philotheus</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܢܨ̈ܚܢܐ ܕܩܕܝܫܐ ܡܪܝ ܚܢܢܝܐ: ܕܟܬ̣ܒ ܫܕܪ ܡܠܦܢܐ ܡܪܝ ܝܥܩܘܒ ܠܪܚ̇ܡ ܐܠܗܐ ܦܝܠܘܬܐܘܣ</rubric>
                 <note>There is a marginal note here, see <ref>additions</ref>.</note>
@@ -541,10 +537,8 @@
                 <author ref="http://syriaca.org/person/2820">
                   <persName xml:lang="en">Zachariah</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>John the less, or the younger, of <placeName>Scete</placeName>
-                  </persName>, translated from the Arabic by
-                  <persName>Zachariah, bishop of <placeName>Sakhā</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>John the less, or the younger, of <placeName>Scete</placeName></persName>, translated from the Arabic by
+                  <persName>Zachariah, bishop of <placeName>Sakhā</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܐܒܐ ܩܕܝܫܐ ܘܒܚ̇ܝܪܐ. ܘܡ̇ܥܠܝܐ ܘܢܗܝܪܐ. ܡܫܡ̇ܠܝܐ ܒܟܠܗܝܢ ܡܝܬܪ̈ܬܐ: ܡܪܝ ܝܘܚܢܢ ܙܥܘܪܐ. ܡܕܒܪܢܐ ܕܡܕܒܪܐ ܕܐܣܝܩܐܝܛܝ. ܐܬܚ̇ܦ̣ܛ ܕܝܢ ܘܦܫܩܗ̇ ܘܬܪܓܡܗ̇ ܐܒܘܢ ܩܕܝܫܐ ܡܪܝ ܙܟܐܪܝܐ ܐܦܝܣܩܘܦܐ ܕܣ̇ܟ݂ܐ <foreign xml:lang="ar">(سَخَا)</foreign> ܡܕܝܢܬܐ̇. ܐܡܪܗ̇ ܕܝܢ ܟܕ ܐܬܟ݁ܢܫ̣ܘ ܨܐܝܕܘܗܝ ܐܢܫܐ ܛܒܝ̈ܒܐ ܘܡܝܬܪ̈ܐ. ܘܬܒܥܘ ܡܢܗ ܕܢܥܒܕ ܙܘܕܩ̣̇ܐ. ܗ̣ܘ ܕܝܢ ܐܫܦ ܠܗܘܢ. ܘܐܡܪܗ̇ ܒܝܘܡܐ ܕܒܗ ܡܬܟ݁ܢܫܝܢ ܠܥܘܗܕܢܗ ܕܐܒܐ ܩܕܝܫܐ ܕܝܠܢ ܝܘܚܢܢ. ܡܬܟ݁ܢܫܝܢ ܕܝܢ ܒܥܣܪ̈ܝܢ ܐܝܟ ܡܢܝ̣ܢܐ ܕܡܨܪ̈ܝܐ. ܘܕܣܘܪ̈ܝܝܐ ܏ܒܝܙ ܒܬܫܪܝܢ ܩܕܡܝܐ</rubric>
                 <finalRubric xml:lang="syr">ܫܠ̣ܡ̇ܬ ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܐ ܝܘܚܢܢ ܙܥܘܪܐ ܘܡܕܒܪܢܐ ܕܡܕܒܪܐ

--- a/data/tei/413.xml
+++ b/data/tei/413.xml
@@ -121,8 +121,7 @@
                 <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
               </author>
               <title xml:lang="en">A work entitled "Histories," or "Lives, of Eastern
-                Saints," compiled by <persName ref="http://syriaca.org/person/74">John, bishop of <placeName>Asia</placeName> or <placeName>Ephesus</placeName>
-                </persName>
+                Saints," compiled by <persName ref="http://syriaca.org/person/74">John, bishop of <placeName>Asia</placeName> or <placeName>Ephesus</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܟܬܒܐ ܕܬܫ̈ܥܝܬܐ ܕܥܠ ܕܘܒܪ̈ܐ ܕܛܘܒ̈ܢܐ ܡ̈ܕܢܚܝܐ̇. ܕܟ̇ܢܫ ܘܟܬ݂ܒ ܝܘܚܢܢ
                 ܐܟܣܢܝܐ. ܘܒܙܒܢ ܝܚܝܕܝܐ ܕܕܝܪܐ ܕܒܝܬ [ܡܪܝ ܝܘܚܢܢ] ܕܐܡ̇ܕ ܒܪܬܚ̣ܐ ܕܛܢ̣ـ[ـܢܐ]
@@ -264,8 +263,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1771">Ḥarpaṭ the chorepiscopus, of <placeName ref="http://syriaca.org/place/1451">Anazete</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1771">Ḥarpaṭ the chorepiscopus, of <placeName ref="http://syriaca.org/place/1451">Anazete</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܐ ܕܚܕܥܣܪܐ ܕܚܪܦܛ ܟܘܪܐܦܝܣܩܘܦܐ ܕܡܢ ܐܬܪܐ ܕܗܢܙܝܛ</rubric>
                 <note>See <bibl>Land, p. 88</bibl>.</note>
@@ -337,8 +335,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>a monk, who quitted his convent without being free to do so, and betook himself to <persName>another</persName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>a monk, who quitted his convent without being free to do so, and betook himself to <persName>another</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܬܡܢܥܣܪܐ̣. ܕܐܚܐ ܚܕ ܕܢܦ̣ܩ ܡܢ ܥܘܡܪܐ ܟܕ ܠܐ ܫܲܪܐ ܠܗ܇ ܘܩ̇ܒ̣ܠ ܢܦܫܗ ܒܐܚܪܢܐ</rubric>
                 <note>See <bibl>Land, p. 144</bibl>.</note>
@@ -369,8 +366,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/2126">Thomas of <placeName ref="http://syriaca.org/place/576">Armenia</placeName>
-                  </persName>, his <persName>wife</persName> and <persName>children</persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/2126">Thomas of <placeName ref="http://syriaca.org/place/576">Armenia</placeName></persName>, his <persName>wife</persName> and <persName>children</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܣܪܝܢ ܘܚܕܐ̣. ܕܛܘܒܢܐ ܪܒܐ ܬܐܘܡܐ ܕܡ ܐܪܡܢܝܐ. ܗ̇ܘ ܕܡܢ ܥܘܬܪܐ ܣܓܝܐܐ ܐܬܬܠܡܕ ܠܡܣܟܢܘܬܐ ܕܪܘܚ ܕܡܛܠ ܐܠܗܐ̣. ܗ̣ܘ ܘܐܢܬܬܗ̣ ܘܒ̈ܢܘܗܝ</rubric>
                 <note>See <bibl>Land, p. 157</bibl>.</note>
@@ -400,8 +396,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/50">John, bishop of <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or <placeName ref="http://syriaca.org/place/200">Constantina</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/50">John, bishop of <placeName ref="http://syriaca.org/place/200">Tellā</placeName> or <placeName ref="http://syriaca.org/place/200">Constantina</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܣܪܝܢ ܘܐܪܒܥ̣ ܕܛܘܒܢܐ ܝܘܚܢܢ ܐܦܝܣܩܘܦܐ ܕܬܠܐ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Land, p. 169</bibl>.</note>
@@ -411,8 +406,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1813">John, bishop of <placeName ref="http://syriaca.org/place/2789">Hephӕstus</placeName> in <placeName ref="http://syriaca.org/place/715">Egypt</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1813">John, bishop of <placeName ref="http://syriaca.org/place/2789">Hephӕstus</placeName> in <placeName ref="http://syriaca.org/place/715">Egypt</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܣܪܝܢ ܘܚ̈ܡܫ̣. ܕܛܘܒܢܐ ܝܘܚܢܢ ܐܦܝܣܩܘܦܐ ܕܐܦܣܛܘ ܡܕܝܢܬܐ
                   ܕܒܐܝܓܝܦܛܣ܇ ܕܐܝܬܘܗܝ ܬܪܝܢܐ ܕܐܓ̈ܘܢܘܗܝ ܕܩܕܝܫܐ ܝܘܚܢܢ ܗ̇ܘ ܕܡܢ ܩܕܡܘܗܝ.</rubric>
@@ -423,8 +417,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/2587">Thomas, bishop of <placeName ref="http://syriaca.org/place/66">Damascus</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/2587">Thomas, bishop of <placeName ref="http://syriaca.org/place/66">Damascus</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܣܪܝܢ ܘܫܬ݂. ܕܩܕܝܫܐ ܬܐܘܡܐ ܪܕܝܦܐ ܘܣܗܕܐ ܐܦܝܣܩܦܐ ܕܕܡܣܩܘܣ</rubric>
                 <note>See <bibl>Land, p. 185</bibl>.</note>
@@ -435,8 +428,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1704">Elias of <placeName>Dārā</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1704">Elias of <placeName>Dārā</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܓܒܪܐ ܕܐܠܗܐ̣ ܕܫܡܗ ܗܘܐ ܐܠܝܐ ܘܐܝܬܘܗܝ ܗܘܐ̣ ܒܕܪܐ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Land, p. 185</bibl>.</note>
@@ -544,9 +536,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1630">Bassianus the solitary</persName>, of <persName ref="http://syriaca.org/person/2040">Romanus the priest and periodeutes of <placeName ref="http://syriaca.org/place/233">the monastery of <placeName ref="http://syriaca.org/place/198">Teleda</placeName>
-                    </placeName>
-                  </persName>, and of the abbat <persName ref="http://syriaca.org/person/2093">Simeon</persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1630">Bassianus the solitary</persName>, of <persName ref="http://syriaca.org/person/2040">Romanus the priest and periodeutes of <placeName ref="http://syriaca.org/place/233">the monastery of <placeName ref="http://syriaca.org/place/198">Teleda</placeName></placeName></persName>, and of the abbat <persName ref="http://syriaca.org/person/2093">Simeon</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܪܒܥܝܢ ܘܚܕܐ̣. ܕܛܘܒܢܐ ܒܣܝܢܐ ܐܝܚܝܕܝܐ̣. ܘܪܘܡܢܐ ܩܫܝ̈ܫܢܐ̣.
                   ܘܣܥܘܪܐ ܕܥܘܡܪܐ ܪܒܐ ܕܬܠܥܕܐ̣. ܘܕܫܡܥܘܢ ܪܝܫܕܝܪܐ. ܕܣܝܡܝܢ ܒܗ ܒܒܝܬ ܩܒܘܪܐ̣ ܥܡ ܣܒ̈ܐ ܗܠܝܢ
@@ -597,8 +587,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1977">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1977">Paul of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܪܒܥܝܢ ܘܫܬ݂. ܕܛܘܒܢܐ ܦܘܠܘܣ ܕܐܝܬܘܗܝ ܗܘܐ ܡܢ ܐܢܛܝܘܟܝܐ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Land, p. 239</bibl>.</note>
@@ -608,8 +597,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">Account of <persName>the monks from various quarters, who were assembled at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName> under the protection of the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
+                <title xml:lang="en">Account of <persName>the monks from various quarters, who were assembled at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName> under the protection of the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܪܒܥܝܢ ܘܫܒܥ̣ ܕܥܠ ܟܢܘ̈ܫܝܐ ܩ̈ܕܝܫܐ ܕܟܢ̇ܫ̣ܬ ܬܐܕܘܪܐ ܡܠܟܬܐ ܒܩܘܣܛܢܛܝܢܐܦܘܠܝܣ</rubric>
                 <note>See <bibl>Land, p. 241</bibl>.</note>
@@ -652,8 +640,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>Ḳashῑsh, bishop of <placeName ref="http://syriaca.org/place/1529">Chios</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Ḳashῑsh, bishop of <placeName ref="http://syriaca.org/place/1529">Chios</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܚܡܫܝܢ ܘܚܕܐ̣. ܕܛܘܒܢܐ ܩܫܝܫ ܐܦܝܣܩܘܦܐ ܕܟܝܘܣ ܓܙܪܬܐ</rubric>
                 <note>See <bibl>Land, p. 257</bibl>.</note>
@@ -749,8 +736,7 @@
               </msItem>
               <msItem xml:id="b57" n="59">
                 <locus from="136b"/>
-                <title xml:lang="en">Of <persName>the various bodies of clergy and laity collected from every quarter at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName> by the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
+                <title xml:lang="en">Of <persName>the various bodies of clergy and laity collected from every quarter at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName> by the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
                 </title>
                 <rubric xml:lang="syr">ܫܪܒܐ ܕܥܠ ܟܢܘ̈ܫܝܐ ܡ̈ܫܚܠܦܐ ܕܐ̈ܦܝܣܩܘܦܐ ܘܦܛܪ̈ܝܪܟܘܿ. ܘܕܝܪ̈ܝܐ
                   ܘܐܝ̈ܚܝܕܝܐ ܘܥ̈ܠܡܝܐ ܕܡܢ ܟܠ ܦܢ̈ܝܢ̇. ܥܠ ܐ̈ܦܝ ܗܝܡܢܘܬܐ ܒܝܘܡ̈ܬܗ ܕܝܘܣܛܝܢܝܢܐ ܡ̇ܠܟܐ ܐܬ̇ܟܢܫܘ
@@ -765,8 +751,7 @@
               </msItem>
               <msItem xml:id="b59" n="61">
                 <locus from="137a"/>
-                <title xml:lang="en">Of <persName>the great assembly of abbats and monks at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName> after the death of the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
+                <title xml:lang="en">Of <persName>the great assembly of abbats and monks at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName> after the death of the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܟܢܘܫܝܐ ܪܒܐ ܕܪ̈ܝܫܝ ܕܝܪ̈ܬܐ ܘܫܪܟܐ ܕܕܝܪ̈ܝܐ ܡ̈ܕܢܚܝܐ ܕܥܡܗܘܢ̇. ܕܗܘ̣ܐ ܒܬܪ ܡܘܬܗ̇ ܕܢܝܚ̣ܬ ܢܦܫܐ ܡܠܟܬܐ ܒܡܕܝܢܬ ܡܠܟܘܬܐ</rubric>
               </msItem>
@@ -791,16 +776,14 @@
               </msItem>
               <msItem xml:id="b63" n="65">
                 <locus from="139a"/>
-                <title xml:lang="en">Of <persName>the Alexandrians who went to <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName> to plead on behalf of the orthodox faith</title>
+                <title xml:lang="en">Of <persName>the Alexandrians who went to <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName> to plead on behalf of the orthodox faith</title>
                 <rubric xml:lang="syr">ܕܥܠ ܓܪ̈ܡܛܝܩܘ ܘܣܟܘ̈ܠܣܛܝܩܐ ܘܢܘܩܠܪ̈ܐ ܘܕܝܪ̈ܝܐ ܐܠܟܣܢܕܪ̈ܝܐ̇. ܕܪܬܚ̣ܘ ܒܛܢܢ̣ܐ ܕܕܚܠܬ ܐܠܗܐ̇. ܘܐܬܘ ܕܢܡܠܠܘܢ ܡܠܬܐ ܕܡܛܠ ܗܝܡܢܘܬܐ</rubric>
               </msItem>
             </msItem>
             <msItem xml:id="a3" n="66">
               <locus from="139b"/>
               <title xml:lang="en">Three lives of <persName>Saints</persName>, which were certainly
-                not written by <persName ref="http://syriaca.org/person/74">John of <placeName>Ephesus</placeName>
-                </persName>
+                not written by <persName ref="http://syriaca.org/person/74">John of <placeName>Ephesus</placeName></persName>
               </title>
               <note>See <bibl>Land, Anecd. Syr., t. ii., p. 27 of the preface</bibl>.</note>
               <msItem xml:id="b64" n="67">

--- a/data/tei/413.xml
+++ b/data/tei/413.xml
@@ -608,8 +608,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">Account of <persName>the monks from various quarters, who were
-                  assembled at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
+                <title xml:lang="en">Account of <persName>the monks from various quarters, who were assembled at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
                   </persName> under the protection of the <persName ref="http://syriaca.org/person/779">empress Theodora</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܪܒܥܝܢ ܘܫܒܥ̣ ܕܥܠ ܟܢܘ̈ܫܝܐ ܩ̈ܕܝܫܐ ܕܟܢ̇ܫ̣ܬ ܬܐܕܘܪܐ ܡܠܟܬܐ ܒܩܘܣܛܢܛܝܢܐܦܘܠܝܣ</rubric>

--- a/data/tei/413.xml
+++ b/data/tei/413.xml
@@ -480,8 +480,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">Account of <placeName>the monasteries of <placeName ref="http://syriaca.org/place/8">Amid</placeName>
-                  </placeName> during the persecution of the year <date datingMethod="Seleucid" when-custom="0832">832</date> (<date calendar="Gregorian" when="0521">A.D. 521</date>)</title>
+                <title xml:lang="en">Account of <placeName>the monasteries of <placeName ref="http://syriaca.org/place/8">Amid</placeName></placeName> during the persecution of the year <date datingMethod="Seleucid" when-custom="0832">832</date> (<date calendar="Gregorian" when="0521">A.D. 521</date>)</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܬܠܬܝܢ ܘܚܡܫ̣. ܕܟܢܘܫܝܐ ܪܒܐ ܘܬܡܝܗܐ ܘܡܫܡ̇ܗܐ ܕܥܘܡܪ̈ܐ
                   ܩ̈ܕܝܫܐ ܕܐܡ̈ܕܝܐ̇. ܗܠܝܢ ܕܒܐ̈ܓܘܢܐ ܪ̈ܘܪܒܐ ܕܪܕܝܦܘܬܐ ܐܬ݁ܢܨܚܘ܇ ܕܒܫܢܬ ܬܡܢܡܐܐ ܘܬܠܬܝܢ
                   ܘܬܪ̈ܬܝܢ ܐܬ݂ܪܕܦܘ</rubric>
@@ -713,9 +712,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
                 </author>
-                <title xml:lang="en">Account of <placeName>the monastery of S. John at
-                  <placeName ref="http://syriaca.org/place/8">Amid</placeName>
-                  </placeName>, and notices of <persName>its abbats</persName>, from its foundation in the year <date datingMethod="Seleucid" when-custom="0700">700</date> (<date calendar="Gregorian" when="0389">A.D. 389</date>) down to the year <date datingMethod="Seleucid" when-custom="0878">878</date> (<date calendar="Gregorian" when="0567">A.D. 567</date>)</title>
+                <title xml:lang="en">Account of <placeName>the monastery of S. John at <placeName ref="http://syriaca.org/place/8">Amid</placeName></placeName>, and notices of <persName>its abbats</persName>, from its foundation in the year <date datingMethod="Seleucid" when-custom="0700">700</date> (<date calendar="Gregorian" when="0389">A.D. 389</date>) down to the year <date datingMethod="Seleucid" when-custom="0878">878</date> (<date calendar="Gregorian" when="0567">A.D. 567</date>)</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܚܡܫܝܢ ܘܬܡܢܐ̣. ܥܠ ܫܘܪܝ ܩܘܝ̇ܡܗ ܕܥܘܡܪܐ ܩܕܝܫܐ ܕܒܝܬ ܡܪܝ
                   ܝܘܚܢܢ ܕܐ̇ܡܕ. ܘܕܐܝܠܝܢ ܪ̈ܝܫܐ ܘܡ̈ܩܝܡܢܐ ܗܘܘ ܠܗ ܡܢ ܒܪܫܝܬ. ܗ̇ܢܘ ܕܝـ̣ܢ ܡܢ ܫܢܬ ܫܒܥܡܐܐ
                   ܕܐܠܟܣܢܕܪܣ̣. ܘܥܕܡܐ ܠܫܢܬ ܬܡܢܐܐ ܘܫܒܥܝܢ ܘܬܡܢܐ ܕܝܠܗ.</rubric>

--- a/data/tei/415.xml
+++ b/data/tei/415.xml
@@ -234,8 +234,7 @@
               </msItem>
               <msItem xml:id="p1a12" n="14">
                 <locus from="99b"/>
-                <title xml:lang="en">The history of <persName>a nun, who was thought to be mad</persName>, and of <persName>the
-                patrician lady Anastasia, the correspondent of <persName>the patriarch Severus</persName>
+                <title xml:lang="en">The history of <persName>a nun, who was thought to be mad</persName>, and of <persName>the patrician lady Anastasia, the correspondent of <persName>the patriarch Severus</persName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ̣ ܕܥܠ ܚܬܐ ܚܕܐ ܛܘܒܢܝܬܐ̇. ܕܥ̇ܡܪܐ ܗܘܐ <foreign xml:lang="en">(sic)</foreign> ܒܕܝܪܐ ܒܝܢܬ ܐܚ̈ܘܬܐ̣. ܘܡܣܬ̇ܒܪܐ ܗܘܬ ܠܗܝ̣ܢ ܕܐܝܬܝܗ̇ ܫܢܝܬܐ ܘܒܪܝܪܬܐ .. ܬܘܒ ܕܝ̣ܢ ܘܥܠ ܛܘܒܢܝܬܐ ܦܛܪܝܩܝܐ</rubric>
@@ -597,8 +596,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">Writings of <persName>Philoxenus of
-                <placeName>Mabūg</placeName>
+                <title xml:lang="en">Writings of <persName>Philoxenus of <placeName>Mabūg</placeName>
                   </persName>
               </title>
                 <author ref="http://syriaca.org/person/44">

--- a/data/tei/415.xml
+++ b/data/tei/415.xml
@@ -162,16 +162,14 @@
               </msItem>
               <msItem xml:id="p1a4" n="4">
                 <locus from="19a"/>
-                <title xml:lang="en">The history of <persName>Euphrosyne of <placeName>Alexandria</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Euphrosyne of <placeName>Alexandria</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܬܐ ܐܘܦܪܘܣܘܢܝ. ܗ̇ܝ ܕܡܢ ܐܠܟܣܢܕܪܝܐ. ܕܐܬܥܢܘܼܝܬ̇ ܡܛܫܝܐܝܬ݂ ܒܥܘܡܪܐ ܕܓܒܪ̈ܐ</rubric>
                 <note>See the <bibl>Acta Sanctt. for February, t. ii., p. 537</bibl>.</note>
               </msItem>
               <msItem xml:id="p1a5" n="5">
                 <locus from="25b"/>
-                <title xml:lang="en">The history of <persName>the Man of God from <placeName>the city of Rome</placeName>
-                (<foreign xml:lang="la">Alexius Romanus</foreign>)</persName>, in two parts</title>
+                <title xml:lang="en">The history of <persName>the Man of God from <placeName>the city of Rome</placeName>(<foreign xml:lang="la">Alexius Romanus</foreign>)</persName>, in two parts</title>
                 <note>Compare <bibl>Add. 14,644, no. 12</bibl>.</note>
                 <msItem xml:id="p1b1" n="6">
                   <locus from="25b"/>
@@ -234,8 +232,7 @@
               </msItem>
               <msItem xml:id="p1a12" n="14">
                 <locus from="99b"/>
-                <title xml:lang="en">The history of <persName>a nun, who was thought to be mad</persName>, and of <persName>the patrician lady Anastasia, the correspondent of <persName>the patriarch Severus</persName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>a nun, who was thought to be mad</persName>, and of <persName>the patrician lady Anastasia, the correspondent of <persName>the patriarch Severus</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ̣ ܕܥܠ ܚܬܐ ܚܕܐ ܛܘܒܢܝܬܐ̇. ܕܥ̇ܡܪܐ ܗܘܐ <foreign xml:lang="en">(sic)</foreign> ܒܕܝܪܐ ܒܝܢܬ ܐܚ̈ܘܬܐ̣. ܘܡܣܬ̇ܒܪܐ ܗܘܬ ܠܗܝ̣ܢ ܕܐܝܬܝܗ̇ ܫܢܝܬܐ ܘܒܪܝܪܬܐ .. ܬܘܒ ܕܝ̣ܢ ܘܥܠ ܛܘܒܢܝܬܐ ܦܛܪܝܩܝܐ</rubric>
                 <explicit xml:lang="syr">ܗܕܐ ܗܟܝܠ ܐܢܣܛܣܝܐ ܦܛܪܝܩܝܐ ܡܫܡܫܢܝܬܐ ܗ̣ܝ ܐܝܬܝܗ̇ ܗ̇ܝ ܕܒܝܘ̈ܡܝ
@@ -284,8 +281,7 @@
               </msItem>
               <msItem xml:id="p1a18" n="20">
                 <locus from="109a"/>
-                <title xml:lang="en">The history of <persName>Onesima of <placeName>Egypt</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Onesima of <placeName>Egypt</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܛܘܒܢܝܬܐ ܐܢܣܝܡܐ ܕܡܢ ܐܓܘܒܛܘܣ</rubric>
                 <incipit xml:lang="syr">ܐܢܬܬܐ ܚܕܐ ܛܘܒܢܝܬܐ ܐܝܬ ܗܘܐ ܒܐܓܘܒܛܘܣ ܡܕܝܢܬܐ. ܕܫܡܗ̇ ܗܘܐ ܐܢܣܝܡܐ.
@@ -304,8 +300,7 @@
               </msItem>
               <msItem xml:id="p1a20" n="22">
                 <locus from="121a"/>
-                <title xml:lang="en">The history of <persName>a merchant at <placeName>Constantinople</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>a merchant at <placeName>Constantinople</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܬܓܪܐ ܚܕ ܕܗܘ̣ܐ ܒܡܕܝܢܬ ܡ̇ܠܟܘܬܐ ܩܘܣܛܢܛܝܢܘܦܠܝܣ</rubric>
                 <note>See <bibl>Add. 12,174, no. 21</bibl>.</note>
@@ -319,8 +314,7 @@
               </msItem>
               <msItem xml:id="p1a22" n="24">
                 <locus from="131b" to="140b"/>
-                <title xml:lang="en">The history of <persName>Simeon of <placeName>Kephar 'Abdin</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Simeon of <placeName>Kephar 'Abdin</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܢܨܝܚܐ ܘܫܒܝܚ ܒܕܘܒܪ̈ܐ ܕܩܕܝܫܘܬܐ ܡܪܝ ܫܡܥܘܢ̇. ܕܐܬܥܢܘܝ ܒܡܝܬܪ̈ܬܐ ܒܕܝܪܐ ܕܥܠ ܚܒܝܢܐ ܢܗܪܐ ܕܒܐܬܪܐ ܕܓܪܒܝܐ</rubric>
                 <quote xml:lang="syr">
@@ -334,8 +328,7 @@
               </msItem>
               <msItem xml:id="p1a23" n="25">
                 <locus from="140b"/>
-                <title xml:lang="en">The history of <persName>the virgin Andromeda of <placeName>Jerusalem</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>the virgin Andromeda of <placeName>Jerusalem</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܐܢܕܪܘܡܝܕܐ ܒܬܘܠܬܐ ܗ̇ܝ ܐܝ̇ܕܐ ܕܡܢ ܥܠܡܐ ܗܢܐ ܐܪܚܩ̣ܬ̇܆ ܥܠ ܕܠܐ ܬܗܘܐ ܥܠ̣ܬܐ ܕܬܘܩܠܬܐ ܠܐܢܫ</rubric>
               </msItem>
@@ -349,8 +342,7 @@
               </msItem>
               <msItem xml:id="p1a25" n="27">
                 <locus from="142a"/>
-                <title xml:lang="en">The history of <persName>John the monk, of <placeName>Rome</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>John the monk, of <placeName>Rome</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ̣ ܕܥܠ ܢܨܝܚܐ ܝܘ݊ܚܢܢ ܝܚܝܕܝܐ̇. ܕܐܝܬܘܗܝ ܗܘܐ ܡܢ ܪܗܘܡܐ ܡܕܝܢܬܐ</rubric>
                 <note>
@@ -367,8 +359,7 @@
               </msItem>
               <msItem xml:id="p1a27" n="29">
                 <locus from="162a"/>
-                <title xml:lang="en">The history of <persName>Hilaria, the daughter of the emperor <persName>Zeno</persName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Hilaria, the daughter of the emperor <persName>Zeno</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܬܐ ܐܠܐܪܝܐ ܒܪܬܗ ܕܙܝܢܘܢ ܡ̇ܠܟܐ</rubric>
                 <note>See <ref>additions</ref>.</note>
@@ -596,8 +587,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">Writings of <persName>Philoxenus of <placeName>Mabūg</placeName>
-                  </persName>
+                <title xml:lang="en">Writings of <persName>Philoxenus of <placeName>Mabūg</placeName></persName>
               </title>
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenos of Mabbug</persName>
@@ -607,8 +597,7 @@
                   <author ref="http://syriaca.org/person/44">
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
-                  <title xml:lang="en">Letter to the monk <persName>Patricius of <placeName>Edessa</placeName>
-                    </persName>
+                  <title xml:lang="en">Letter to the monk <persName>Patricius of <placeName>Edessa</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܕܝܫܐ ܡܪܝ ܐܟܣܢܝܐ ܐܦܝܣܩܘܦܐ ܕܡܒܘܓ܆ ܕܠܘܩܒܠ ܚ̈ܫܐ ܕܢܦܫܐ̣.
                   ܘܥܠ ܕܟܝܘܬܐ ܕܝܠܗ̇ ܕܢܦܫܐ. ܘܕܐܝܟ̣ܢ ܘܒܡܘܢ ܡܬܩܢܝܐ. ܘܕܐܢ ܘ̇ܠܐ ܕܢܓܒ̣ܐ ܕܘ̈ܟܝܬܐ ܠܩܪܒܐ

--- a/data/tei/418.xml
+++ b/data/tei/418.xml
@@ -253,8 +253,7 @@
               <author ref="http://syriaca.org/person/480">
                 <persName xml:lang="en">Eusebius</persName>
               </author>
-              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName>
+              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܣܗܕܘܬܐ ܕܩܕܝܫܐ ܦܛܪܘܣ ܪܝܫ ܐܦܝ̈ܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ ܕܗܘ̣ܬ ܒܝܘ̈ܡܝ ܕܘܩܠܛܝܢܘܣ ܪܫܝܥܐ</rubric>
               <note>See <bibl>Add. 14,641, no. 4, b</bibl>.</note>
@@ -264,8 +263,7 @@
               <author ref="http://syriaca.org/person/480">
                 <persName xml:lang="en">Eusebius</persName>
               </author>
-              <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1227">the eight Youths of <placeName>Ephesus</placeName>
-                </persName>
+              <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1227">the eight Youths of <placeName>Ephesus</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܗܠܝܢ ܬܡ̈ܢܝܐ ܛ̈ܠܝܐ ܕܐܣܗܕܘ ܒܐܦܣܣ</rubric>
               <note>See <bibl>Add. 12,160, fol. 147 a</bibl>.</note>
@@ -289,9 +287,7 @@
               <title xml:lang="en">A tract entitled "Plerophoriae, or
                                 Testimonies and Revelations given by God to the <persName>Saints</persName>, concerning
                                 the heresy of the <persName>Diphysites</persName> and the transgression at <placeName>Chalcedon</placeName>,"
-                                written by the priest <persName ref="http://syriaca.org/person/39">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>, of the "<persName>gens Rufina</persName>," bishop of <placeName ref="http://syriaca.org/place/456">Maiuma near <placeName ref="http://syriaca.org/place/87">Gaza</placeName>
-                  </placeName>, and one of the disciples of <persName ref="http://syriaca.org/person/680">Peter the Iberian</persName>
-                </persName>
+                                written by the priest <persName ref="http://syriaca.org/person/39">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>, of the "<persName>gens Rufina</persName>," bishop of <placeName ref="http://syriaca.org/place/456">Maiuma near <placeName ref="http://syriaca.org/place/87">Gaza</placeName></placeName>, and one of the disciples of <persName ref="http://syriaca.org/person/680">Peter the Iberian</persName></persName>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܦܠܝܪ̈ܘܦܘܪܝܣ ܐܘܟܝܬ ܣܗ̈ܕܘܬܐ ܘܓ̈ܠܝܢܐ ܕܗ̣ܘܘ ܡܢ
                                 ܐܠܗܐ ܠܘܬ ܩ̈ܕܝܫܐ̇. ܡܛܠ ܗܪܣܝܣ ܕܬܪ̈ܝܝ ܟܝ̈ܢܐ܇ ܘܡܬܥܒܪܢܘܬܐ ܕܗܘ̣ܬ
@@ -352,8 +348,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>
+              <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܗܝܡܢܘܬܐ ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ ܦܛܪܝܪܟܐ</rubric>
               <note>See <bibl>Add. 14,582, no. 12</bibl>.</note>
@@ -363,8 +358,7 @@
               <author>
                 <persName xml:lang="en">Simeon the bishop of the Persian Christians</persName>
               </author>
-              <title xml:lang="en">An extract from the letter of <persName>Simeon, the bishop of <persName>the Persian Christians</persName>
-                </persName>, to <persName>Simeon, abbat of Gabula</persName>, regarding <persName>the Himyarite martyrs</persName>
+              <title xml:lang="en">An extract from the letter of <persName>Simeon, the bishop of <persName>the Persian Christians</persName></persName>, to <persName>Simeon, abbat of Gabula</persName>, regarding <persName>the Himyarite martyrs</persName>
               </title>
               <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܐܘܟܝܬ ܬܫܥܝܬܐ ܡܛܠ ܣܗ̈ܕܐ ܚܡܝܪ̈ܝܐ: ܕܫܡܥܘܢ ܐܦܝܣܩܦܐ ܕܦܪ̈ܣܝܐ ܟܪ̈ܣܛܝܢܐ. ܕܐܫ̣ܬܕܪܬ ܡܢ ܚܝܪܬܐ ܕܒܝܬ ܢܥܡܢ</rubric>
               <note>See <bibl>Add. 14,641, no. 4, f</bibl>.</note>
@@ -374,8 +368,7 @@
               <author ref="http://syriaca.org/person/74">
                 <persName xml:lang="en">John, bishop of Asia or Ephesus</persName>
               </author>
-              <title xml:lang="en">Lives of <persName>holy men and women</persName>, composed by <persName ref="http://syriaca.org/person/74">John, bishop of <placeName ref="http://syriaca.org/place/2747">Asia</placeName> or <placeName ref="http://syriaca.org/place/623">Ephesus</placeName>
-                </persName>
+              <title xml:lang="en">Lives of <persName>holy men and women</persName>, composed by <persName ref="http://syriaca.org/person/74">John, bishop of <placeName ref="http://syriaca.org/place/2747">Asia</placeName> or <placeName ref="http://syriaca.org/place/623">Ephesus</placeName></persName>
               </title>
               <msItem xml:id="b9" n="27">
                 <locus from="161b"/>
@@ -516,8 +509,7 @@
                 <persName xml:lang="en">John of Asia</persName>
               </author>
               <title xml:lang="en">Extracts from the Ecclesiastical History of
-                <persName ref="http://syriaca.org/person/74">John of <placeName ref="http://syriaca.org/place/2747">Asia</placeName>
-                </persName>, relating to various periods between <date>A. Gr. 831—879</date> (<date>A.D. 520 —568</date>)</title>
+                <persName ref="http://syriaca.org/person/74">John of <placeName ref="http://syriaca.org/place/2747">Asia</placeName></persName>, relating to various periods between <date>A. Gr. 831—879</date> (<date>A.D. 520 —568</date>)</title>
               <finalRubric xml:lang="syr">
                 <locus from="206a"/>ܫܠ̣ܡܘ ܫܪ̈ܒܐ ܕܓܒܝܢܢ ܡܢ ܕܝܘܚܢܢ ܕܐܣܝܐ</finalRubric>
               <note>See <bibl>Land, Anecd. Syr., t. ii., pp. 289—329</bibl>.</note>
@@ -555,8 +547,7 @@
                   <author ref="http://syriaca.org/person/74">
                     <persName xml:lang="en">John of Asia</persName>
                   </author>
-                  <title xml:lang="en">Of the persecution under <persName ref="http://syriaca.org/person/2274">Ephraim of <placeName ref="http://syriaca.org/place/8">Amid</placeName>, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">Of the persecution under <persName ref="http://syriaca.org/person/2274">Ephraim of <placeName ref="http://syriaca.org/place/8">Amid</placeName>, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܡܚܬܬܗ ܕܐܦܪܝܡ ܠܡܕܢܚܐ. ܘܥܠ ܪܕܘܦܝܐ ܪܒܐ ܕܥܒ̣ܕ ܘܥܠ ܟܢܘܫܝܐ ܕܥܘܡܪ̈ܐ ܕܐ̈ܡܕܝܐ</rubric>
                 </msItem>
@@ -683,8 +674,7 @@
             </msItem>
             <msItem xml:id="a20" n="59">
               <locus from="206a"/>
-              <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1268">Hilaria, the daughter of <persName>the emperor Zeno</persName>
-                </persName>
+              <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1268">Hilaria, the daughter of <persName>the emperor Zeno</persName></persName>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܠܐܪܝܐ ܒܪܬܗ ܕܙܐܢܘܢ ܡ̇ܠܟܐ</rubric>
               <note>See <bibl>Add. 14,641, no. 4, h</bibl>.</note>

--- a/data/tei/418.xml
+++ b/data/tei/418.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/857">
                 <persName xml:lang="en">Hieronymus</persName>
               </author>
-              <title xml:lang="en">Three leaves from the Lives of <persName>the Egyptian
-                                Solitaries</persName>
+              <title xml:lang="en">Three leaves from the Lives of <persName>the Egyptian Solitaries</persName>
               </title>
               <rubric xml:lang="syr">ܢܨܚ̈ܢܐ ܕܐܒܗ̈ܬܐ</rubric>
             </msItem>
@@ -290,8 +289,7 @@
               <title xml:lang="en">A tract entitled "Plerophoriae, or
                                 Testimonies and Revelations given by God to the <persName>Saints</persName>, concerning
                                 the heresy of the <persName>Diphysites</persName> and the transgression at <placeName>Chalcedon</placeName>,"
-                                written by the priest <persName ref="http://syriaca.org/person/39">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>, of the "<persName>gens Rufina</persName>," bishop
-                                  of <placeName ref="http://syriaca.org/place/456">Maiuma near <placeName ref="http://syriaca.org/place/87">Gaza</placeName>
+                                written by the priest <persName ref="http://syriaca.org/person/39">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>, of the "<persName>gens Rufina</persName>," bishop of <placeName ref="http://syriaca.org/place/456">Maiuma near <placeName ref="http://syriaca.org/place/87">Gaza</placeName>
                   </placeName>, and one of the disciples of <persName ref="http://syriaca.org/person/680">Peter the Iberian</persName>
                 </persName>
               </title>
@@ -536,8 +534,7 @@
                   <author ref="http://syriaca.org/person/74">
                     <persName xml:lang="en">John of Asia</persName>
                   </author>
-                  <title xml:lang="en">Regarding the persecution of <persName>the
-                                        faithful</persName> by <persName>the heretics</persName> in the time of <persName>Justinian (Justin)</persName>, <date>A. Gr. 831</date> (<date>A.D. 520</date>)</title>
+                  <title xml:lang="en">Regarding the persecution of <persName>the faithful</persName> by <persName>the heretics</persName> in the time of <persName>Justinian (Justin)</persName>, <date>A. Gr. 831</date> (<date>A.D. 520</date>)</title>
                   <rubric xml:lang="syr">ܬܘܒ ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܩܕܝܫܐ ܡܪܝ ܝܘܚܢܢ ܕܐܣܝܐ ܡܢ
                                         ܟܬܒܐ ܕܩܠܝܣܛܝܩܐ <foreign xml:lang="en">(sic)</foreign>  ܕܝܠܗ ܥܠ ܪܕܘܦܝܐ ܕܗܘ̣ܐ ܥܠ ܡܗ̈ܝܡܢܐ ܡܢ
                                         ܗܪ̈ܝܛܝܩܘ܇ ܒܙܒܢܗ ܕܝܘܣܛܢܝܢܐ ܡ̇ܠܟܐ̇. ܫܢܬ ܬܡܢܡܐܐ ܘܬܠܬܝܢ

--- a/data/tei/418.xml
+++ b/data/tei/418.xml
@@ -537,8 +537,7 @@
                   <author ref="http://syriaca.org/person/74">
                     <persName xml:lang="en">John of Asia</persName>
                   </author>
-                  <title xml:lang="en">Of the persecution of <placeName>the Convent of the
-                                        Orientals</placeName> at <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                  <title xml:lang="en">Of the persecution of <placeName>the Convent of the Orientals</placeName> at <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܪܕܘܦܝܗ ܕܥܘܡܪܐ ܕܡ̈ܕܢܚܝܐ ܕܐܘܪܗܝ. ܥܡ ܫܪܟܐ ܕܟܠܗܘܢ ܥܘܡܪ̈ܐ ܕܒܟܠܗ̇ ܡܕܢܚܐ ܘܡܥܪܒܐ</rubric>
                 </msItem>

--- a/data/tei/419.xml
+++ b/data/tei/419.xml
@@ -200,8 +200,7 @@
                   <author ref="http://syriaca.org/person/354">
                     <persName xml:lang="en">Athanasius</persName>
                   </author>
-                  <title xml:lang="en">Letter of <persName>Athanasius</persName> to <persName>the Virgins, who went and prayed
-                  at <placeName>Jerusalem</placeName>, and returned</persName>
+                  <title xml:lang="en">Letter of <persName>Athanasius</persName> to <persName>the Virgins, who went and prayed at <placeName>Jerusalem</placeName>, and returned</persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܕܝܫܐ ܐܬܢܣܝܘܣ ܪܝܫ ܐܦܝܣܩ̈ܦܐ ܕܠܟܣܢܕܪܝܐ <foreign xml:lang="en">(sic)</foreign> ܕܠܘܬ ܒܬܘ̈ܠܬܐ ܕܐܙ̈ܠܝ ܗ̈ܘܝ ܨ̈ܠܝ ܒܐܘܪܫܠܡ ܘܦ̣ܢ̈ܝ</rubric>
                   <note>See <bibl>Add. 14,607, no. 7, a</bibl>.</note>
@@ -290,8 +289,7 @@
                   <author ref="http://syriaca.org/person/13">
                     <persName xml:lang="en">Ephraim</persName>
                   </author>
-                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/13">Ephraim</persName> on the <persName>Prophet Elijah</persName> and <persName>the Widow
-                  of <placeName>Zarephath</placeName>
+                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/13">Ephraim</persName> on the <persName>Prophet Elijah</persName> and <persName>the Widow of <placeName>Zarephath</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܣܡ <foreign xml:lang="en">(sic)</foreign> ܠܛܘܒܢܐ ܡܪܝ ܐܦܪܝܡ ܥܠ ܡܪܝ ܐܠܝܐ ܟܕ ܫܕܪܗ ܡܪܢ

--- a/data/tei/419.xml
+++ b/data/tei/419.xml
@@ -218,8 +218,7 @@
                 </msItem>
                 <msItem xml:id="p1b7" n="8">
                   <locus from="103b"/>
-                  <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName>Rome</placeName>
-                    </persName>
+                  <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName>Rome</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝܬܐ ܐܘ ܟܝܬ ܕܘܒܪܐ ܕܩܕܝܫܐ ܘܠܒܝܫ ܠܐܠܗܐ ܡܪܝ ܝܘܚܢܢ ܐܒܝܠܐ: ܗ̇ܘ ܕܡܢ ܕܗܘܡܐ <foreign xml:lang="en">(sic)</foreign> ܡܕܝܢܬܐ ܪܒܬܐ</rubric>
                 </msItem>
@@ -249,8 +248,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>
                   </title>
                   <msItem xml:id="p1c1" n="13" defective="true">
                     <locus from="163b"/>
@@ -289,8 +287,7 @@
                   <author ref="http://syriaca.org/person/13">
                     <persName xml:lang="en">Ephraim</persName>
                   </author>
-                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/13">Ephraim</persName> on the <persName>Prophet Elijah</persName> and <persName>the Widow of <placeName>Zarephath</placeName>
-                    </persName>
+                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/13">Ephraim</persName> on the <persName>Prophet Elijah</persName> and <persName>the Widow of <placeName>Zarephath</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܣܡ <foreign xml:lang="en">(sic)</foreign> ܠܛܘܒܢܐ ܡܪܝ ܐܦܪܝܡ ܥܠ ܡܪܝ ܐܠܝܐ ܟܕ ܫܕܪܗ ܡܪܢ
                   ܠܨܪܦܬ ܨܝܪܢ <foreign xml:lang="en">(sic)</foreign> ܨܝܪ <foreign xml:lang="en">(sic)</foreign> ܐܪܡܡܠܬܐ <foreign xml:lang="en">(sic)</foreign> .ܡܛܠ ܕܟܦܢ</rubric>
@@ -301,8 +298,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName> on Pride</title>
+                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on Pride</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܡܪܝ ܝܥܩܘܒ ܕܡܪܬܝܢܘܐ: ܕܥܠ ܚܬܝܪܘܬܐ ܫܘܒܚܐ <foreign xml:lang="en">(sic)</foreign>
                   </rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 316, no. 86.</bibl>.</note>
@@ -323,8 +319,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                    </persName> on <persName>the Ten Virgins</persName>
+                  <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on <persName>the Ten Virgins</persName>
                   </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܣܪ ܒܬܘ̈ܠܢ</rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 322, no. 139</bibl>.</note>
@@ -346,8 +341,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Funeral discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
-                    </persName> on <persName>priests</persName> and <persName>deacons</persName>
+                  <title xml:lang="en">Funeral discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName></persName> on <persName>priests</persName> and <persName>deacons</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܩܫ̈ܝܫܐ ܘܡܫܡ̈ܫܢܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ ܥܠ ܥܢܝ̈ܕܐ</rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 233, no. 95</bibl>.</note>

--- a/data/tei/420.xml
+++ b/data/tei/420.xml
@@ -180,8 +180,7 @@
                 <author ref="http://syriaca.org/person/26">
                   <persName xml:lang="en">Rabūlas, bishop of Edessa</persName>
                 </author>
-                <title xml:lang="en">A sermon preached in <placeName>the church at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </placeName> before <persName>the whole people</persName>
+                <title xml:lang="en">A sermon preached in <placeName>the church at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></placeName> before <persName>the whole people</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܪܓܡܐ ܕܡܠܠ ܡܪܝ ܪܒܘܠܐ ܐܦܣܩܘܦܐ ܕܐܘܪܗܝ ܒܥܕܬܐ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ ܩܕܡ ܥܡܐ ܟܠܗ</rubric>
                 <note>Imperfect at the end.</note>

--- a/data/tei/420.xml
+++ b/data/tei/420.xml
@@ -151,8 +151,7 @@
             </msItem>
             <msItem xml:id="a2" n="7" defective="true">
               <locus from="83a"/>
-              <title xml:lang="en">The life of <persName ref="http://syriaca.org/person/26">Rabūlas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>
+              <title xml:lang="en">The life of <persName ref="http://syriaca.org/person/26">Rabūlas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܢܨܚ̈ܢܘܗܝ ܕܡܪܝ ܪܒܘܠܐ ܐܦܣܩܦܐ ܕܐܘܪܗܝ ܡܕܝܢܬܐ ܒܪܝܟܬܐ</rubric>
               <note>See <bibl>Overbeck, S. Ephraemi Syri etc. Opera Selecta, p. 159</bibl>.</note>

--- a/data/tei/421.xml
+++ b/data/tei/421.xml
@@ -141,8 +141,7 @@
             <msItem xml:id="a3" n="3">
               <locus from="55a"/>
               <title xml:lang="en">A discourse on the parable of the Prodigal
-                Son, written in the metre of <persName ref="http://syriaca.org/person/42">Jacob of
-                                Batnae</persName>
+                Son, written in the metre of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
               </title>
               <rubric xml:lang="syr">ܕܥܠ ܗ̇ܘ ܒܪܐ ܐܣܘܛܐ ܕܦܲܪܚ ܢܟ̈ܣܘܗܝ</rubric>
               <note>A note on the margin wrongly ascribes it to that writer
@@ -166,8 +165,7 @@
               <author ref="http://syriaca.org/person/857">
                 <persName xml:lang="en">Jerome</persName>
               </author>
-              <title xml:lang="en">The history of <persName>Paul of the
-                                    Thebaid</persName>, written by
+              <title xml:lang="en">The history of <persName>Paul of the Thebaid</persName>, written by
                 <persName ref="http://syriaca.org/person/857">Jerome</persName>
               </title>
               <rubric xml:lang="syr">

--- a/data/tei/423.xml
+++ b/data/tei/423.xml
@@ -161,8 +161,7 @@
             </msItem>
             <msItem xml:id="a6" n="8" defective="true">
               <locus from="97a"/>
-              <title xml:lang="en">The history of <persName>Paul the
-                solitary</persName> from <placeName>the District of Sophene</placeName>
+              <title xml:lang="en">The history of <persName>Paul the solitary</persName> from <placeName>the District of Sophene</placeName>
               </title>
               <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܦܘܠܐ ܐܒܝܠܐ ܘܪܚ̇ܡܐ ܕܐܠܗܐ ܡܢ ܐܬܪܐ ܕܨܘ̈ܦܢܝܐ</rubric>
               <note>Very imperfect.</note>

--- a/data/tei/424.xml
+++ b/data/tei/424.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/13">
                 <persName xml:lang="en">Ephrem</persName>
               </author>
-              <title xml:lang="en">A discourse in heptasyllabic metre on the <ref>Acts of <persName>S. Andrew the Apostle</persName>
-                </ref>
+              <title xml:lang="en">A discourse in heptasyllabic metre on the <ref>Acts of <persName>S. Andrew the Apostle</persName></ref>
               </title>
               <note>Imperfect at the beginning.</note>
               <note>Probably that ascribed to Ephraim. See <bibl>Assemani, Bibl. Or., t. i., p. 148</bibl>.</note>
@@ -166,8 +165,7 @@
             </msItem>
             <msItem xml:id="a7" n="7" defective="true">
               <locus from="82a"/>
-              <title xml:lang="en">An extract from <ref>the history of <persName ref="http://syriaca.org/person/1913">Maximus</persName> and <persName ref="http://syriaca.org/person/1374">Domitius</persName>
-                </ref>
+              <title xml:lang="en">An extract from <ref>the history of <persName ref="http://syriaca.org/person/1913">Maximus</persName> and <persName ref="http://syriaca.org/person/1374">Domitius</persName></ref>
               </title>
               <rubric xml:lang="syr">ܦܣܘܩܐ ܡܢ ܬܫܥܝܬܐ ܕܩ̈ܕܝܫܐ ܡܟܣܝܡܘܣ ܘܕܝܡܛܝܘܣ ܐܚ̈ܐ ܒ̈ܢܝ ܡܠܟܐ ܘܠܢܛܝܘܣ ܡܗܝܡܢܐ</rubric>
               <note>See <bibl>Add. 14,732, fol. 74 b</bibl>.</note>

--- a/data/tei/424.xml
+++ b/data/tei/424.xml
@@ -124,8 +124,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">A discourse on expatriation ascribed to <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                </persName>
+              <title xml:lang="en">A discourse on expatriation ascribed to <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
               </title>
               <note>Imperfect at the end</note>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܡܪܝܥܩܘܒ ܕܥܠ ܐܟܣ̇ܢ</rubric>

--- a/data/tei/425.xml
+++ b/data/tei/425.xml
@@ -109,8 +109,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="1b"/>
-              <title xml:lang="en">The life of <persName ref="http://syriaca.org/person/477">Epiphanius, bishop of <placeName ref="http://syriaca.org/place/2292">Cyprus</placeName>
-                </persName>, in two parts</title>
+              <title xml:lang="en">The life of <persName ref="http://syriaca.org/person/477">Epiphanius, bishop of <placeName ref="http://syriaca.org/place/2292">Cyprus</placeName></persName>, in two parts</title>
               <note>See <bibl>Add. 17,192, no. 11</bibl>.</note>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1b"/>
@@ -129,8 +128,7 @@
                 <author ref="http://syriaca.org/person/2799">
                   <persName xml:lang="en">Polybius, bishop of Rhinocorura</persName>
                 </author>
-                <title xml:lang="en">Part second, composed by <persName>Polybius, bishop of <placeName ref="http://syriaca.org/place/2709">Rhinocorura</placeName>
-                  </persName>
+                <title xml:lang="en">Part second, composed by <persName>Polybius, bishop of <placeName ref="http://syriaca.org/place/2709">Rhinocorura</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܐܟܬܒ ܦܠܘܒܝܣ ܥܠ ܕܘܒܪ̈ܘܗܝ ܕܛܘܒܬܢܐ ܐܒܘܢ ܐܦܝܦܢܝܣ ܐܦܣܩܘܦܐ ܕܩܘܣܛܢܛܝܢܐ ܕܗ̣ܝ ܗ̣ܝ ܣܠܡܢܐ ܡܕܝܢܬܐ ܕܩܘܦܪܘܣ ܓܙܪܬܐ</rubric>
                 <note>See <bibl>Surius, loc. cit., capp. xxxix.—lxvii.</bibl>; or <bibl>Epiphanii Opera, t. ii., p. 353</bibl>.</note>
@@ -139,8 +137,7 @@
                   <author ref="http://syriaca.org/person/2799">
                     <persName xml:lang="en">Polybius</persName>
                   </author>
-                  <title xml:lang="en">The letter of <persName ref="http://syriaca.org/person/2799">Polybius</persName> to <persName>Sabinus, bishop of <placeName ref="http://syriaca.org/place/200">Constantina</placeName>
-                    </persName>
+                  <title xml:lang="en">The letter of <persName ref="http://syriaca.org/person/2799">Polybius</persName> to <persName>Sabinus, bishop of <placeName ref="http://syriaca.org/place/200">Constantina</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܓܪܬܐ ܕܦܘܠܘܒܝܐ ܐܦܝܣܩܘܦܐ ܕܢܐܩܘܪܘܪܐ <foreign xml:lang="en">(sic)</foreign> ܠܘܬ ܣܒܝܢܐ ܕܩܘܣܛܢܛܝܢܐ</rubric>
                   <note>See <bibl>Surius, loc. cit., cap. lxviii.</bibl>; or <bibl>Epiphanii Opera, t. ii., p. 379</bibl>.</note>

--- a/data/tei/428.xml
+++ b/data/tei/428.xml
@@ -190,8 +190,7 @@
                 <persName xml:lang="en">Paul the Persian</persName>
               </author>
               <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/675">Paul the Persian</persName> on
-                the art of Logic, addressed to <persName ref="http://syriaca.org/person/2244">Khusrau Nūshīrwān, king of
-                  <placeName ref="http://syriaca.org/place/526">Persia</placeName>
+                the art of Logic, addressed to <persName ref="http://syriaca.org/person/2244">Khusrau Nūshīrwān, king of <placeName ref="http://syriaca.org/place/526">Persia</placeName>
                 </persName>
               </title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܒܝܕ: ܠܦܘܠܘܣ ܦܪܣܝܐ: ܥܠ ܡܟܬܒܢܘܬܐ ܡܠܝܠܬܐ: ܕܐܪܝܣܛܘܛܠܝܣ

--- a/data/tei/428.xml
+++ b/data/tei/428.xml
@@ -190,8 +190,7 @@
                 <persName xml:lang="en">Paul the Persian</persName>
               </author>
               <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/675">Paul the Persian</persName> on
-                the art of Logic, addressed to <persName ref="http://syriaca.org/person/2244">Khusrau Nūshīrwān, king of <placeName ref="http://syriaca.org/place/526">Persia</placeName>
-                </persName>
+                the art of Logic, addressed to <persName ref="http://syriaca.org/person/2244">Khusrau Nūshīrwān, king of <placeName ref="http://syriaca.org/place/526">Persia</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܒܝܕ: ܠܦܘܠܘܣ ܦܪܣܝܐ: ܥܠ ܡܟܬܒܢܘܬܐ ܡܠܝܠܬܐ: ܕܐܪܝܣܛܘܛܠܝܣ
                 ܦܝܠܣܘܦܐ: ܠܘܬ ܡ̇ܠܟܐ ܟܣܪܘ</rubric>
@@ -244,8 +243,7 @@
               <author ref="http://syriaca.org/person/49">
                 <persName xml:lang="en">Sergius of Rās-'ain</persName>
               </author>
-              <title xml:lang="en">A scholion of <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/1654">Rās-'ain</placeName>
-                </persName> on
+              <title xml:lang="en">A scholion of <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/1654">Rās-'ain</placeName></persName> on
                 the term <foreign xml:lang="grc">σχῆμα</foreign>
               </title>
               <rubric xml:lang="syr">ܣܟܘܠܐܝܢ ܕܥܒܝܕ ܠܣܪܓܝܣ ܪܝܫܥܝܢܝܐ: ܕܡ̇ܚܘܐ ܕܡ̇ܢܘ ܐܣܟܡܐ</rubric>

--- a/data/tei/428.xml
+++ b/data/tei/428.xml
@@ -112,9 +112,7 @@
               <author ref="http://syriaca.org/person/686">
                 <persName xml:lang="en">Probus</persName>
               </author>
-              <title xml:lang="en">The commentary of <persName ref="http://syriaca.org/person/686">Probus</persName> on the <ref>
-                  <foreign xml:lang="grc">περὶ ἑρμηνείας</foreign>
-                </ref> of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
+              <title xml:lang="en">The commentary of <persName ref="http://syriaca.org/person/686">Probus</persName> on the <ref><foreign xml:lang="grc">περὶ ἑρμηνείας</foreign></ref> of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
               </title>
               <finalRubric xml:lang="syr">
                 <locus from="46a"/>ܫ̣ܠܡ ܒܥܘܕܪܢ ܛܝܒܘܬܗ ܕܡܪܢ: ܦܘܫܩܐ
@@ -162,10 +160,8 @@
                 <persName xml:lang="en">Severus Sabocht</persName>
               </author>
               <title>A letter of <persName ref="http://syriaca.org/person/99">Severus Sabocht</persName> to the
-                priest <persName ref="http://syriaca.org/person/326">Aitīlāhā</persName> on certain terms in the treatise <ref>
-                  <foreign xml:lang="grc">περὶ
-                ἑρμηνείας</foreign>
-                </ref>
+                priest <persName ref="http://syriaca.org/person/326">Aitīlāhā</persName> on certain terms in the treatise <ref><foreign xml:lang="grc">περὶ
+                ἑρμηνείας</foreign></ref>
               </title>
               <rubric xml:lang="syr">ܕܚܣܝܐ ܣܐܘܪܐ ܣܒܘܟܬ: ܐܓܪܬܐ ܡܛܠ ܒ̈ܢܬ ܩ̈ܠܐ ܡܕܡ: ܕܒܟܬܒܐ ܕܦܪܝܐܪܡܢܝܐܣ:
                 ܠܘܬ ܩܫܝܫܐ ܐܝܬܝܠܗܐ. </rubric>

--- a/data/tei/428.xml
+++ b/data/tei/428.xml
@@ -217,8 +217,7 @@
               <locus from="67b" to="79b"/>
               <title xml:lang="en">
                 <ref>An anonymous Isagoge, or Introduction to the art of Logic</ref>,
-                translated from the Greek by the monk <persName ref="http://syriaca.org/person/109">Athanasius</persName>, of <placeName ref="http://syriaca.org/place/393">the
-                convent of Malchus</placeName>
+                translated from the Greek by the monk <persName ref="http://syriaca.org/person/109">Athanasius</persName>, of <placeName ref="http://syriaca.org/place/393">the convent of Malchus</placeName>
               </title>
               <rubric xml:lang="syr">ܐܣܘܓܘܓܐ ܕܡܛܠ ܦܪܐܓܡܛܝܐ ܡܠܝܠܬܐ ܘܣܘܠܘܓܝܣܛܝܩܝܬܐ: ܕܐܪܝܣܛܘܛܠܝܣ
                 ܦܝܠܣܘܦܐ: ܐܝܟ ܕܒܙܥܘܪ̈ܝܬܐ</rubric>

--- a/data/tei/429.xml
+++ b/data/tei/429.xml
@@ -117,8 +117,7 @@
                 <persName xml:lang="en">Galen</persName>
               </author>
               <title xml:lang="en">The sixth, seventh and eighth books of the
-                                treatise of <persName>Galen</persName>, entitled de <ref>Simplicium
-                                Medicamentorum Temperamentis ac Facultatibus</ref> translated by
+                                treatise of <persName>Galen</persName>, entitled de <ref>Simplicium Medicamentorum Temperamentis ac Facultatibus</ref> translated by
                 <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName></persName>
                             </title>
               <rubric xml:lang="syr">ܦܢܩܝܬܐ ܕܣܡ̈ܡܢܐ ܦܫ̈ܝܛܐ</rubric>

--- a/data/tei/429.xml
+++ b/data/tei/429.xml
@@ -119,8 +119,7 @@
               <title xml:lang="en">The sixth, seventh and eighth books of the
                                 treatise of <persName>Galen</persName>, entitled de <ref>Simplicium
                                 Medicamentorum Temperamentis ac Facultatibus</ref> translated by
-                <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName>
-                </persName>
+                <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName></persName>
                             </title>
               <rubric xml:lang="syr">ܦܢܩܝܬܐ ܕܣܡ̈ܡܢܐ ܦܫ̈ܝܛܐ</rubric>
               <note>See <bibl>Galeni Opera, ed. Kuhn, t. xi., pp. 789—892, t. xii., pp. 1—158</bibl>.</note>
@@ -153,8 +152,7 @@
                   <author ref="http://syriaca.org/person/496">
                     <persName xml:lang="en">Galen</persName>
                   </author>
-                  <title xml:lang="en">Book VI, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName>
-                    </persName>
+                  <title xml:lang="en">Book VI, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName></persName>
                   </title>
                 </msItem>
               </msItem>
@@ -183,8 +181,7 @@
                   <author ref="http://syriaca.org/person/496">
                     <persName>Galen</persName>
                   </author>
-                  <title xml:lang="en">Book VII, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName>
-                    </persName>
+                  <title xml:lang="en">Book VII, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName></persName>
                   </title>
                 </msItem>
               </msItem>
@@ -214,8 +211,7 @@
                   <author ref="http://syriaca.org/person/496">
                     <persName>Galen</persName>
                   </author>
-                  <title xml:lang="en">Book VIII, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName>
-                    </persName>
+                  <title xml:lang="en">Book VIII, translated by <persName ref="http://syriaca.org/person/49">Sergius of <placeName ref="http://syriaca.org/place/172">Ras-'ain</placeName></persName>
                   </title>
                 </msItem>
               </msItem>

--- a/data/tei/431.xml
+++ b/data/tei/431.xml
@@ -172,8 +172,7 @@
                 <title xml:lang="en">2. A letter written by <persName>the orthodox bishops</persName>
                   (<persName>Sergius</persName>, <persName>Marion, <foreign xml:lang="syr">ܡܪܝܘܢ</foreign>
                   </persName>, <persName>Nonnus, <foreign xml:lang="syr">ܢܘܢܐ</foreign>
-                  </persName>, <persName>Thomas</persName>, and <persName>John</persName>) to <persName>the
-                                monks of <placeName>Amid</placeName>
+                  </persName>, <persName>Thomas</persName>, and <persName>John</persName>) to <persName>the monks of <placeName>Amid</placeName>
                   </persName>
               </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܡܢ ܚ̈ܣܝܐ ܐ̈ܦܣܩܘܦܐ ܕܐܪ̈ܬܕܘܟܣܐ܆ ܠܕܝܪ̈ܝܐ ܕܒܟܢܘܫܝܐ ܕܐܡܕ̈ܝܐ ܘܕܟܠܗ ܫܘܠܛܢܗܘܢ</rubric>
@@ -228,8 +227,7 @@
                     </persName>, <persName>Ebion, <foreign xml:lang="syr">ܐܒܝܘܢ</foreign>
                     </persName>,
                     <persName>Bar-shūmā the magus, <foreign xml:lang="syr">ܒܪܫܘܡܐ ܚ̇ܪܫܐ</foreign>
-                    </persName>, <persName>Arius</persName>, <persName>Paul
-                                        of <placeName>Samosata</placeName>
+                    </persName>, <persName>Arius</persName>, <persName>Paul of <placeName>Samosata</placeName>
                   </persName>,
                                         <persName>Marcion</persName>,
                                         <persName>Valentinus</persName>,

--- a/data/tei/431.xml
+++ b/data/tei/431.xml
@@ -159,8 +159,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">The "Explanatio duodecim capitum" of <persName>Cyril of <placeName ref="http://syriaca.org/person/430">Alexandria</placeName>
-                  </persName>, from the seventh anathema to the end</title>
+                <title xml:lang="en">The "Explanatio duodecim capitum" of <persName>Cyril of <placeName ref="http://syriaca.org/person/430">Alexandria</placeName></persName>, from the seventh anathema to the end</title>
                 <note>
                   <bibl>Opera, t. vi., p. 153 A</bibl>.</note>
               </msItem>
@@ -170,10 +169,7 @@
                   <persName xml:lang="en">the orthodox bishops (Sergius, Marion, Nonnus, Thomas, and John)</persName>
                 </author>
                 <title xml:lang="en">2. A letter written by <persName>the orthodox bishops</persName>
-                  (<persName>Sergius</persName>, <persName>Marion, <foreign xml:lang="syr">ܡܪܝܘܢ</foreign>
-                  </persName>, <persName>Nonnus, <foreign xml:lang="syr">ܢܘܢܐ</foreign>
-                  </persName>, <persName>Thomas</persName>, and <persName>John</persName>) to <persName>the monks of <placeName>Amid</placeName>
-                  </persName>
+                  (<persName>Sergius</persName>, <persName>Marion, <foreign xml:lang="syr">ܡܪܝܘܢ</foreign></persName>, <persName>Nonnus, <foreign xml:lang="syr">ܢܘܢܐ</foreign></persName>, <persName>Thomas</persName>, and <persName>John</persName>) to <persName>the monks of <placeName>Amid</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܐܬܟ̣ܬܒܬ ܡܢ ܚ̈ܣܝܐ ܐ̈ܦܣܩܘܦܐ ܕܐܪ̈ܬܕܘܟܣܐ܆ ܠܕܝܪ̈ܝܐ ܕܒܟܢܘܫܝܐ ܕܐܡܕ̈ܝܐ ܘܕܟܠܗ ܫܘܠܛܢܗܘܢ</rubric>
                 <incipit xml:lang="syr">
@@ -202,16 +198,14 @@
                   <author>
                     <persName xml:lang="en">Felix, bishop of Rome</persName>
                   </author>
-                  <title xml:lang="en">The creed of <persName>Felix, bishop of <placeName>Rome</placeName>
-                    </persName>
+                  <title xml:lang="en">The creed of <persName>Felix, bishop of <placeName>Rome</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܬܚܘܝܬܐ ܕܗܝܡܢܘܬܐ ܕܩܕܝܫܐ ܦܝܠܟܣ ܪܝܫܐ ܕ[ܐ̈ܦܝܣܩܦܐ ܕܪܗܘܡܐ]</rubric>
                   <note>The commencement coincides with the fragment given in <bibl>Gallandii Bibl. Patr., t. iii., p. 542</bibl>.</note>
                 </msItem>
                 <msItem xml:id="p1b3" n="7" defective="true">
                   <locus from="6b"/>
-                  <title xml:lang="en">Chapters drawn up by <persName>the monks of <placeName>the western convents</placeName>
-                    </persName>
+                  <title xml:lang="en">Chapters drawn up by <persName>the monks of <placeName>the western convents</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܩ̈ܦܠܐܐ ܕܐܫܬܕܪܘ ܡܢ ܥܘܡܪ̈ܐ</rubric>
                   <incipit xml:lang="syr">ܐܢܚܢܢ ܥܘܡܪ̈ܐ ܕܡܥܪܒܐ ܕܒܝܬ ܡܪܝ ܐܝܣܚܩ ܘܕܒܝܬ ܡܪܝ
@@ -223,12 +217,8 @@
                 <msItem xml:id="p1b4" n="8">
                   <locus from="7"/>
                   <title xml:lang="en">Against <persName>Nestorius</persName>, comparing his overthrow with
-                    that of <persName>the older heretics</persName>, <persName>Simon Magus, <foreign xml:lang="syr">ܣܝܡܘܢ ܗ̇ܘ ܚ̇ܪܫܐ</foreign>
-                    </persName>, <persName>Ebion, <foreign xml:lang="syr">ܐܒܝܘܢ</foreign>
-                    </persName>,
-                    <persName>Bar-shūmā the magus, <foreign xml:lang="syr">ܒܪܫܘܡܐ ܚ̇ܪܫܐ</foreign>
-                    </persName>, <persName>Arius</persName>, <persName>Paul of <placeName>Samosata</placeName>
-                  </persName>,
+                    that of <persName>the older heretics</persName>, <persName>Simon Magus, <foreign xml:lang="syr">ܣܝܡܘܢ ܗ̇ܘ ܚ̇ܪܫܐ</foreign></persName>, <persName>Ebion, <foreign xml:lang="syr">ܐܒܝܘܢ</foreign></persName>,
+                    <persName>Bar-shūmā the magus, <foreign xml:lang="syr">ܒܪܫܘܡܐ ܚ̇ܪܫܐ</foreign></persName>, <persName>Arius</persName>, <persName>Paul of <placeName>Samosata</placeName></persName>,
                                         <persName>Marcion</persName>,
                                         <persName>Valentinus</persName>,
                                         <persName>Sabellius</persName>,
@@ -253,8 +243,7 @@
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
                   <title xml:lang="en">Extracts from discourses of
-                    <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName>
-                    </persName>, regarding the
+                    <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName></persName>, regarding the
                                     Incarnation and Passion of <persName>our Lord</persName>
                 </title>
                   <msItem xml:id="p1c2" n="11" defective="true">
@@ -302,8 +291,7 @@
                     <author ref="http://syriaca.org/person/44">
                       <persName xml:lang="en">Philoxenus of Mabūg</persName>
                     </author>
-                    <title xml:lang="en">From a discourse addressed to <persName>the monks of <placeName>Teleda</placeName>
-                      </persName>
+                    <title xml:lang="en">From a discourse addressed to <persName>the monks of <placeName>Teleda</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܡܪܝ ܐܟܣܢܝܐ܆ ܡܢ ܡܐܡܪܐ ܕܟ݂ܬܒ ܠܕܝܪܐ ܕܬܠܥܕܐ</rubric>
                     <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 37, no. 13</bibl>.</note>
@@ -498,8 +486,7 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title>Two short extracts from the writings of <persName>Severus of <placeName>Antioch</placeName>
-                  </persName>
+                <title>Two short extracts from the writings of <persName>Severus of <placeName>Antioch</placeName></persName>
                 </title>
               </msItem>
             </msContents>

--- a/data/tei/437.xml
+++ b/data/tei/437.xml
@@ -203,8 +203,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p1a1" n="1">
                 <locus from="1a"/>
-                <title xml:lang="en">A tract concerning <persName>Apostates from Christianity to
-                Islamism</persName>
+                <title xml:lang="en">A tract concerning <persName>Apostates from Christianity to Islamism</persName>
                 </title>
                 <rubric xml:lang="syr">ܫܪܒܐ ܕܥܠ ܟܦܘܪ̈ܐ</rubric>
                 <note>This work is introductory to <ref>the following item</ref>.</note>

--- a/data/tei/437.xml
+++ b/data/tei/437.xml
@@ -209,8 +209,7 @@
                 <note>This work is introductory to <ref>the following item</ref>.</note>
                 <msItem xml:id="p1b1" n="2">
                   <locus from="3b"/>
-                  <title xml:lang="en">An account of the martyr <persName ref="http://syriaca.org/person/1187">Cyrus (?) or Curius (?) of <placeName ref="http://syriaca.org/place/216">Harrān</placeName>
-                    </persName>, who suffered in the year <date datingMethod="Seleucid" when-custom="1081">1081</date>, <date calendar="Gregorian" when="0770">A.D. 770</date>
+                  <title xml:lang="en">An account of the martyr <persName ref="http://syriaca.org/person/1187">Cyrus (?) or Curius (?) of <placeName ref="http://syriaca.org/place/216">Harrān</placeName></persName>, who suffered in the year <date datingMethod="Seleucid" when-custom="1081">1081</date>, <date calendar="Gregorian" when="0770">A.D. 770</date>
                   </title>
                   <rubric xml:lang="syr">
                     <locus from="4a"/>ܬܘܒ ܕܥܠ ܣܗܕܐ ܩܘܪܝܣ ܗ̇ܘ ܕܗ̣ܘ ܥܠܬܐ ܠܫܪܒܐ ܗܢܐ</rubric>
@@ -924,8 +923,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p8a1" n="1">
                 <locus>Foll. 18, upper half, a and b, 10 b and a</locus>
-                <title>The martyrdom of <persName>Peter of <placeName>Alexandria</placeName>
-                  </persName>
+                <title>The martyrdom of <persName>Peter of <placeName>Alexandria</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܣܗܕܘܬܐ ܕܩܕܝܫܐ ܦܛܪܘܣ܆ ܐܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ ܒ̈ܝܘܡܝ ܕܘܩܠܛܝܢܘܣ ܡ̇ܠܟܐ</rubric>
                 <note>See <bibl>Add, 14,641, fol. 140 b</bibl>.</note>
@@ -935,8 +933,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                  </persName> on the
+                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on the
                 End of the World and the Coming of <persName>the Antichrist</persName>
                 </title>
                 <rubric xml:lang="syr">[ܕܡܪܝ ܝܥܩܘܒ ܕܥܠ] ܚܪܬܐ ܘܡܐܬܝܬܗ ܕܐ[ܢܛܝܟܪܝܣܛܘܣ]</rubric>
@@ -956,8 +953,7 @@
                 <author ref="http://syriaca.org/person/481">
                   <persName xml:lang="en">Eusebius of Emesa</persName>
                 </author>
-                <title xml:lang="en">A small portion of a discourse of <persName ref="http://syriaca.org/person/481">Eusebius of <placeName>Emesa</placeName>
-                  </persName> on Lent</title>
+                <title xml:lang="en">A small portion of a discourse of <persName ref="http://syriaca.org/person/481">Eusebius of <placeName>Emesa</placeName></persName> on Lent</title>
                 <rubric xml:lang="syr">ܕܐܘܣܒܝܣ ܐܦܝܣܩܘܦܐ ܕܚܡܨ܀ ܡܛܠ ܨܘܡܐ</rubric>
               </msItem>
               <msItem xml:id="p8a4" n="5">
@@ -965,8 +961,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah ofScete</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah <placeName>ofScete</placeName>
-                  </persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah <placeName>ofScete</placeName></persName>
               </title>
                 <note>See <bibl>Add. 14,575, no. 13</bibl>.</note>
               </msItem>

--- a/data/tei/44.xml
+++ b/data/tei/44.xml
@@ -181,8 +181,7 @@
                   <author ref="http://syriaca.org/person/2485">
                     <persName xml:lang="en">Alexander of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2485">Alexander of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2485">Alexander of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c3" n="8">
@@ -222,8 +221,7 @@
                   <author ref="http://syriaca.org/person/2786">
                     <persName xml:lang="en">Atticus of Constantinople</persName>
                   </author>
-                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2786">Atticus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                    </persName>
+                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2786">Atticus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>
                   </title>
                   <msItem xml:id="d6" n="15">
                     <locus from="135b"/>
@@ -331,8 +329,7 @@
                   <author ref="http://syriaca.org/person/430">
                     <persName xml:lang="en">Cyril of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                   </title>
                   <msItem xml:id="d23" n="35">
                     <locus from="132a"/>
@@ -485,8 +482,7 @@
                   <author ref="http://syriaca.org/person/481">
                     <persName xml:lang="en">Eusebius of Emesa</persName>
                   </author>
-                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/481">Eusebius of <placeName ref="http://syriaca.org/place/215">Emesa</placeName>
-                    </persName>
+                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/481">Eusebius of <placeName ref="http://syriaca.org/place/215">Emesa</placeName></persName>
                   </title>
                   <msItem xml:id="d51" n="65">
                     <locus from="131b"/>
@@ -559,8 +555,7 @@
                   <author ref="http://syriaca.org/person/2507">
                     <persName xml:lang="en">Theophilus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">Testimony of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                   </title>
                   <msItem xml:id="d63" n="79">
                     <locus from="135b"/>

--- a/data/tei/445.xml
+++ b/data/tei/445.xml
@@ -1954,8 +1954,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">A metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of
-                  Antioch</persName> on the plague in the days of King <persName>David</persName> (<title ref="http://syriaca.org/work/9527">2 Sam., ch. xxiv</title>)</title>
+                <title xml:lang="en">A metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName> on the plague in the days of King <persName>David</persName> (<title ref="http://syriaca.org/work/9527">2 Sam., ch. xxiv</title>)</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܡܘܬܢܐ ܕܗܘܐ ܒܝ̈ܘܡܝ ܕܘܝܕ ܢܒܝܐ. ܕܣܝܡ ܠܛܘܒܢܐ ܡܪܝ ܐܝܣܚܩ
                 ܐܦܝܣܩܘܦܐ ܘܡܠܦܢܐ.</rubric>
                 <incipit xml:lang="syr">ܕܘܝܕ ܡܠܟܐ ܒܪ ܐܝܫܝ ܐܬܚ̇ܫܒ ܗܘܐ ܟܣܝܐܝܬ: ܘܪܗ̣ܛ ܫ̇ܡܫ ܓܠܝܐܝܬ. ܡܕܡ

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -158,8 +158,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">On the blessed <persName ref="http://syriaca.org/person/624">
-                    Virgin Mary</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                    Batnae</persName>.</title>
+                    Virgin Mary</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܕܝ̇ܠܕܬ̇ ܐܠܗܐ</rubric>
                 <note>Imperfect at the beginning and in the middle.</note>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 310, no. 21</bibl>, and
@@ -191,8 +190,7 @@
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
                 <title xml:lang="en">On the Epiphany (<foreign xml:lang="grc">τὰ φῶτα</foreign>),
-                    by <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>.</title>
+                    by <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>.</title>
                 <note>Imperfect at the beginning and end.</note>
                 <note>See <bibl>Opera, t. i., p. 677</bibl>.</note>
               </msItem>
@@ -226,8 +224,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On the Epiphany, by <persName ref="http://syriaca.org/person/42">Jacob of
-                  Batnae</persName>.<!--WLP: maybe this is http://syriaca.org/work/8828? That is for Christ's baptism, celebrated at Epiphany-->
+                <title xml:lang="en">On the Epiphany, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.<!--WLP: maybe this is http://syriaca.org/work/8828? That is for Christ's baptism, celebrated at Epiphany-->
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ. ܡܐܡܪܐ ܕܥܐܕܐ ܩܕܝܫܐ̣ ܕܢܘܼܗܪ̈ܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 312, no. 28</bibl>.</note>
@@ -239,8 +236,7 @@
                 </author>
                 <title ref="http://syriaca.org/work/1283" xml:lang="en">On the Decollation of
                     <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>,
-                    by <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName>.</title>
+                    by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܐ݊ܝܘ݊ܢ݊ܢܝܣ. ܡܐܡܪܐ̣. ܕܥܠ ܦܣ̇ܩ̣ ܪܝܫܗ ܕܝܘܚܢܢ
                               ܡܥܡܕܢܐ
                 </rubric>
@@ -254,8 +250,7 @@
                 <title xml:lang="en">The tenth homily of <persName ref="http://syriaca.org/person/430">Cyril</persName> on the <title>Gospel of
                       <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
                   </title>,
-                  concerning <persName ref="http://syriaca.org/person/1808">S. John the
-                    Baptist</persName>.</title>
+                  concerning <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
                 <rubric xml:lang="syr">ܬܘܪܓܡܐ ܕܥܣܪܐ ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ. ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ̣ ܕܥܠ
                   ܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
                 <note>See <bibl>Payne Smith's edition, p. *11, and his translation, part i., p.
@@ -300,8 +295,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en" ref="http://syriaca.org/work/8843">On the holy fast of Lent and
-                  on love of the poor, by <persName ref="http://syriaca.org/person/42">Jacob of
-                    Batnae</persName>.</title>
+                  on love of the poor, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܫܒܬܐ ܩܕܡܝܬܐ ܕܨܘܡܐ. ܕܩܕܝܫܐ ܡܪܝ
                            ܝܥܩܘܒ. ܡܐܡܪܐ. ܕܥܠ ܨܘܡܐ ܩܕܝܫܐ ܕܐܪ̈ܒܥܝ̣ܢ ܘܥܠ ܪܚܡ̣ܬ̇ ܡ̈ܣܟܢܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 315, no. 69, serm. i</bibl>.</note>
@@ -311,8 +305,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On Lent, by <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName>.</title>
+                <title xml:lang="en">On Lent, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܐܢܢܝܣ ܡܐܡܪܐ̣. ܕܥܠ ܨܘܡܐ ܩܕܝܫܐ ܕܐܪܒܥܝܢ</rubric>
                 <rubric xml:lang="syr">ܕܐܪܒܥܐ ܒܫܒܐ ܕܫܒܬܐ ܩܕܡܝܬܐ ܕܨܘܡܐ</rubric>
                 <note>See <bibl>Opera, t. iv., p. 3</bibl>.</note>
@@ -350,8 +343,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On Lent, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On Lent, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܐܢܢܝܣ. ܡ܏ܐܡ ܕܥܠ ܨܘܡܐ ܩܕܝܫܐ
                            ܕܐܪ̈ܒܥܝܢ</rubric>
                 <rubric xml:lang="syr">ܕܚܕܒܫܒܐ ܕܬܪ̈ܝܢ ܕܨܘܡܐ ܩܕܝܫܐ
@@ -368,8 +360,7 @@
                 <title xml:lang="en">On the King who made a marriage-feast for his son
                       (<title>
                     <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>,
-                    ch. xxii. 1—14</title>), by <persName ref="http://syriaca.org/person/42">Jacob
-                    of Batnae</persName>.</title>
+                    ch. xxii. 1—14</title>), by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܗ̇ܘ ܓܒܪܐ ܕܥܒ̣ܕ ܡܫܬܘܬܐ ܠܒܪܗ ܘܥܠ ܗ̇ܘ ܕܠܒܝ̣ܫ
                   ܗܘܐ ܡ̈ܐܢܐ ܨ̈ܐܐ̇. ܘܥܠ ܩܪܝܬ̇ܐ ܕܥܡ̈ܡܐ ܘܡܣܬܠܝܢܘܬܐ ܕܥܡܐ.</rubric>
                 <rubric xml:lang="syr">ܕܝܘܡܐ ܕܬܪܝܢ ܕܫܒܬܐ ܕܬܪ̈ܬܝܢ
@@ -452,8 +443,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On Lent and on Repentance, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On Lent and on Repentance, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܨܘܡܐ ܩܕܝܫܐ̣ ܘܥܠ ܬܝܒܘܬܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܪ̈ܝܢ ܒܫܒܐ ܕܫܒܬܐ ܕܬܠܬ ܕܨܘܡܐ
                 </rubric>
@@ -467,8 +457,7 @@
                 </author>
                 <title xml:lang="en">On the Beatitudes (<title>
                     <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. v.
-                           1—12</title>), by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           1—12</title>), by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܗܠܝܢ ܛܘ̈ܒܐ ܕܐܡ̣ܪ ܡܪܢ ܒܐܘܢܓܠܝܘܢ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܫܒܬܐ ܕܬܠܬܐ ܕܨܘܡܐ ܩܕܝܫܐ
                 </rubric>
@@ -507,8 +496,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the parable of the Ten Virgins, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On the parable of the Ten Virgins, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܥܣܪ̈ ܒ̈ܬܘܠܢ ܕܐܝܬ ܒܐܘܢܓܠܝܘܢ ܘܥܠ
                            ܡܪܚܡܢܘܬܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ ܕܫܒܬܐ ܕܬ̈ܠܬ ܕܨܘܡܐ ܩܕܝܫܐ
@@ -529,8 +517,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On <title>Psalm xxxviii. (xxxix.) 11</title>, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On <title>Psalm xxxviii. (xxxix.) 11</title>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣ ܥܠ ܦܬܓܡܐ: ܗ̇ܘ ܕܐܡܝ̣ܪ ܠܗ ܠܛܘܒܢܐ ܕܘܝܕ ܒܡܙܡܘܪܐ.
                            ܐܝܟ ܕܒܠܫܢܐ ܝܘܢܝܐ̣. ܕܒܪܡ ܣܪܝܩܐܝܬ ܡܫ̣ܬܓܫ ܟܠ ܒܪܢܫ ܕܚܲܝ. ܕܐܝܬܘܗܝ ܒܣܘܪܝܝܐ̣.
                            ܐܝܟ ܠܗܓܐ ܐܢܘܢ ܟܠܗܘܢ ܒ̈ܢܝܢܫܐ</rubric>
@@ -555,8 +542,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Sermon for the middle of Lent, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">Sermon for the middle of Lent, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܡܨܥ̣ܬ̇ ܨܘܡܐ ܩܕܝܫܐ ܕܐܪ̈ܒܥܝܢ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܫܒܬܐ ܕܐܪ̈ܒܥ ܕ܏ܨ
                 </rubric>
@@ -570,8 +556,7 @@
                 </author>
                 <title xml:lang="en">On <title>
                     <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. viii.
-                           20</title>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           20</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">. ܕܠܠܝܐ ܕܐܪܒܥܐ ܕܦܠܓܗ ܕܨܘܡܐ
                 </rubric>
                 <incipit xml:lang="syr">ܡܪܝ ܠܟ ܢ̇ܚ̣ܒ ܟܠܗ ܥܠܡܐ ܠܡܫ̇ܒܚܘܼ. ܐ̇ܫܘܢܝ ܐܦ ܠܝ ܕܐ̇ܙܡܪ
@@ -583,8 +568,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On Psalm c., by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On Psalm c., by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܡܫܐ ܒܫܒܐ ܕܫܒܬܐ ܕܐܪ̈ܒܥ ܕܨܘܡܐ ܩܕܝܫܐ
                 </rubric>
                 <incipit xml:lang="syr">ܝܘܡܢܐ ܫܡ̣ܥܢܝܗܝ ܠܛܘܒܢܐ ܕܘܝܕ ܕܢܩ̇ܫ ܒܟܢܪܐ ܘܐܡ̇ܪ܇ ܥܘ̣ܠܘ
@@ -610,8 +594,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">On <persName>Zaccheus the publican</persName>,
-                           by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣ ܕܥܠ ܙܟܝ ܡܟܣܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܫܒܬܐ ܕܫܒܥ (sic) ܕܐܪ̈ܒܥ ܕܨܘܡܐ ܩܕܝܫܐ
                 </rubric>
@@ -623,8 +606,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. x. 17</title>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                    <persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. x. 17</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܕܒܫܒܐ ܕܚܡܫܐ ܕܨܘܡܐ
                 </rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 319, no. 101</bibl>.</note>
@@ -635,8 +617,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Extract from hom. v. on the <title>Epistle of <persName ref="http://syriaca.org/person/1983">S. Paul</persName> to the Romans</title>,
-                           by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܪܝܢ ܒܫܒܐ ܕܫܒܬܐ ܕܬܕܡܪ̈ܬܐ.
                 </rubric>
                 <note>
@@ -661,8 +642,7 @@
                 </author>
                 <title xml:lang="en">Extract from hom. xxxii. on the <title>Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>
                   </title>,
-                           by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܐܪܒܥܐ ܒܫܒܐ ܕܫܒܬܐ ܕܬܕܡܪ̈ܬܐ
                 </rubric>
                 <note>
@@ -687,8 +667,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">On <persName>Lazarus</persName> and the Rich
-                           Man, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           Man, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ ܕܫܒܬܐ ܕܬܕܡܪ̈ܬܐ
                 </rubric>
                 <note>See <bibl>Opera, t. viii., p. 756</bibl>.</note>
@@ -700,8 +679,7 @@
                 </author>
                 <title xml:lang="en">On <title>
                     <persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. viii. 36</title>,
-                           by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܫܒܬܐ ܕܫܒܬܐ ܕܬܕ܏ܡܪ̈
                 </rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 315, no. 77</bibl>.</note>
@@ -711,8 +689,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Extract from hom. x. on the <title>second Epistle of <persName ref="http://syriaca.org/person/1983">S. Paul</persName> to the Corinthians</title>, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                <title xml:lang="en">Extract from hom. x. on the <title>second Epistle of <persName ref="http://syriaca.org/person/1983">S. Paul</persName> to the Corinthians</title>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܕܒܫܒܐ ܕܫܬܐ ܕܨܘܡܐ
                 </rubric>
                 <note>
@@ -726,8 +703,7 @@
                 </author>
                 <title xml:lang="en">On <title>
                     <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xiii.
-                           33</title>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           33</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܪ̈ܝܢ ܒܫܒܐ. ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ
                 </rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p 316, no. 78</bibl>.</note>
@@ -765,8 +741,7 @@
                 </author>
                 <title xml:lang="en">On <title>
                     <persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. xii. 16</title>,
-                           by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ. ܕܥܠ ܥܬܝܪܐ ܕܐܥ̣ܠܬ̇ ܠܗ ܐܪܥܗ̣ ܥ̈ܠ̇ܠܬܐ
                            ܣ̈ܓܝܐܬܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܡܫܐ ܒܫܒܐ. ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ.
@@ -779,8 +754,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the termination of Lent and on Repentance, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                <title xml:lang="en">On the termination of Lent and on Repentance, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܫܘܠܡ ܨܘܡܐ̣. ܘܥܠ ܬܝܒܘܬܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ
                 </rubric>
@@ -794,8 +768,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">On the raising of <persName>Lazarus</persName>,
-                           by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܠܥܙܪ ܕܒܝܬ ܥܢܝܐ ܕܐܢܚܡ ܡܪܢ ܡܢ ܩܒ̣ܪܐ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܫܒܬܐ. ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ
                 </rubric>
@@ -819,8 +792,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Discourse for Palm Sunday, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">Discourse for Palm Sunday, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <incipit xml:lang="syr">ܚ̈ܒܝܒܝ̣. ܐܝܟܢܐ ܟܕ ܩܲܒܠܬܘܢܝܗܝ ܠܫܪܒܐ ܕܥܠ ܬܫܥܝܬܗ ܕܠܥܙܪ.
                            ܘܐܝܟܢܐ ܐܫܬܡ̣ܥ ܠܟܘܢ ܬܘܪܓܡܐ ܕܥܠ ܚܲܝܬ̇ ܡ̈ܝ̣ܬܐ.</incipit>
               </msItem>
@@ -858,8 +830,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Discourse for the Monday in Passion Week, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                <title xml:lang="en">Discourse for the Monday in Passion Week, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܬܪ̈ܝܢ ܒܫܒܐ ܕܫܒܬܐ ܪܒܬܐ ܕܚ̣ܫܐ̣. ܘܡܛܠ ܘܥܕܗ
                            ܕܠܡܐܢܐ. ܐܡ̣ܪܗ ܕܝܢ ܒܥܕܬܐ ܕܐܣܝܐ ܟܕ ܗ̣ܘ ܐܝܬܘܗܝ ܗܘܐ̣ ܒܐܟܣܘܪܝܐ</rubric>
                 <incipit xml:lang="syr">ܢܗܝܪ̈ܐ ܕܥ̇ܠܒܝܢ ܠܕܥܝܕܐ ܝܘܡܢܐ ܒܡܕܝܢܬܐ ܚ̇ܙܐ ܐܢ̣ܐ. ܘܫܦܝܪ
@@ -891,8 +862,7 @@
                 </author>
                 <title xml:lang="en">On <title>
                     <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xxvi.
-                           39</title>, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           39</title>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܬܠܬܐ ܒܫܒܐ ܕܚܫ̣ܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܐܢܢܝܣ. ܡܐܡܪܐ̣ ܥܠ
                            ܗ̇ܝ ܕܐܒܝ ܐܢ ܡ̣ܨܝܐ ܢܥܒ̣ܪܢܝ ܟܣܐ ܗܢܐ̣. ܘܠܘܩܒܠ ܐܪ̈ܣܝܘܛܐ.</rubric>
                 <note>See <bibl>Opera, t. x., p. 966</bibl>, from the beginning to p. 971, <foreign xml:lang="grc">ἁμαρτωλῶν
@@ -927,8 +897,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Extract from the second sermon on the
-                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ ܕܬܠܬܐ ܒܫܒܐ ܕܚܫ̣ܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 324, no. 163</bibl>.</note>
               </msItem>
@@ -937,8 +906,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the Passion of <persName ref="http://syriaca.org/person/2245">the Redeemer</persName>, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On the Passion of <persName ref="http://syriaca.org/person/2245">the Redeemer</persName>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܐܪܒܥܐ ܒܫܒܐ ܕܚܫܐ. ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܐܢܢܝܣ. ܡ܏ܐܡ ܕܥܠ
                            ܚܫܐ ܦܪܘܩܝܐ</rubric>
                 <incipit xml:lang="syr">ܕܚ̇ܠ ܐܢ̣ܐ ܕܐ̇ܡܠܠ ܘܒܠܫܢܐ ܐ̇ܓܫܘܦ܇ ܥܠ ܬܫܥܝܬܐ ܕܚܫܗ
@@ -961,9 +929,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <persName>Jephthah</persName> and <persName>his
-                           Daughter</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                <title xml:lang="en">On <persName>Jephthah</persName> and <persName>his Daughter</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣ ܕܥܠ ܢܦܬܚ ܟܕ ܕܒܚ̣ ܗܘܐ ܒܪܬܗ. ܕܝܘܡܐ̣ ܕܐܪܒܥܐ
                            ܕܚܫܐ.</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 321, no. 125</bibl>.</note>
@@ -974,8 +940,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Extract from the third sermon on the
-                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ ܕܐܪܒܥܐ ܒܫܒܐ ܕܚܫ̣ܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 321, no. 163</bibl>.</note>
               </msItem>
@@ -1060,8 +1025,7 @@
                   <persName xml:lang="en">Proclus of Constantinople
                 </persName>
                 </author>
-                <title xml:lang="en">For Good Friday and on <persName>Judas the
-                              traitor</persName>, by <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
+                <title xml:lang="en">For Good Friday and on <persName>Judas the traitor</persName>, by <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܪܘܩܠܘܣ ܐ܏ܦܝܣܩܘ ܕܩܘܣܛܐܢܛܝܢܘ ܦܘܠܝܣ. ܬܘܪܓܡܐ
                            ܕܠܠܝܐ ܩܕܝܫܐ ܕܥܪܘܒܬܐ ܕܙ܏ܩܝܦܘܼ. ܘܥܠ ܝܗܘܕܐ ܡܫܠ̣ܡܢܐ</rubric>
@@ -1072,8 +1036,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">For Good Friday, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">For Good Friday, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ. ܕܠܠܝܐ ܩܕܝܫܐ̣ ܕܥܪܘܒܬܐ ܕܙܩܝܦܘܬܐ</rubric>
                 <incipit xml:lang="syr">ܝܘܡܢܐ ܚ̈ܒܝܒܝ̣. ܪܐܙܐ ܗ̇ܘ ܕܡܚ̇ܦܝ ܗܘܐ ܡܢ ܥܠܡ̈ܐ ܘܡܢ
                            ܕܪ̈ܐ̣. ܒܡܨܥܬܗ̇ ܕܬܒܝܠ ܐܬܓܠ̣ܝ̣ ܘܐܬܝ̣ܕܥ. ܏ܘܫ.</incipit>
@@ -1095,8 +1058,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title ref="http://syriaca.org/work/8841" xml:lang="en">On the Denial of <persName ref="http://syriaca.org/person/2008">Simon Peter</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                <title ref="http://syriaca.org/work/8841" xml:lang="en">On the Denial of <persName ref="http://syriaca.org/person/2008">Simon Peter</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܟܦܘܪܝܗ ܕܫܡܥܘܢ ܪܝܫܐ ܕܫ̈ܠܝܚܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 325, no. 161, serm. iii</bibl>.</note>
               </msItem>
@@ -1106,8 +1068,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Extract from the fifth sermon on the
-                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ̣. ܕܝܘܡܐ ܕܥܪܘܒܬܐ ܕܙܩܝܦܘܬܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 321, no. 163</bibl>.</note>
               </msItem>
@@ -1117,8 +1078,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Continuation of the fifth sermon on the
-                  Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                    Batnae</persName>.</title>
+                  Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ̣ ܕܬܫ̈ܥ ܫ̈ܥܝܢ ܕܥܪܘܒܬܐ ܕܙܩܝܦܘܬܐ</rubric>
               </msItem>
               <msItem xml:id="b85" n="86">
@@ -1126,10 +1086,8 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title ref="http://syriaca.org/work/1915" xml:lang="en">On the Saturday of Annunciation, on Baptism, <persName ref="http://syriaca.org/person/1851">the
-                  Thief on the <persName ref="http://syriaca.org/person/1661">Cross</persName>
-                  </persName>, etc., by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom.</persName>
+                <title ref="http://syriaca.org/work/1915" xml:lang="en">On the Saturday of Annunciation, on Baptism, <persName ref="http://syriaca.org/person/1851">the Thief on the <persName ref="http://syriaca.org/person/1661">Cross</persName>
+                  </persName>, etc., by <persName ref="http://syriaca.org/person/573">John Chrysostom.</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܫܒܬܐ ܕܣܒܪܬܐ ܘܡܥܡܘܕܝܬܐ ܘܓܝ̇ܣܐ̣. ܘܥܠ ܗ̇ܝ ܕܠܐ
                            ܢܗܘܐ ܐܣ̈ܘܛܐ ܘܪ̈ܘܝܐ</rubric>
@@ -1142,8 +1100,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Extract from the sixth sermon on the
-                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                           Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ ܕܠܠܝܐ ܕܫܒܬܐ ܕܣܒܪܬܐ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 324, no. 163</bibl>.</note>
               </msItem>
@@ -1152,8 +1109,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">On the Passover, by <persName ref="http://syriaca.org/person/511">Gregory
-                           Nazianzen</persName>.</title>
+                <title xml:lang="en">On the Passover, by <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܦܨܚܐ ܘܥܠ ܬܘܚܪܬܐ̣. ܐܘܟܝܬ ܥܠ ܐܒܘܗܝ ܐܦܝܣܩܘܦܐ
                            ܕܢܐܙܝܐܢܙܘܿ. ܒܗ̇ܝ ܕܐܦ ܟܝܪܘܛܘܢܝܣܐ ܥܒ̣ܕܗ ܩܫܝܫܐ.</rubric>
                 <note>See <bibl>Opera, t. i., p. 3</bibl>.</note>
@@ -1164,8 +1120,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Continuation of the sixth sermon on the
-                  Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of
-                    Batnae</persName>.</title>
+                  Crucifixion, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܩܘܡܐ ܕܠܠܝܐ ܕܚܕܒܫܒܐ ܩܕܝܫܐ ܕܩܝ̣ܡܬܐ</rubric>
                 <finalRubric xml:lang="syr">
                   <locus from="297"/>
@@ -1188,8 +1143,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Discourses for Monday of the Week of Cessation
-                           or Best, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           or Best, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ. ܕܬܪ̈ܝܢ ܒܫܒܐ ܕܢܝ̇ܚܬܐ ܘܡܪܬܝܢܘܬܐ̣. ܘܕܢܥ̣ܪܘܩ ܐܢܫ
                            ܡܢ ܙܢܝܘܬܐ</rubric>
                 <incipit xml:lang="syr">ܒܥܘܗܕܢܐ ܕܩܝ̣ܡܬܗ ܕܡܪܢ ܡܬܚ̇ܙܝܐ ܠܝ: ܕܘ̇ܠܐ ܕܢܬܥ̣ܗܕܘܢ ܐܦ
@@ -1200,8 +1154,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Discourse for Wednesday of the same week, by <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                <title xml:lang="en">Discourse for Wednesday of the same week, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <incipit xml:lang="syr">ܚ̈ܒܝܒܝ̣. ܝܘܡܢܐ ܙܕܩ̇ ܠܢ ܕܟܠܢ ܢܩ̣ܥܐ ܘܢܐܡܪ̈. ܗ̇ܘ ܦܬܓܡܐ
                            ܕܢܒܝܐ ܕܘܝܕ: ܟܕ ܡܫ̇ܒܚܝܢܢ ܠܡܪܝܐ ܐܠܗܢ ܘܡ̇ܙܥܩܝܢܢ̇. ܕܡܲܢܘ ܢܫܬ̇ܥܐ ܬܕܡܪܬܗ
                            ܕܡܪܝܐ̇. ܏ܘܫ.</incipit>
@@ -1211,8 +1164,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Discourse for Friday of the same week, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                <title xml:lang="en">Discourse for Friday of the same week, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣. ܕܥܠ ܥܪܘܒܬܐ ܩܕܝܫܬܐ ܕܢܝ̇ܚܬܐ</rubric>
                 <incipit xml:lang="syr">ܩܛܝܠܐ ܕܢܚ̣ܬܐ ܘܙܟ̣ܐ ܘܣܠ̣ܩ ܡܢ ܓܘ ܩܒ̣ܪܐ̣. ܗܒ̣ ܠܝ ܡܠܬܐ
                            ܕܡ̇ܛܝܐ ܬܙܡ̣ܪܝ ܥܠ ܢܘܚܡܟ.</incipit>
@@ -1223,8 +1175,7 @@
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
                 <title xml:lang="en">Discourse for New (or Low) Sunday (<foreign xml:lang="grc">ἡ καινὴ
-                           κυριακή</foreign>), by <persName ref="http://syriaca.org/person/511">Gregory
-                              Nazianzen</persName>.</title>
+                           κυριακή</foreign>), by <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܚܕܒܫܒܐ ܚ̣ܕܬܐ̣. ܘܥܠ ܬܕܐܐ ܘܥܠ ܣܗܕܐ ܡܐܡܐ.
                            ܒܚܕܒܫܒܐ ܓܝܪ ܚ̣ܕܬܐ ܡܫܬܡܠܐ̣ ܕܘܟܪܢܗ ܒܩܐܣܐܪܝܐ</rubric>
                 <note>See <bibl>Opera, t. i., p. 835</bibl>.</note>
@@ -1243,8 +1194,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the Ascension of <persName ref="http://syriaca.org/person/2245">our Lord</persName>, by <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>.</title>
+                <title xml:lang="en">On the Ascension of <persName ref="http://syriaca.org/person/2245">our Lord</persName>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣. ܕܥܠ ܣܘܠܩܗ ܕܡܪܢ ܘܦܪܘܩܢ ܝܫܘܥ ܡܫܝܚܐ
                            ܠܫܡܝܐ.</rubric>
                 <note>See <bibl>Opera, t. iii., p. 913</bibl>.</note>
@@ -1262,8 +1212,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">On Pentecost, by <persName ref="http://syriaca.org/person/511">Gregory
-                           Nazianzen</persName>.</title>
+                <title xml:lang="en">On Pentecost, by <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܦܢܛܝܩܘܣܛܐ̣. ܘܥܠ ܪܘܚܐ ܩܕܝܫܐ</rubric>
                 <note>See <bibl>Opera, t. i., p. 731</bibl>.</note>
               </msItem>
@@ -1283,8 +1232,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title ref="http://syriaca.org/work/1080" xml:lang="en">On the Decease and Obsequies of <persName ref="http://syriaca.org/person/624">the blessed Virgin</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>.</title>
+                <title ref="http://syriaca.org/work/1080" xml:lang="en">On the Decease and Obsequies of <persName ref="http://syriaca.org/person/624">the blessed Virgin</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܡܢܐܝܢ ܘܚܕ ܡ̈ܥܕܥܕܢܐ̣. ܕܐܡܝ̣ܪ ܠܗ ܟܕ ܗ̣ܘܬ̇ ܒܥ̇ܬܐ
                            ܡܛܠܬܗ ܒܣܘܢܘܕܘܣ܇ ܟܕ ܩ̇ܐܡ ܒܥܕܬܐ ܕܩܕܝܫܐ ܡܪܝ ܩܘܪܝܐܩܘܣ ܣܗܕܐ ܒܢܨܝܒܝܢ ܡܕܝܢܬܐ̣.
                            ܒܝܘܡ ܐܪܒܥܐ ܒܫܒܐ ܒܐܪܒܬܥܣܪ ܒܐܒ ܝܪܚܐ. ܕܥܠ ܥܘܦܝܗ̇ ܐܘܟܝܬ ܥܘܢܕܗ̇ ܕܒܬܘܠܬܐ ܩܕܝܫܬܐ
@@ -1309,8 +1257,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title ref="http://syriaca.org/work/1398" xml:lang="en">On the Invention of the <persName ref="http://syriaca.org/person/1661">holy Cross</persName> by the <persName ref="http://syriaca.org/person/1265">empress
-                              Helene</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
+                <title ref="http://syriaca.org/work/1398" xml:lang="en">On the Invention of the <persName ref="http://syriaca.org/person/1661">holy Cross</persName> by the <persName ref="http://syriaca.org/person/1265">empress Helene</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܫܟܚܬܗ ܕܨܠܝܒܐ̣ ܡܢ ܗܠܢܐ ܡܠܟܬܐ.</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 328, no. 188</bibl>.</note>
               </msItem>
@@ -1363,8 +1310,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Funeral sermon, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>, on bishops and priests.</title>
+                <title xml:lang="en">Funeral sermon, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>, on bishops and priests.</title>
                 <rubric xml:lang="syr">ܕܥܠ ܪ̈ܝܫܝ ܟܗ̈ܢܐ̣. ܘܟܗ̈ܢܐ ܕܥ̇ܢܕܝܢ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 313, no. 39, serm. i</bibl>.</note>
               </msItem>
@@ -1373,8 +1319,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Funeral sermon, by <persName ref="http://syriaca.org/person/42">Jacob of
-                              Batnae</persName>, for the deceased in general.</title>
+                <title xml:lang="en">Funeral sermon, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>, for the deceased in general.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥ̈ܢܝܕܐ̣ ܕܥܠ ܟܠܢܫ</rubric>
                 <finalRubric xml:lang="syr">
                   <locus from="354b"/>

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -129,8 +129,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">On the Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>, being the second homily on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>.</title>
+                <title xml:lang="en">On the Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>, being the second homily on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>.</title>
                 </title>
                 <rubric xml:lang="syr">ܬܘܪܓܳܡܳܐ ܕܩܕܝܫܐ ܩ݊ܘ݊ܪܝ݊ܠܠܘܣ ܪܝܫ ܐܦܝ̈ܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ. ܡܢ
                   ܦܘܫܳܩܳܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ̣. ܕܥܠ ܒܝܬ ܝܠܕܗ ܕܦܪܘܩܢ ܕܒܒܣܪ</rubric>
@@ -157,8 +156,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On the blessed <persName ref="http://syriaca.org/person/624">
-                    Virgin Mary</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
+                <title xml:lang="en">On the blessed <persName ref="http://syriaca.org/person/624">Virgin Mary</persName>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܕܝ̇ܠܕܬ̇ ܐܠܗܐ</rubric>
                 <note>Imperfect at the beginning and in the middle.</note>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 310, no. 21</bibl>, and
@@ -170,8 +168,7 @@
                   <persName xml:lang="en">Severus of Antioch
                 </persName>
                 </author>
-                <title ref="http://syriaca.org/work/883" xml:lang="en">On the Massacre of <persName ref="http://syriaca.org/person/1786">the Innocents</persName>, by <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>.</title>
+                <title ref="http://syriaca.org/work/883" xml:lang="en">On the Massacre of <persName ref="http://syriaca.org/person/1786">the Innocents</persName>, by <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܣ݊ܐܘ݊ܝ݊ܪܐ ܡܐܡܪܐ̣. ܕܥܠ ܛ̈ܠܝܐ ܕܐܬܩܲܛܠܘ ܡܢ ܐܝܪܘܕܝܣ
                   ܡܲܠܟܐ ܥ̇ܘܠܐ</rubric>
               </msItem>
@@ -211,8 +208,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">The eleventh homily of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
+                <title xml:lang="en">The eleventh homily of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
                   </title>, on the Epiphany.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܚܕܥܣܪ. ܕܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ ܕܩܕܝܫܐ
                            ܩ݊ܘ݊ܪܝ݊ܠܠܘܣ ܪܝܫܐ ܕܐܦܝܣܩ̈ܘܦܐ ܕܐܠܟܣܢܕܪܝܐ̣. ܥܠ ܕܢܚ̣ܗ ܕܡܪܢ.</rubric>
@@ -782,8 +778,7 @@
                 </author>
                 <title xml:lang="en">Hom. cxxx. on the <title>Gospel of <persName>S.
                               Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 358</bibl>, and <bibl>his translation, part ii., p.
                            601</bibl>.</note>
               </msItem>
@@ -819,8 +814,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxxxiv. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <incipit xml:lang="syr">ܡܢܐ ܗܟܝܠ ܐܪܐ ܐܡ̇ܪ ܠܪ̈ܝܫܢܐ ܕܝܘ̈ܕܝܐ</incipit>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 371, line 19</bibl>; and <bibl>his translation,
                            part ii., p. 624</bibl>.</note>
@@ -875,8 +869,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxl. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܚ̣ܫܐ</rubric>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 396</bibl>; and <bibl>his translation, part ii., p.
                            655</bibl>.</note>
@@ -919,8 +912,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxlvi. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 418</bibl>; and <bibl>his translation, part ii., p.
                            683</bibl>.</note>
               </msItem>
@@ -961,8 +953,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxli. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܡܫܐ ܒܫܒܐ ܕܪܐܙܐ</rubric>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 400</bibl>; and <bibl>his translation, part ii., p.
                            659</bibl>.</note>
@@ -973,8 +964,7 @@
                   <persName xml:lang="en">Jacob of Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">On the Consecration of the Chrism, by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">On the Consecration of the Chrism, by <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܣܝ̣ܡ ܠܚܣܝܐ ܡܪܝ ܝܥܩܘܒ ܐܘܪܗܝܐ. ܕܥܠ ܩ̇ܘܕܫ ܡܘܪܘܢ̇.
                            ܕܝܠܗ ܕܝܘܡܐ ܩܕܝܫܐ</rubric>
                 <incipit xml:lang="syr">ܥܠ ܪ̈ܐܙܐ ܘܛܘ̈ܦ̣ܣܐ ܕܡܫ̣ܚܐ ܗܢܐ ܩܕܝܫܐ: ܘܪܘܟܒܐ ܕܡܘܪܘܢ
@@ -996,8 +986,7 @@
                   <persName xml:lang="en">John, patriarch of Antioch
                 </persName>
                 </author>
-                <title xml:lang="en">On the Consecration of the Chrism, by <persName>John, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">On the Consecration of the Chrism, by <persName>John, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܘܚܢܢ ܦܐܛܪܝܐܪܟܐ ܕܐܢܛܝܘܟܝܐ. ܡܐܡܪܐ̣ ܕܥܠ
                            ܩ̇ܘܕܫ ܡܘܪܘܢ</rubric>
                 <incipit xml:lang="syr">ܡܛܠ ܥܐܕܐ ܗܢܐ ܕܗܫܐ ܩ̇ܐܡ ܐܚ̈ܝ̣. ܕܙܥܘܪ̈ܝܬܐ ܦܝܠܘܣܘܦܝܐ
@@ -1025,8 +1014,7 @@
                   <persName xml:lang="en">Proclus of Constantinople
                 </persName>
                 </author>
-                <title xml:lang="en">For Good Friday and on <persName>Judas the traitor</persName>, by <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">For Good Friday and on <persName>Judas the traitor</persName>, by <persName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܪܘܩܠܘܣ ܐ܏ܦܝܣܩܘ ܕܩܘܣܛܐܢܛܝܢܘ ܦܘܠܝܣ. ܬܘܪܓܡܐ
                            ܕܠܠܝܐ ܩܕܝܫܐ ܕܥܪܘܒܬܐ ܕܙ܏ܩܝܦܘܼ. ܘܥܠ ܝܗܘܕܐ ܡܫܠ̣ܡܢܐ</rubric>
                 <note>See <bibl>Gallandii Biblioth. Yett. Patrum, t. ix., p. 655</bibl>.</note>
@@ -1048,8 +1036,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxlix. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName>.</title>
+                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 429</bibl>; and <bibl>his translation, part ii., p.
                            698</bibl>.</note>
               </msItem>
@@ -1086,8 +1073,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title ref="http://syriaca.org/work/1915" xml:lang="en">On the Saturday of Annunciation, on Baptism, <persName ref="http://syriaca.org/person/1851">the Thief on the <persName ref="http://syriaca.org/person/1661">Cross</persName>
-                  </persName>, etc., by <persName ref="http://syriaca.org/person/573">John Chrysostom.</persName>
+                <title ref="http://syriaca.org/work/1915" xml:lang="en">On the Saturday of Annunciation, on Baptism, <persName ref="http://syriaca.org/person/1851">the Thief on the <persName ref="http://syriaca.org/person/1661">Cross</persName></persName>, etc., by <persName ref="http://syriaca.org/person/573">John Chrysostom.</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܫܒܬܐ ܕܣܒܪܬܐ ܘܡܥܡܘܕܝܬܐ ܘܓܝ̇ܣܐ̣. ܘܥܠ ܗ̇ܝ ܕܠܐ
                            ܢܗܘܐ ܐܣ̈ܘܛܐ ܘܪ̈ܘܝܐ</rubric>
@@ -1246,8 +1232,7 @@
                   <persName xml:lang="en">Pantaleon of Byzantium
                 </persName>
                 </author>
-                <title ref="http://syriaca.org/work/1464" xml:lang="en">On the Exaltation of the holy Cross, by <persName ref="http://syriaca.org/person/2795">Pantaleon of <placeName ref="http://syriaca.org/place/2759">Byzantium</placeName>
-                  </persName>.</title>
+                <title ref="http://syriaca.org/work/1464" xml:lang="en">On the Exaltation of the holy Cross, by <persName ref="http://syriaca.org/person/2795">Pantaleon of <placeName ref="http://syriaca.org/place/2759">Byzantium</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܦܐܢܛܠܝܘܢ ܩܫܝܫܐ ܡܢ ܕܝܪܐ ܕܒܘܙܢܛܝܐ̣. ܕܥܠ ܨܠܝܒܐ
                            ܦܪܘܩܝܐ̣ ܘܥܠ ܡܬܬܪܝܡܢܘܬܗ.</rubric>
                 <note>See <bibl>Cave, Hist. Litterar., vol. ii., Dissert. Prima, p. 15</bibl>.</note>
@@ -1285,8 +1270,7 @@
                 <author ref="http://syriaca.org/person/512">
                   <persName xml:lang="en">Gregory Nyssen</persName>
                 </author>
-                <title ref="http://syriaca.org/work/1432" xml:lang="en">On the death of <persName ref="http://syriaca.org/person/1919">Meletius, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>, by <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>.</title>
+                <title ref="http://syriaca.org/work/1432" xml:lang="en">On the death of <persName ref="http://syriaca.org/person/1919">Meletius, bishop of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, by <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܡ̇ܘܬܗ ܕܪܒܐ ܡܝܠܝܛܘܣ ܐܦܝܣܩܘܦܐ ܕܐܢܛܝܘܟܝܐ.
                            ܬܪܓܡ̣ܗ ܕܝܢ ܛܘܒܢܐ ܓܪܝܓܘܪܝܣ ܐܦܝܣܩܘܦܐ ܕܢܘܣܐ̣. ܩܕܡ ܡܐܐ ܘܚܡܫܝܢ ܐܦ܏ܝܣܩ̈ܘ
                            ܒܩܘܣܛܢܛܝܢܘܦܘܠܝܘܣ</rubric>

--- a/data/tei/45.xml
+++ b/data/tei/45.xml
@@ -208,8 +208,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">The eleventh homily of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, on the Epiphany.</title>
+                <title xml:lang="en">The eleventh homily of <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, on the Epiphany.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܚܕܥܣܪ. ܕܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ ܕܩܕܝܫܐ
                            ܩ݊ܘ݊ܪܝ݊ܠܠܘܣ ܪܝܫܐ ܕܐܦܝܣܩ̈ܘܦܐ ܕܐܠܟܣܢܕܪܝܐ̣. ܥܠ ܕܢܚ̣ܗ ܕܡܪܢ.</rubric>
                 <note>. See <bibl>Dr. Payne Smith's edition, p. *15</bibl>, and <bibl>his
@@ -243,9 +242,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril</persName>
                 </author>
-                <title xml:lang="en">The tenth homily of <persName ref="http://syriaca.org/person/430">Cyril</persName> on the <title>Gospel of
-                      <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>,
+                <title xml:lang="en">The tenth homily of <persName ref="http://syriaca.org/person/430">Cyril</persName> on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>,
                   concerning <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
                 <rubric xml:lang="syr">ܬܘܪܓܡܐ ܕܥܣܪܐ ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ. ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ̣ ܕܥܠ
                   ܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
@@ -354,8 +351,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">On the King who made a marriage-feast for his son
-                      (<title>
-                    <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>,
+                      (<title><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>,
                     ch. xxii. 1—14</title>), by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܗ̇ܘ ܓܒܪܐ ܕܥܒ̣ܕ ܡܫܬܘܬܐ ܠܒܪܗ ܘܥܠ ܗ̇ܘ ܕܠܒܝ̣ܫ
                   ܗܘܐ ܡ̈ܐܢܐ ܨ̈ܐܐ̇. ܘܥܠ ܩܪܝܬ̇ܐ ܕܥܡ̈ܡܐ ܘܡܣܬܠܝܢܘܬܐ ܕܥܡܐ.</rubric>
@@ -451,8 +447,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On the Beatitudes (<title>
-                    <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. v.
+                <title xml:lang="en">On the Beatitudes (<title><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. v.
                            1—12</title>), by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܗܠܝܢ ܛܘ̈ܒܐ ܕܐܡ̣ܪ ܡܪܢ ܒܐܘܢܓܠܝܘܢ</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܫܒܬܐ ܕܬܠܬܐ ܕܨܘܡܐ ܩܕܝܫܐ
@@ -550,8 +545,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. viii.
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. viii.
                            20</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">. ܕܠܠܝܐ ܕܐܪܒܥܐ ܕܦܠܓܗ ܕܨܘܡܐ
                 </rubric>
@@ -601,8 +595,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. x. 17</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. x. 17</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܕܒܫܒܐ ܕܚܡܫܐ ܕܨܘܡܐ
                 </rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 319, no. 101</bibl>.</note>
@@ -636,8 +629,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Extract from hom. xxxii. on the <title>Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>
-                  </title>,
+                <title xml:lang="en">Extract from hom. xxxii. on the <title>Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName></title>,
                            by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܐܪܒܥܐ ܒܫܒܐ ܕܫܒܬܐ ܕܬܕܡܪ̈ܬܐ
                 </rubric>
@@ -673,8 +665,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. viii. 36</title>,
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/1871">S. Mark</persName>, ch. viii. 36</title>,
                            by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܫܒܬܐ ܕܫܒܬܐ ܕܬܕ܏ܡܪ̈
                 </rubric>
@@ -697,8 +688,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xiii.
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xiii.
                            33</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܪ̈ܝܢ ܒܫܒܐ. ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ
                 </rubric>
@@ -721,8 +711,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">On the <title>Epistle of <persName ref="http://syriaca.org/person/1983">S. Paul</persName> to the
-                           Colossians, ch. iii. 1, 2</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
+                <title xml:lang="en">On the <title>Epistle of <persName ref="http://syriaca.org/person/1983">S. Paul</persName> to the Colossians, ch. iii. 1, 2</title>, by <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ̣ ܥܠ ܡܠܬܐ ܗ̇ܝ ܕܐܡ̣ܪ ܦܐܘܠܘܣ ܫܠܝܚܐ. ܕܠܥܠ ܒܥ̣ܘ
                            ܘܕܠܥܠ ܐܬܪܥ̇ܘܼ. ܘܥܠ ܚܫܘܟܐ ܒܲܪܝܐ.</rubric>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܐܪܒܥܐ ܒܫܒܐ ܕܫܒܬܐ ܕܐܘܫ̈ܥܢܐ.
@@ -735,8 +724,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. xii. 16</title>,
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. xii. 16</title>,
                            by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ. ܕܥܠ ܥܬܝܪܐ ܕܐܥ̣ܠܬ̇ ܠܗ ܐܪܥܗ̣ ܥ̈ܠ̇ܠܬܐ
                            ܣ̈ܓܝܐܬܐ</rubric>
@@ -777,8 +765,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Hom. cxxx. on the <title>Gospel of <persName>S.
-                              Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                              Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 358</bibl>, and <bibl>his translation, part ii., p.
                            601</bibl>.</note>
               </msItem>
@@ -813,8 +800,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Hom. cxxxiv. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                <title xml:lang="en">Hom. cxxxiv. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <incipit xml:lang="syr">ܡܢܐ ܗܟܝܠ ܐܪܐ ܐܡ̇ܪ ܠܪ̈ܝܫܢܐ ܕܝܘ̈ܕܝܐ</incipit>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 371, line 19</bibl>; and <bibl>his translation,
                            part ii., p. 624</bibl>.</note>
@@ -854,8 +840,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On <title>
-                    <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xxvi.
+                <title xml:lang="en">On <title><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. xxvi.
                            39</title>, by <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܬܠܬܐ ܒܫܒܐ ܕܚܫ̣ܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܐܢܢܝܣ. ܡܐܡܪܐ̣ ܥܠ
                            ܗ̇ܝ ܕܐܒܝ ܐܢ ܡ̣ܨܝܐ ܢܥܒ̣ܪܢܝ ܟܣܐ ܗܢܐ̣. ܘܠܘܩܒܠ ܐܪ̈ܣܝܘܛܐ.</rubric>
@@ -868,8 +853,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Hom. cxl. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                <title xml:lang="en">Hom. cxl. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ ܒܫܒܐ ܕܚ̣ܫܐ</rubric>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 396</bibl>; and <bibl>his translation, part ii., p.
                            655</bibl>.</note>
@@ -911,8 +895,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Hom. cxlvi. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                <title xml:lang="en">Hom. cxlvi. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 418</bibl>; and <bibl>his translation, part ii., p.
                            683</bibl>.</note>
               </msItem>
@@ -952,8 +935,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Hom. cxli. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                <title xml:lang="en">Hom. cxli. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܚܡܫܐ ܒܫܒܐ ܕܪܐܙܐ</rubric>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 400</bibl>; and <bibl>his translation, part ii., p.
                            659</bibl>.</note>
@@ -1035,8 +1017,7 @@
                   <persName xml:lang="en">Cyril of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Hom. cxlix. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
+                <title xml:lang="en">Hom. cxlix. on the <title>Gospel of <persName ref="http://syriaca.org/person/1855">S. Luke</persName></title>, by <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                 <note>See <bibl>Dr. Payne Smith's edit., p. 429</bibl>; and <bibl>his translation, part ii., p.
                            698</bibl>.</note>
               </msItem>

--- a/data/tei/462.xml
+++ b/data/tei/462.xml
@@ -220,8 +220,7 @@
                 </msItem>
                 <msItem xml:id="p1b2" n="3">
                   <locus from="2b">Fol. 2b</locus>
-                  <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName>
-                    </persName>
+                  <title xml:lang="en">The Proverbs of <persName>Jesus the son of <persName>Sirach</persName></persName>
                   </title>
                   <rubric xml:lang="syr">ܫܡ̈ܗܐ ܕܒܪܣܝܪܟ</rubric>
                 </msItem>

--- a/data/tei/462.xml
+++ b/data/tei/462.xml
@@ -207,8 +207,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p1a1" n="1" defective="true">
                 <locus from="1b">Fol. 1b</locus>
-                <title xml:lang="en">Part of a small book of the Vowel-points of <ref>the
-                Scriptures</ref>
+                <title xml:lang="en">Part of a small book of the Vowel-points of <ref>the Scriptures</ref>
                 </title>
                 <rubric xml:lang="syr">ܒܫܡ ܐܒܐ ܘܒ[ܪܐ ܘܪܘܚܐ ܩܕܝܫܐ. ܬܠܝܬܝܘܬܐ] ܡܪܝܡܬܐ. ܡܫܪܝܢܢ ܕ[ܢܟܬܘܒ
                 ܟܬܒܐ ܕܦܘܫ]ܩܐ ܕܫܡܗ̈ܐ ܕܟܬܒ̈ܐ ܩܕܝܫ̈ܐ ܕܣܘ[ܪ̈ܝܝܐ. ܠܗܓܝ]ܢܐ ܘܠܩܪܝܢܐ ܕܪ̈ܚܡܝ ܝܘܠܦܢܐ̣. ܟܕ ܐܝܟ
@@ -1781,8 +1780,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p15a1" n="1">
                 <locus from="65"/>
-                <title>A canon for <ref>the Annunciation of <persName>Zacharias</persName>
-                  </ref>
+                <title>A canon for <ref>the Annunciation of <persName>Zacharias</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܩܢܘܢܐ ܕܣܘܒܪܐ ܕܙܟܪܝܐ ܚܡܝܫܝܐ</rubric>
               </msItem>

--- a/data/tei/49.xml
+++ b/data/tei/49.xml
@@ -145,8 +145,7 @@
                   <persName xml:lang="en">Xystus, bishop of Rome
                 </persName>
                 </author>
-                <title xml:lang="en">Select Sayings of <persName ref="http://syriaca.org/person/22">Xystus, bishop of <placeName ref="http://syriaca.org/place/641">Rome</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Select Sayings of <persName ref="http://syriaca.org/person/22">Xystus, bishop of <placeName ref="http://syriaca.org/place/641">Rome</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܡ̈ܠܐ ܡ̈ܓܒܝܬܐ ܕܩܕܝܫܐ ܟܣܘܣܛܘܣ ܐܦܝܣܩܘܦܐ ܕܪܗܘܡܐ</rubric>
                 <note>See <bibl>de Lagarde's Anal. Syr., pp. 1—31</bibl>, and p. iii. of the
                            preface.</note>
@@ -219,8 +218,7 @@
                   <persName xml:lang="en">Macarius of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/1346">Macarius of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> on the Christian character.</title>
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/1346">Macarius of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the Christian character.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܡܪܬܝܢܘܬܐ ܕܐܒ̇ܐ ܡܩܪܝܣ ܐܠܟܣܢܕܪܝܐ̣. ܥܠ ܕܘܒܪ̈ܐ
                            ܕܟܪ̈ܣܛܝܢܐ ܕܐܝܟܢ ܢܗܘܘܢ</rubric>
                 <incipit xml:lang="syr">ܙܕܩ̇ ܠܗ ܠܟܪܣܛܝܢܐ ܕܢܬ̇ܢܟܪܐ ܡܢ ܚܛܝ̣ܬܐ ܕܕܝ̇ܠܐ
@@ -395,12 +393,10 @@
                   <persName xml:lang="en">Philoxenus of Mabug
                 </persName>
                 </author>
-                <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName>.</title>
                 <msItem xml:id="c23" n="38">
                   <locus from="144b" to="179">Foll. 144b-179</locus>
-                  <title xml:lang="en">Epistle to <persName>Patricius of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </persName>.</title>
+                  <title xml:lang="en">Epistle to <persName>Patricius of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܦܝܠܟܣܝܢܘܣ ܐܦܣܝܩܘܦܐ ܕܡܒܘܓ. ܫܪܒܐ ܕܫ̈ܐܘܠܐ
                               ܕܠܘܩܒܠ ܚ̈ܫܐ ܕܢܦܫܐ. ܘܥܠ ܕܟܝܘܬܐ ܕܝܠܗ̇ ܕܢܦܫܐ. ܘܕܐܝܟܢ ܘܒܡ̣ܢ ܡܬܩܢܝܐ. ܘܐܢ
                               ܘ̇ܠܐ ܕܢܓܒ̣ܐ ܕܘ̈ܟܝܬܐ ܠܩܪܒܐ ܕܠܘܩܒܠ ܚ̈ܫܐ. ܘܐܢ ܙܕܩ ܕܒܥܒ̇ܕܐ ܢܓܡܘܪ ܟܠܗܘܢ
@@ -591,8 +587,7 @@
                   <persName xml:lang="en">Isaiah of Scete
                 </persName>
                 </author>
-                <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܐܒܐ ܐܫܥܝܐ ܝܚܝܕܝܐ.</rubric>
                 <msItem xml:id="c40" n="64">
                   <locus from="247b" to="249">Foll. 247b-249</locus>
@@ -700,8 +695,7 @@
                   <persName xml:lang="en">Philoxenus of Mabug
                 </persName>
                 </author>
-                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                  </persName> to
+                <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName> to
                            a lawyer, who had turned monk, and was tempted by
                               <persName>Satan</persName>.</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܠܟܣܝܢܘܣ ܐܓܪܬܐ ܕܟܬܒ ܠܐܢܫ ܛܘܒܢܐ ܕܡܢ ܐܘܡܢܘܬܐ

--- a/data/tei/49.xml
+++ b/data/tei/49.xml
@@ -132,8 +132,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Discourse on Virginity and Repentance, ascribed
-                           to <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                           to <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                 <rubric xml:lang="syr">ܥܠ ܒܬܘܠܘܬܐ ܘܬܝܒܘܬܐ ܘܡܪܬܝܢܘܬܐ</rubric>
                 <note>
                   <bibl>See Add. 12,163<ptr target="https://bl.syriac.uk/ms/42"/>, <citedRange unit="fol">128b</citedRange>
@@ -177,8 +176,7 @@
                   <persName xml:lang="en">Macarius the Great, or the
                            Egyptian</persName>
                 </author>
-                <title xml:lang="en">Letters of <persName ref="http://syriaca.org/person/856">Macarius the Great, or the
-                              Egyptian</persName>.</title>
+                <title xml:lang="en">Letters of <persName ref="http://syriaca.org/person/856">Macarius the Great, or the Egyptian</persName>.</title>
                 <rubric xml:lang="syr">ܐܓܪ̈ܬܐ ܕܩܕܝܫܐ ܐܒ̇ܐ ܡܩܪܝܣ ܪܒܐ.</rubric>
                 <msItem xml:id="c3" n="8">
                   <locus from="64a" to="65">Foll. 64a-65</locus>
@@ -491,8 +489,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the monk</persName>
                 </author>
-                <title xml:lang="en">Writings of <persName>John the
-                           monk</persName>.</title>
+                <title xml:lang="en">Writings of <persName>John the monk</persName>.</title>
                 <msItem xml:id="c33" n="50">
                   <locus from="203a" to="206">Foll. 203a-206</locus>
                   <title xml:lang="en">On Purity of Spirit.</title>
@@ -720,8 +717,7 @@
                 <author ref="http://syriaca.org/person/321">
                   <persName>Abraham Nephtarenus</persName>
                 </author>
-                <title xml:lang="en">Writings of <persName>Abraham
-                              Nephtarenus</persName>.</title>
+                <title xml:lang="en">Writings of <persName>Abraham Nephtarenus</persName>.</title>
                 <rubric xml:lang="syr">ܡܪܝ ܐܒܪܗܡ ܢܦܬܪܝܐ ܘܝܚܝܕܝܐ</rubric>
                 <msItem xml:id="c51" n="79">
                   <locus from="282b" to="284"/>

--- a/data/tei/5.xml
+++ b/data/tei/5.xml
@@ -339,9 +339,7 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">The first half, or chap. i—xx., of the <title>Thesaurus of
-                  <persName>Cyril of Alexandria</persName>, concerning the Holy and Consubstantial
-                Trinity</title>, <title xml:lang="grc">ἡ βίβλος τῶν Θησαυρῶν περὶ τῆς ἁγίας καὶ ὁμοουσίου
+                <title xml:lang="en">The first half, or chap. i—xx., of the <title>Thesaurus of <persName>Cyril of Alexandria</persName>, concerning the Holy and Consubstantial Trinity</title>, <title xml:lang="grc">ἡ βίβλος τῶν Θησαυρῶν περὶ τῆς ἁγίας καὶ ὁμοουσίου
                 Τριάδος</title>
                 </title>
                 <rubric xml:lang="syr">ܟܬܒܐ ܩܕܡܝܐ ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܪܫܐ ܕܐ̈ܦܣܩܦܐ ܕܐܠܟܣܢܕܪܝܐ̣. ܡܛܘܠ

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -325,8 +325,7 @@
                 <author ref="http://syriaca.org/person/354">
                   <persName xml:lang="en">Athanasius</persName>
                 </author>
-                <title xml:lang="en">The <ref target="http://syriaca.org/work/9672">Psalms</ref>, with an abridgment of <title xml:lang="en">the
-                                    commentary of Athanasius</title>
+                <title xml:lang="en">The <ref target="http://syriaca.org/work/9672">Psalms</ref>, with an abridgment of <title xml:lang="en">the commentary of Athanasius</title>
                 </title>
                 <rubric xml:lang="syr">ܟܘܢܫܐ ܐܝܟ ܕܒܦܣܝ̈ܩܬܐ ܡܢ ܦܘܫܩܐ ܕܡ̈ܙܡܘܪܐ̣. ܗ̇ܘ
                                     ܕܥܒܝܕ ܠܩܕܝܫܐ ܐܬܢܣܝܘܗ. ܕܡܘܕܥ ܐܝܟ ܕܒܩܦܠܐܘܢ ܚܝܠܐ ܕܟܠܚܕ ܡܢ ܡܙܡܘܪ̈ܐ
@@ -361,9 +360,7 @@
               <msItem xml:id="b10" n="19">
                 <locus from="116b"/>
                 <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9538">Ecclesiastes</ref>, with
-                                    extracts from <title xml:lang="en">
-                                      the commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus, deacon of Alexandria</persName>
-                                    </title>
+                                    extracts from <title xml:lang="en">the commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus, deacon of Alexandria</persName></title>
                 </title>
                 <rubric xml:lang="syr">ܩܘܗܠܬ</rubric>
               </msItem>
@@ -450,9 +447,7 @@
                   <persName xml:lang="en">Epiphanius</persName>
                 </author>
                 <title xml:lang="en">A short
-                                    extract from the treatise of <persName>Epiphanius</persName> <title xml:lang="en">
-                                      on
-                                      Weights and Measures, sect. i.
+                                    extract from the treatise of <persName>Epiphanius</persName> <title xml:lang="en">on Weights and Measures, sect. i.
                                     </title>
                 </title>
               </msItem>

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -362,8 +362,7 @@
                 <locus from="116b"/>
                 <title xml:lang="en">The book of <ref target="http://syriaca.org/work/9538">Ecclesiastes</ref>, with
                                     extracts from <title xml:lang="en">
-                                      the commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus, deacon
-                                          of Alexandria</persName>
+                                      the commentary of <persName ref="http://syriaca.org/person/2727">Olympiodorus, deacon of Alexandria</persName>
                                     </title>
                 </title>
                 <rubric xml:lang="syr">ܩܘܗܠܬ</rubric>
@@ -400,8 +399,7 @@
                     <persName xml:lang="en">John bar Aphtūnāyā, abbat of Kinnesrīn</persName>
                   </author>
                   <title xml:lang="en">Extracts from the commentary on
-                                        the Song of Songs by <persName>John (bar Aphtūnāyā), abbat
-                                            of <placeName>Kinnesrīn</placeName>
+                                        the Song of Songs by <persName>John (bar Aphtūnāyā), abbat of <placeName>Kinnesrīn</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܪܝܫܕܝܪܐ ܡܪܝ ܝܘܚܢܢ ܕܩܢܫܪܐ</rubric>

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -399,8 +399,7 @@
                     <persName xml:lang="en">John bar Aphtūnāyā, abbat of Kinnesrīn</persName>
                   </author>
                   <title xml:lang="en">Extracts from the commentary on
-                                        the Song of Songs by <persName>John (bar Aphtūnāyā), abbat of <placeName>Kinnesrīn</placeName>
-                    </persName>
+                                        the Song of Songs by <persName>John (bar Aphtūnāyā), abbat of <placeName>Kinnesrīn</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܪܝܫܕܝܪܐ ܡܪܝ ܝܘܚܢܢ ܕܩܢܫܪܐ</rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. ii., p.

--- a/data/tei/50.xml
+++ b/data/tei/50.xml
@@ -115,8 +115,7 @@
             <msItem xml:id="a1" n="1">
               <locus from="1a"/>
               <title xml:lang="en">A Catena Patrum, or Selections from the
-                                writings of the Fathers, forming a commentary on a great part of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the
-                                Old and New Testaments</ref>
+                                writings of the Fathers, forming a commentary on a great part of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the Old and New Testaments</ref>
               </title>
               <note>The Biblical books are taken in the following order.</note>
               <msItem xml:id="b1" n="2">
@@ -129,9 +128,7 @@
                                     mentioned on foll. <locus from="5b">5 b</locus>,
                                     <quote xml:lang="syr">ܫܠܡ ܗܠܝܢ ܕܡܢ ܟܬܒܐ ܕܒܪܝܬܐ: ܐ̇ܬܦܫܩ ܐܝܟ ܕܒܦܣܝ̈ܩܬܐ ܡܢ ܓܠܝܦܪܐ<locus from="5b"/>
                   </quote>,
-                                    <locus from="19a">19 a</locus>, <locus from="29a">29 a</locus>. His <title xml:lang="en">commentary on <ref target="http://syriaca.org/work/9648">the Gospel of
-                                        <persName>S. Luke</persName>
-                    </ref>
+                                    <locus from="19a">19 a</locus>, <locus from="29a">29 a</locus>. His <title xml:lang="en">commentary on <ref target="http://syriaca.org/work/9648">the Gospel of <persName>S. Luke</persName></ref>
                   </title> is cited on fol. <locus from="7b">7 b</locus>. The other
                                     authorities named are: <persName ref="http://syriaca.org/person/13">Ephraim</persName>, foll. <locus from="17b">17 b</locus>,
                                     <locus from="24a">24 a</locus>; <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>,  <quote xml:lang="syr">
@@ -215,8 +212,7 @@
                 </msItem>
                 <msItem xml:id="c3" n="7">
                   <locus from="39b"/>
-                  <title xml:lang="en">On the canonical books of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the Old
-                                        and New Testaments</ref>
+                  <title xml:lang="en">On the canonical books of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the Old and New Testaments</ref>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܟܡܐ̣ ܘܐܝܠܝܢ ܐܢܘܢ ܟܬ̈ܒܐ ܕܡܩܒܠܐ
                                         ܥܕܬܐ</rubric>

--- a/data/tei/533.xml
+++ b/data/tei/533.xml
@@ -154,8 +154,7 @@
               </msItem>
               <msItem xml:id="b5" n="8" defective="true">
                 <locus from="146a"/>
-                <title xml:lang="en">Hymn of <persName ref="http://syriaca.org/person/780">Theodore
-                    of Mopsuestia</persName>
+                <title xml:lang="en">Hymn of <persName ref="http://syriaca.org/person/780">Theodore of Mopsuestia</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܪܝ ܬܐܘܕܘܪܘܣ ܡܦܫܩܢܐ</rubric>
                 <incipit xml:lang="syr">ܢܘܗܪܐ ܕܕܢܚ ܠܙܕܝܩ̈ܐ</incipit>

--- a/data/tei/540.xml
+++ b/data/tei/540.xml
@@ -442,8 +442,7 @@
                       <persName xml:lang="en">Dionysius the Areopagite</persName>
                     </author>
                     <title xml:lang="en">The writings of Dionysius the Areopagite, as translated
-                  by <persName>Phocas bar Sergius of <placeName>Edessa</placeName>
-                      </persName>
+                  by <persName>Phocas bar Sergius of <placeName>Edessa</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܬܘܒ ܟܬܒܐ ܕܩܕܝܫܐ ܕܺܝܴܢܘܣܻܝܳܘܣ ܗ̇ܘ ܕܡܢ ܐܱܪܷܐܝܳܘܣ ܦܰܐܓܴܘܣ</rubric>
                   </msItem>
@@ -553,8 +552,7 @@
                         <persName xml:lang="en">the synod (of Antioch)</persName>
                       </author>
                       <title xml:lang="en">The letter of <persName>the synod (of <placeName>Antioch</placeName>)</persName> to <persName>John,
-                    patriarch of <placeName>Alexandria</placeName>
-                        </persName>
+                    patriarch of <placeName>Alexandria</placeName></persName>
                       </title>
                       <rubric xml:lang="syr">ܐܓܪܬܐ ܕܣܘܢܕܘܣ ܠܪܝܫ ܐܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ ܡܪܝ ܝܘܚܢܢ</rubric>
                       <note>Prefixed to <ref>The discourses of Severus of Antioch, in three parts</ref>.</note>

--- a/data/tei/540.xml
+++ b/data/tei/540.xml
@@ -483,15 +483,13 @@
                     <msItem xml:id="p2d3" n="15">
                       <locus from="89b"/>
                       <title xml:lang="en">A short tract on the various meanings of the word <foreign xml:lang="syr">ܡܠܬܐ</foreign>
-                    in <ref>the writings of <persName>Gregory Nazianzen</persName>
-                        </ref>, with examples</title>
+                    in <ref>the writings of <persName>Gregory Nazianzen</persName></ref>, with examples</title>
                       <rubric xml:lang="syr">ܒܗ̈ܠܝܢ ܙܢܝ̈ܐ ܡܬܡܪܐ <foreign xml:lang="en">(sic)</foreign> ܡܠܬܐ. ܒܟܬܒܐ ܕܩܕܝܫܐ ܬܐܘ݊ܠܓܘܣ</rubric>
                       <note>Inserted into <ref>The writings of Gregory Nazianzen, part I</ref>.</note>
                     </msItem>
                     <msItem xml:id="p2d4" n="16">
                       <locus from="90b"/>
-                      <title xml:lang="en">Words from the commentary to <ref>certain of the discourses of <persName>Gregory Nazianzen</persName>
-                        </ref>
+                      <title xml:lang="en">Words from the commentary to <ref>certain of the discourses of <persName>Gregory Nazianzen</persName></ref>
                       </title>
                       <note>Inserted into <ref>The writings of Gregory Nazianzen, part I</ref>.</note>
                     </msItem>

--- a/data/tei/543.xml
+++ b/data/tei/543.xml
@@ -115,8 +115,7 @@
               <author ref="http://syriaca.org/person/113">
                 <persName xml:lang="en">Jacob of Edessa</persName>
               </author>
-              <title>Fragments of a Chronicle, in continuation of the <title>Chronicle of <persName ref="http://syriaca.org/person/480">Eusebius</persName>
-                </title>, composed, as it would seem, by <persName>Jacob of Edessa</persName>
+              <title>Fragments of a Chronicle, in continuation of the <title>Chronicle of <persName ref="http://syriaca.org/person/480">Eusebius</persName></title>, composed, as it would seem, by <persName>Jacob of Edessa</persName>
               </title>
               <rubric xml:lang="syr">ܡܟܬܒܘܬ ܙܒ̈ܢܐ ܕܒܬܪ ܗ̇ܝ ܕܐܘܣܒܝܣ ܩܐܣܪܝܐ̣. ܕܥܒܝܕܐ ܠܝܥܩܘܒ ܪܚ̇ܡ ܥܡܠܐ.</rubric>
               <incipit xml:lang="syr">The introduction begins with the following outline of the plan and contents of the work. ܟܕ ܐܘܣܒܝܣ ܗ̇ܘ ܕܦܐܡܦܝܠܘܣ ܐܦܝܣܩܘܦܐ ܕܩܐܣܐܪܝܐ ܗ̇ܝ ܕܣܛܪܐܛܘܢ ܕܒܦܐܠܣܛܝܢܝ̣. ܥܒ̣ܕ ܡܟܬܒܘܬ ܙܒ̈ܢܐ ܗ̇ܝ ܪܒܬܐ ܘܟܘܠܢܝܬܐ ܘܛܒܝܒܬܐ ܥܡ ܟܠܗ̇ ܝܨܝܦܘܬܐ ܘܚܦܝܛܘܬܐ: ܘܥܡ ܟܠܗ̇ ܚܬܝܬܘܬܐ ܐܝܟ ܕܡ̇ܨܝܐ ܠܒܢ̈ܝܢܫܐ ܠܡܚ̣ܢܐ ܘܠܡܕܪܟܘ ܠ̈ܙܒܢܐ ܕܡܢ ܪܘܚܩܐ܇ ܘܣܡ ܒܗ̇ ܡܛܟܣܐܝܬ ܠܡܢܝܢܐ ܕܫ̈ܢܝܐ ܘܠ̈ܙܒܢܐ ܘܠܬܫ̈ܥܝܬܐ ܕܒܗܘܢ: ܡܢ ܐܕܡ ܪܝܫ ܛܘܗܡܢ ܥܕܡܐ ܠܫܢܬܐ ܩܕܡܝܬܐ ܕܚ̈ܝܝ ܐܒܪܗܡ ܗ̇ܘ ܐܒܐ ܩܕܡܝܐ ܕܥ̈ܒܪܝܐ: ܘܥܕܡܐ ܠܢܝܢܘܣ ܡ̇ܠܟܐ ܕܬܪܝܢ ܕܐܬܘܪ̈ܝܐ ܗ̇ܘ ܕܒܢ̣ܐ ܠܢܝܢܘܝ: ܘܥܕܡܐ ܠܐܘܪܘܦܣ ܡ̇ܠܟܐ ܕܬܪܝܢ ܕܣܝܩܘܐܘܢ ܗ̇ܝ ܕܒܐܠܕܐ ܐܬܪܐ ܗ̇ܘ ܕܝܘ̈ܢܝܐ: ܡܢ ܟܬܒ̈ܐ ܟܝܬ ܟ̈ܗܢܝܐ ܕܡܘܫܐ ܗ̇ܠܝܢ ܕܠܘܬ ܥ̈ܒܪܝܐ܇ ܘܡܢ ܟ̈ܬܒܐ ܕܬܫ̈ܥܝܬܐ ܟ̈ܠܕܝܬܐ ܘܐܬܘܪ̈ܝܬܐ ܘܐܓܘ̈ܦܛܝܬܐ: ܘܐܠܘܬ ܠܗ̇ ܬܘܒ ܐܚܪܬܐ ܝܬܝܪ ܦܬܝܬܐ ܘܪܘܝܚܬܐ ܕܡܢ ܙܒܢܐ ܗܢܐ ܕܐܬܐܡܪ: ܕܐܒܪܗܡ ܪܝܫ ܐܒ̈ܗܬܐ ܘܕܢܝܢܘܣ ܒܪ ܒܝܠܘܣ ܘܕܐܘܪܘܦܣ ܡ̇ܠܟܐ ܕܣܝܩ̈ܘܐܘܢܝܐ: ܥܕܡܐ ܠܫܢܬܐ ܗ̇ܝ ܕܥܣܪܝܢ ܕܩܘܢܣܛܐܢܛܝܢܘܣ ܙܟ݁ܝܐ ܡ̇ܠܟܐ ܕܪܘܡ̈ܝܐ: ܟܕ ܟܝܬ ܡ̈ܠܟܘܬܐ ܣ̈ܓܝܐܬܐ ܐܬܥܗܕ: ܟ̈ܠܗܝܢ ܗ̈ܠܝܢ ܕܒܐܘܪܘܦܝ ܘܒܠܝܒܘܐܝ ܘܒܐܣܝܐ ܪܒܬܐ ܐܫ̈ܬܠܛܝܢ: ܕܟ̈ܠܕܝܐ ܐܡ̇ܪ ܐܢܐ ܘܕܐܬܘ̈ܪܝܐ ܘܕܣܝܩ̈ܘܐܘܢܝܐ. ܘܕܐܪܓ̈ܝܐ. ܘܕܐܬܝ̈ܢܝܐ܇ ܕܥ̈ܒܪܝܐ ܟܝܬ ܘܕܐܓ̈ܘܦܛܝܐ: ܘܕܠ̈ܛܝܢܝܐ ܗ̇ܢܘܢ ܕܒܬܪܟܢ ܪܘܡ̈ܝܐ: ܕܡ̈ܕܝܐ ܘܕܒ̈ܒܠܝܐ ܘܕܠ̈ܘܕܝܐ ܘܕܦܪ̈ܣܝܐ: ܘܗ̈ܠܝܢ ܟ̈ܠܗܝܢ ܐܚ̈ܪܢܝܬܐ .

--- a/data/tei/548.xml
+++ b/data/tei/548.xml
@@ -321,8 +321,7 @@
               </msItem>
               <msItem xml:id="b10" n="39">
                 <locus from="108b"/>
-                <title xml:lang="en">Of <persName>Celestinus, bishop of
-                  Rome</persName>
+                <title xml:lang="en">Of <persName>Celestinus, bishop of Rome</persName>
                 </title>
                 <rubric xml:lang="syr">ܐܢܢܦܘܪܐ ܕܩܕܝܫܐ ܘܠܒ̣ܝܫ ܠܐܠܗܐ ܩܐܠܐܣܛܝܢܘܣ ܐܦܝ܏ܣ ܕܪܘܡܝ</rubric>
                 <note>This anaphora has been printed in the <bibl>Journal of Sacred Literature for

--- a/data/tei/552.xml
+++ b/data/tei/552.xml
@@ -174,8 +174,7 @@
                 <rubric xml:lang="syr">ܚܘ̈ܬܡܐ ܠܩܘܪܒܐ</rubric>
                 <msItem xml:id="p1b3" n="6">
                   <locus from="19a"/>
-                  <title xml:lang="en">In the metre of <persName>Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title xml:lang="en">In the metre of <persName>Jacob of <placeName>Batnae</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܒܢܝ̣ܫܐ ܕܡܪܝܲܥܩܘܒ</rubric>
                   <incipit xml:lang="syr">ܒܲܪܶܟ݂ ܠܟ݂ܠܢ ܢ̇ܛܪ ܠܟ݂ܠܢ ܒܰܟ݂ܢܺܝܫܽܘܬ݂ܳܐ: ܣܳܬ݁ܪ ܠܟ݂ܠܢ ܬ݁ܚܝ̣ܬ݂ ܛ̣ܐܠܠܟ ܒܲܐܟܹܝܦܘܬܐ</incipit>
@@ -313,8 +312,7 @@
                   <author ref="http://syriaca.org/person/87">
                     <persName xml:lang="en">Thomas of Heraclea</persName>
                   </author>
-                  <title>Of <persName>Thomas of <placeName>Heraclea</placeName>
-                    </persName>
+                  <title>Of <persName>Thomas of <placeName>Heraclea</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܐܢܢܦܘܪܐ ܕܩܕܝܫܐ ܡܪܝ ܬܘܡܐ ܫܠܝܚܐ</rubric>
                   <note>To the rubric is appended, marginally, <foreign xml:lang="syr">ܚܪܩܠܳܝܐ</foreign>.</note>
@@ -335,8 +333,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title>Of <persName>Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title>Of <persName>Jacob of <placeName>Batnae</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܐܢܢܦܘܪܐ ܗܕܐ ܕܩܕܝܫܐ ܘܠܒܝ̣ܫ ܠܐܠܗܐ ܡܪܝ ܝܥܩܘܼܒ ܡܠܦܢܐ ܘܡܠܸܐ ܚܟ̈ܡܬܐ ܘܐܦܝܣܩܘܦܐ ܕܒܲܛܢܢ ܕܣܪܘܓ</rubric>
                 </msItem>
@@ -345,8 +342,7 @@
                   <author ref="http://syriaca.org/person/149">
                     <persName xml:lang="en">Lazarus bar Sābtā, or Philoxenus, bishop of Bagdad</persName>
                   </author>
-                  <title>Of <persName>Lazarus bar Sābtā, or Philoxenus, bishop of <placeName>Bagdad</placeName>
-                    </persName>
+                  <title>Of <persName>Lazarus bar Sābtā, or Philoxenus, bishop of <placeName>Bagdad</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܐܢܢܦܘܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܦܝ܏ܣܩ <foreign xml:lang="en">(sic)</foreign> ܕܒܓܕܕ ܕܗ̣ܘ ܠܥܙܪ ܒܪ ܣ̇ܒܬܐ</rubric>
                 </msItem>

--- a/data/tei/555.xml
+++ b/data/tei/555.xml
@@ -202,8 +202,7 @@
                   Eucharist</title>
                   <msItem xml:id="p1c1" n="11">
                     <locus from="88a"/>
-                    <title xml:lang="en">The one in the metre of <persName ref="http://syriaca.org/person/42">Jacob of
-                      Batnae</persName>
+                    <title xml:lang="en">The one in the metre of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                   </title>
                     <rubric xml:lang="syr">ܚܘܬܡܐ ܒܡܫܘܚܬܐ ܣܪܘܓܝܬܐ</rubric>
                   </msItem>
@@ -237,8 +236,7 @@
                 </msItem>
                 <msItem xml:id="p1b12" n="16" defective="true">
                   <locus from="120a"/>
-                  <title xml:lang="en">The Anaphora of <persName ref="http://syriaca.org/person/544">Ignatius of
-                  Antioch</persName>
+                  <title xml:lang="en">The Anaphora of <persName ref="http://syriaca.org/person/544">Ignatius of Antioch</persName>
                 </title>
                   <rubric xml:lang="syr">ܐܢܢܦܘܪܐ ܕ܏ܩܕ ܡܪܝ ܐܝܓܢܐܛܝܘܣ ܢܘܪܢܐ ܬܠܡܝܕܗ ܕܝܘܚܢܢ ܫܠܝܚܐ ܘܪܝܫ
                   ܐܦܝܣ̈ܩܘܦܐ ܕܐܢܛܝ̈ܘܟܝܐ </rubric>

--- a/data/tei/558.xml
+++ b/data/tei/558.xml
@@ -162,15 +162,13 @@
                 </msItem>
                 <msItem xml:id="p1b2" n="3">
                   <locus from="17a"/>
-                  <title xml:lang="en">Of S. <persName ref="http://syriaca.org/person/1826">John the
-                                        Evangelist</persName>
+                  <title xml:lang="en">Of S. <persName ref="http://syriaca.org/person/1826">John the Evangelist</persName>
                 </title>
                   <rubric xml:lang="syr">ܐܢܢܦܪܐ ܕ܏ܩܕ ܡܪܝ ܝܘܚܢܢ ܐܘܢܓܠܝܣܛܐ </rubric>
                 </msItem>
                 <msItem xml:id="p1b3" n="4">
                   <locus from="27b"/>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/573">John
-                                    Chrysostom</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                 </title>
                   <rubric xml:lang="syr">ܐܢܐܦܘܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܘܢܢܝܘܣ ܦܘܡܐ
                                     ܕܕܗܒܐ</rubric>

--- a/data/tei/561.xml
+++ b/data/tei/561.xml
@@ -166,8 +166,7 @@
               </msItem>
               <msItem xml:id="b13" n="14">
                 <locus from="68a"/>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܩܕܝܫܐ ܡܪܝ ܣܘܪܐ</rubric>
               </msItem>

--- a/data/tei/562.xml
+++ b/data/tei/562.xml
@@ -259,8 +259,7 @@
               </msItem>
               <msItem xml:id="b28" n="31">
                 <locus from="175a"/>
-                <title xml:lang="en">The Resurrection of <persName>Lazarus of
-                    Bethany</persName>
+                <title xml:lang="en">The Resurrection of <persName>Lazarus of Bethany</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟ̣ܣܐ ܕܥܠ ܢܘܚ̣ܡܗ ܕܠܥܙܪ ܕܡܢ ܒܝܬ ܥ̇ܢ̣ܝܐ</rubric>
               </msItem>

--- a/data/tei/563.xml
+++ b/data/tei/563.xml
@@ -325,8 +325,7 @@
                 </msItem>
                 <msItem xml:id="c15" n="43">
                   <locus from="310b"/>
-                  <title xml:lang="en">Twelve hymns by <persName ref="http://syriaca.org/person/431">Cyril of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
-                    </persName>
+                  <title xml:lang="en">Twelve hymns by <persName ref="http://syriaca.org/person/431">Cyril of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܡܬܐܡܪܝܢ ܒܗ ܒܝܘܡܐ ܕܣܝ̣ܡܝܢ ܠܩܘܪܝܠܘܣ ܪܝܫ ܐܦ܏ܝܣ̈
                     ܕܐܘܪܝܫܠܡ</rubric>

--- a/data/tei/563.xml
+++ b/data/tei/563.xml
@@ -229,8 +229,7 @@
               <msItem xml:id="b21" n="22">
                 <locus from="168a"/>
                 <title xml:lang="en">The Sunday of the Entrance into Lent, or the Sunday of
-                    <placeName>Cana in Galilee</placeName>, and the Commemoration of <persName>king
-                    Abgar</persName>
+                    <placeName>Cana in Galilee</placeName>, and the Commemoration of <persName>king Abgar</persName>
                 </title>
                 <rubric xml:lang="syr">ܛܟܣ̣ܐ ܕܚܕ ܒܫܒܐ ܕܥܠܠ ܨܘܡܐ. ܕܡ̇ܫܬܡܫ ܒܗ. ܥܠ ܬܕܡܘܪܬܐ ܕܣ̣ܥܪ ܡܪܢ
                   ܒܩܛܢܐ ܕܓܠܝܠܐ: ܘܥܠ ܐܒܓܪ ܡ̇ܠ̣ܟܐ ܕܐܘܪܗܝ </rubric>

--- a/data/tei/564.xml
+++ b/data/tei/564.xml
@@ -203,8 +203,7 @@
               </msItem>
               <msItem xml:id="b20" n="21">
                 <locus from="65b"/>
-                <title xml:lang="en">The order of the miracle at <placeName>Cana of
-                    Galilee</placeName>
+                <title xml:lang="en">The order of the miracle at <placeName>Cana of Galilee</placeName>
                 </title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܥܠ ܬܕܡܘܪܬܐ ܕܒܩܛܢܐ ܟܕ ܫ̇ܚܠܦ ܦܪܘܩܢ ܡ̈ܝܐ ܠܚܡܪܐ</rubric>
               </msItem>

--- a/data/tei/567.xml
+++ b/data/tei/567.xml
@@ -174,8 +174,7 @@
               </msItem>
               <msItem xml:id="b11" n="12">
                 <locus from="41a"/>
-                <title xml:lang="en">The Commemoration of <persName>S. John the
-                    Baptist</persName>
+                <title xml:lang="en">The Commemoration of <persName>S. John the Baptist</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܩ̈ܘܠܣܘܗܝ ܕܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
               </msItem>
@@ -195,8 +194,7 @@
               </msItem>
               <msItem xml:id="b15" n="16">
                 <locus from="59a"/>
-                <title xml:lang="en">The Commemoration of <persName>the seven Youths of
-                    <placeName>Ephesus</placeName>
+                <title xml:lang="en">The Commemoration of <persName>the seven Youths of <placeName>Ephesus</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܛܠܝ̈ܐ ܫܒܥܐ ܕܐܦܣܘܣ</rubric>
@@ -249,15 +247,13 @@
               </msItem>
               <msItem xml:id="b25" n="26">
                 <locus from="119b"/>
-                <title xml:lang="en">The Commemoration of <persName>Mār
-                  George</persName>
+                <title xml:lang="en">The Commemoration of <persName>Mār George</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܡܪܝ ܓܘܪܓܝܣ</rubric>
               </msItem>
               <msItem xml:id="b26" n="27">
                 <locus from="124a"/>
-                <title xml:lang="en">The Commemoration of <persName>Elias the
-                    Prophet</persName>
+                <title xml:lang="en">The Commemoration of <persName>Elias the Prophet</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܥܠ ܡܪܝ ܐܠܝܐ</rubric>
               </msItem>
@@ -278,8 +274,7 @@
               </msItem>
               <msItem xml:id="b30" n="31">
                 <locus from="138a"/>
-                <title xml:lang="en">The Nativity of <persName>S. John the
-                  Baptist</persName>
+                <title xml:lang="en">The Nativity of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b31" n="32">
@@ -324,8 +319,7 @@
               </msItem>
               <msItem xml:id="b38" n="39">
                 <locus from="165a"/>
-                <title xml:lang="en">The Decollation of <persName>S. John the
-                    Baptist</persName>
+                <title xml:lang="en">The Decollation of <persName>S. John the Baptist</persName>
                 </title>
               </msItem>
               <msItem xml:id="b39" n="40">

--- a/data/tei/567.xml
+++ b/data/tei/567.xml
@@ -194,8 +194,7 @@
               </msItem>
               <msItem xml:id="b15" n="16">
                 <locus from="59a"/>
-                <title xml:lang="en">The Commemoration of <persName>the seven Youths of <placeName>Ephesus</placeName>
-                  </persName>
+                <title xml:lang="en">The Commemoration of <persName>the seven Youths of <placeName>Ephesus</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܛܠܝ̈ܐ ܫܒܥܐ ܕܐܦܣܘܣ</rubric>
               </msItem>

--- a/data/tei/570.xml
+++ b/data/tei/570.xml
@@ -122,8 +122,7 @@
                   <persName xml:lang="en">Jacob of Edessa</persName>
                 </author>
                 <title xml:lang="en">Services for the canonical hours of the ferial days (<foreign xml:lang="syr">ܢܓܗܐ, ܠܠܝܐ, ܨܦܪܐ</foreign>), the arrangement of which is ascribed
-                  to <persName ref="http://syriaca.org/person/113">Jacob of
-                  Edessa</persName>.</title>
+                  to <persName ref="http://syriaca.org/person/113">Jacob of Edessa</persName>.</title>
                 <rubric xml:lang="syr">ܥܠ ܚܲܝܠܐ ܕܬܠܝܬܝܘܬܐ ܩܕܝܫܬܐ ܡܫܲܪܝܢܢ ܕܢܟܬܘܒ ܬܫܡܫ̣ܬܐ ܫܡܚܝܡܝܬܐ
                   (ܫܚܝܡܝܬܐ read ) ܕܡܪܝ ܝܥܩܘܒ ܐܘܪܗܝܐ.</rubric>
                 <finalRubric xml:lang="syr">

--- a/data/tei/571.xml
+++ b/data/tei/571.xml
@@ -234,8 +234,7 @@
                 <title xml:lang="en">For the dead</title>
                 <msItem xml:id="c1" n="26">
                   <locus from="61a"/>
-                  <title xml:lang="en">For Priests, Deacons, etc., and for <persName>Silas the
-                      ascetic</persName>
+                  <title xml:lang="en">For Priests, Deacons, etc., and for <persName>Silas the ascetic</persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܟܗ̈ܢܐ ܘܡܫ̈ܡܫܢܐ. ܘܫܪܟܐ ܕܬܓܡ̈ܐ܀ ܕܩܕܝܫܐ ܫܝܠܐ
                     ܐܒܝܠܐ</rubric>

--- a/data/tei/572.xml
+++ b/data/tei/572.xml
@@ -158,8 +158,7 @@
                   ܬܓ̈ܡܝܢ.</rubric>
                 <msItem xml:id="c8" n="11">
                   <locus from="35a"/>
-                  <title xml:lang="en">From the <ref>Old Testament</ref>, <ref>the Apocrypha</ref>, and <ref>the
-                    Acts of the Apostles</ref>
+                  <title xml:lang="en">From the <ref>Old Testament</ref>, <ref>the Apocrypha</ref>, and <ref>the Acts of the Apostles</ref>
                   </title>
                 </msItem>
                 <msItem xml:id="c9" n="12">

--- a/data/tei/572.xml
+++ b/data/tei/572.xml
@@ -179,8 +179,7 @@
               </msItem>
               <msItem xml:id="b3" n="14">
                 <locus from="50b"/>
-                <title>Conciones (<foreign xml:lang="syr">ܟܪ̈ܘܙܘܬܐ</foreign>), spoken by <persName>the officiating
-                  deacon</persName>
+                <title>Conciones (<foreign xml:lang="syr">ܟܪ̈ܘܙܘܬܐ</foreign>), spoken by <persName>the officiating deacon</persName>
                 </title>
                 <rubric xml:lang="syr">܏ܘܡܟܪܙܝܢ ܏ܟܪܘܙܘܬܐ ܢܩܘܡ ܫܦܝܪ܀ ܐܠܗܐ ܐܒܐ ܕܪ̈ܘܚܬܐ. ܘܡܪܐ ܕܟܠ ܒܣܪ܀ ܏ܘܫ</rubric>
               </msItem>
@@ -260,8 +259,7 @@
               </msItem>
               <msItem xml:id="b7" n="29" defective="true">
                 <locus from="119b"/>
-                <title>Concio (<foreign xml:lang="syr">ܟܪܘܙܘܬܐ</foreign>), spoken by <persName>the officiating
-                  deacon</persName>
+                <title>Concio (<foreign xml:lang="syr">ܟܪܘܙܘܬܐ</foreign>), spoken by <persName>the officiating deacon</persName>
                 </title>
                 <rubric xml:lang="syr">ܘܡܟܪܙ ܡܫܡܫܢܐ ܟܪܘܙܘܬܐ ܗܕܐ܀ ܟܕ ܡܫܚܠܦ ܠܗ ܠܢܝܫܐ ܠܦܘܬ
                   ܕܙܕܩ</rubric>

--- a/data/tei/574.xml
+++ b/data/tei/574.xml
@@ -381,8 +381,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Two prayers of <persName>Jacob of <placeName>Batnae</placeName>
-                    </persName> for
+                  <title xml:lang="en">Two prayers of <persName>Jacob of <placeName>Batnae</placeName></persName> for
                   the festival of <persName>the holy Cross</persName>
                   </title>
                   <rubric xml:lang="syr">ܒܥ̈ܘܬܐ ܕܡܪܝ ܝܥܩܘܒ ܕܬܠܬܫܥܝܢ ܕܨܠܝܒܐ</rubric>

--- a/data/tei/58.xml
+++ b/data/tei/58.xml
@@ -191,8 +191,7 @@
                 <author ref="http://syriaca.org/person/576">
                   <persName xml:lang="en">John Philoponus</persName>
                 </author>
-                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/576">John Philoponus, <foreign xml:lang="syr">ܝܘܚܢܢ ܦܝܠܝܦܘܢܘܣ</foreign>
-                  </persName>, addressed to the priest
+                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/576">John Philoponus, <foreign xml:lang="syr">ܝܘܚܢܢ ܦܝܠܝܦܘܢܘܣ</foreign></persName>, addressed to the priest
                   <persName>Sergius</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܢܐ ܐܝܬܘܗܝ ܫܘܚܠܦܐ ܕܡܢ̈ܘܬܐ ܟܝܬ ܘܕܐ̈ܣܛܘܟܣܐ. ܘܐܝܟܢܐ ܟܘܠܝܘܬܐ
@@ -206,8 +205,7 @@
                 <author ref="http://syriaca.org/person/55">
                   <persName xml:lang="en">Samuel of Ras'ain</persName>
                 </author>
-                <title xml:lang="en">Extract from a discourse of <persName>Samuel of <placeName>Ras'ain</placeName>
-                  </persName> against <persName>the Diphysites</persName>
+                <title xml:lang="en">Extract from a discourse of <persName>Samuel of <placeName>Ras'ain</placeName></persName> against <persName>the Diphysites</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܫܡܘܐܝܠ ܪܝܫܥܝܢܝܐ. ܠܘܩܒܠ ܬܪ̈ܝܝ ܟܝ̈ܢܐ: ܕܐܝܬܘܗܝ̣ ܒܩܘܣܛܢܛܝܢܐܦܘܠܝܣ</rubric>
                 <incipit xml:lang="syr">ܐܪܒܥܐ ܗܟܝܠ ܐܝܬܝܗܘܢ ܟܝ̈ܢܐ ܕܦܓܪܐ.

--- a/data/tei/58.xml
+++ b/data/tei/58.xml
@@ -149,8 +149,7 @@
                 <author ref="http://syriaca.org/person/576">
                   <persName xml:lang="en">John Philoponus</persName>
                 </author>
-                <title xml:lang="en">The "Diaetetes" or "Arbiter" of <persName ref="http://syriaca.org/person/576">John
-                  Philoponus</persName>, on the Union of the two Natures in the person of
+                <title xml:lang="en">The "Diaetetes" or "Arbiter" of <persName ref="http://syriaca.org/person/576">John Philoponus</persName>, on the Union of the two Natures in the person of
                 Christ</title>
                 <title xml:lang="grc">Διαιτητὴς ἢ περὶ ἑνώσεως</title>
                 <rubric xml:lang="syr">ܕܝܐܛܝܛܝܣ ܐܘ ܟܝܬ ܡܛܠ ܚܕܝܘܬܐ̣. ܕܝܘܚܢܢ ܓܪܡܛܝܩܘܣ ܐܠܟܣܢܪܝܐ</rubric>

--- a/data/tei/583.xml
+++ b/data/tei/583.xml
@@ -252,8 +252,7 @@
               </msItem>
               <msItem xml:id="b17" n="27">
                 <locus from="213b"/>
-                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the
-                    Baptist</persName>, 29th of Ab</title>
+                <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>, 29th of Ab</title>
                 <rubric xml:lang="syr">ܟܛ ܒܐܒ ܥܐܕܐ ܕܟܘܠܠܗ ܕܡܪܝ ܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
               </msItem>
             </msItem>

--- a/data/tei/586.xml
+++ b/data/tei/586.xml
@@ -102,8 +102,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="1a"/>
-              <title xml:lang="en">The Hymns of <persName>Severus</persName>, <persName>John bar
-                  Aphtūnāyā</persName>, etc., 394 (<foreign xml:lang="syr">ܫܨܕ</foreign>) in
+              <title xml:lang="en">The Hymns of <persName>Severus</persName>, <persName>John bar Aphtūnāyā</persName>, etc., 394 (<foreign xml:lang="syr">ܫܨܕ</foreign>) in
                 number.</title>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a"/>
@@ -174,8 +173,7 @@
               </msItem>
               <msItem xml:id="b16" n="17">
                 <locus from="55a"/>
-                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>, arranged according to the eight tones</title>
+                <title xml:lang="en">The <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>, arranged according to the eight tones</title>
                 <rubric xml:lang="syr">ܛܟܣܐ ܕܡ̈ܥܢܝܬܐ ܕܝ̇ܠܕܬ ܐܠܗܐ</rubric>
               </msItem>
               <msItem xml:id="b17" n="18">

--- a/data/tei/587.xml
+++ b/data/tei/587.xml
@@ -407,8 +407,7 @@
               </persName>
                 </author>
                 <title>A letter of <persName>Jacob of <placeName>Edessa</placeName></persName> to the
-                priest <persName>Addai</persName> regarding <ref>the Orders of Baptism</ref> and of <ref>the
-                Consecration of Water</ref> on the night of the Epiphany</title>
+                priest <persName>Addai</persName> regarding <ref>the Orders of Baptism</ref> and of <ref>the Consecration of Water</ref> on the night of the Epiphany</title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܝܥܩ݊ܘܒ ܐܘܪܗܝܐ ܕܟ̣ܬܒ ܠܘܬ ܐܕܝ ܏ܩܫ</rubric>
                 <incipit xml:lang="syr">ܡܛܠ ܣ̈ܓܝܐܬܐ ܕܡܫܐܠܐ ܐܚܘܬܟ. ܕܡܛܠ ܛܟ̣ܣܐ ܗ̇ܘ ܕܥܡܕܐ ܏ܩܕ. ܨܒ̣ܝܬ
                 ܠܡܫ̇ܐܠܘ ܐܦ ܡܛܠ ܛܟ̣ܣܐ ܗ̇ܘ ܕܒܘܿܪܟܐ ܕܡ̈ܝܐ ܕܡܫܬܡܠܐ ܠܘܬ ܗܠܝܢ ܕܒܣܘܪܝܐ ܒܠܠܝܐ ܗ̇ܘ ܩܕܝܫܐ

--- a/data/tei/587.xml
+++ b/data/tei/587.xml
@@ -406,8 +406,7 @@
                   <persName xml:lang="en">Jacob of Edessa
               </persName>
                 </author>
-                <title>A letter of <persName>Jacob of <placeName>Edessa</placeName>
-                  </persName> to the
+                <title>A letter of <persName>Jacob of <placeName>Edessa</placeName></persName> to the
                 priest <persName>Addai</persName> regarding <ref>the Orders of Baptism</ref> and of <ref>the
                 Consecration of Water</ref> on the night of the Epiphany</title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܝܥܩ݊ܘܒ ܐܘܪܗܝܐ ܕܟ̣ܬܒ ܠܘܬ ܐܕܝ ܏ܩܫ</rubric>
@@ -568,8 +567,7 @@
             <msContents>
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p3a1" n="1">
-                <title xml:lang="en">Services for the Commemoration of <persName>Jacob of <placeName>Batnae</placeName>
-                  </persName>
+                <title xml:lang="en">Services for the Commemoration of <persName>Jacob of <placeName>Batnae</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܚ̇ܝ̣ܠܐ ܕܐܠܗܐ ܟܬ݀ܒܝܢܢ ܛܟ̣ܣܐ ܕܩ̈ܢܘܢܐ ܘܩ̈ܠܐ ܘܒ̈ܥܘܬܐ ܘܡܕܪ̈ܫܐ ܕܥܠ ܢܨ̇ܝܚܐ ܘܠܒܝ̣ܫ ܠܐܠܗܐ ܡܪܝ ܝ̇݅ܥܩܘܒ ܡ̇ܠ̣ܦܢܐ ܒܚܝ̣ܪܐ</rubric>
               </msItem>

--- a/data/tei/591.xml
+++ b/data/tei/591.xml
@@ -371,8 +371,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">Hymns ascribed to <persName>Jacob of <placeName>Batnae</placeName>
-                    </persName>
+                  <title xml:lang="en">Hymns ascribed to <persName>Jacob of <placeName>Batnae</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܪܝ ܝܥܩܘܒ ܏ܡܫ</rubric>
                   <note>Some of these constitute <ref>the order of <placeName>the convent of Bar-saumā</placeName>

--- a/data/tei/61.xml
+++ b/data/tei/61.xml
@@ -541,8 +541,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p3a1" n="1" defective="true">
                 <locus from="25a"/>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1721">Euphrosyne of
-                  Alexandria</persName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1721">Euphrosyne of Alexandria</persName>
               </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܬܐ ܐܘܦܪܘܣܘܢܝ. ܗ̇ܝ ܕܡܢ ܐܠܟܣܢܕܪܝܐ ܕܐܬܥܢ̣ܘܝܬ݀
                 ܡܛܫܝܐܝܬ ܒܥܘܡܪܐ ܕܓܒܪ̈ܐ.</rubric>

--- a/data/tei/61.xml
+++ b/data/tei/61.xml
@@ -202,48 +202,42 @@
                 <note>See <bibl>Add. 14,575<ptr target="https://bl.syriac.uk/ms/311"/>, items 1—6</bibl>.</note>
                 <msItem xml:id="p1b1" n="2">
                   <locus from="1b" to="4">Foll. 1b-4</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܡܘܬܪܢܐ ܕܢܦܫܐ<locus from="1b" to="1b"/>
                   </rubric>
                 </msItem>
                 <msItem xml:id="p1b2" n="3">
                   <locus from="4a" to="5">Foll. 4a-5</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܪ̈ܥܣܪ ܡܬܟܪ̈ܟܢܐ ܟܕ ܝܬܒܝܢ ܘܐܡ̣ܪܘ ܗܠܝܢ<locus from="4a" to="4a"/>
                   </rubric>
                 </msItem>
                 <msItem xml:id="p1b3" n="4">
                   <locus from="5b" to="7">Foll. 5b-7</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܐܝܟܢܐ ܘ̇ܠܐ ܠܗܘܢ ܠܐܚ̈ܐ ܕܢܚܘܢ ܥܡ ܚܕܕܐ<locus from="5b" to="5b"/>
                   </rubric>
                 </msItem>
                 <msItem xml:id="p1b4" n="5">
                   <locus from="7b" to="8">Foll. 7b-8</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܛܠ ܡܟܝܟܘܬܐ<locus from="7b" to="7b"/>
                   </rubric>
                 </msItem>
                 <msItem xml:id="p1b5" n="6">
                   <locus from="8a" to="9">Foll. 8a-9</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܦܘܩ̈ܕܢܐ ܠܗ̇ܢܘܢ ܕܡܬܪܚܩܝܢ ܡܢ ܥܠܡܐ<locus from="8a" to="8a"/>
                   </rubric>
                 </msItem>
                 <msItem xml:id="p1b6" n="7" defective="true">
                   <locus from="9a" to="11">Foll. 9a-11</locus>
-                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                  <title>Part of Part of the works of <persName>Isaiah of <placeName>Scete</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܛܠ ܐܝܠܝܢ ܕܫ̣ܡܥ ܘܚ̣ܙܐ ܨܝܕ ܣ̈ܒܐ<locus from="9a" to="9a"/>
                   </rubric>
@@ -1313,8 +1307,7 @@
                     <persName xml:lang="en">Jacob of Edessa</persName>
                   </author>
                   <title xml:lang="en">Seventeen letters of Jacob of Edessa, addressed, with one exception, to
-                <persName ref="http://syriaca.org/person/127">John the Stylite of <placeName xml:lang="syr">ܠܝܬܪܝܒ</placeName>
-                    </persName>
+                <persName ref="http://syriaca.org/person/127">John the Stylite of <placeName xml:lang="syr">ܠܝܬܪܝܒ</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܒ ܐܓܪ̈ܬܐ ܕܝܠܗ ܕܚܣܝܐ ܘܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ ܡܕܝܢܬܐ̣.
                 ܕܠܘܬ ܩܫܝܫܐ ܝܘܚܢܢ ܐܣܛܘܢܝܐ ܕܠܝܬܪܝܒ.<locus from="79a"/>

--- a/data/tei/611.xml
+++ b/data/tei/611.xml
@@ -193,9 +193,7 @@
               </msItem>
               <msItem xml:id="p1a5" n="5">
                 <locus from="93a"/>
-                <title xml:lang="en">Catchwords of <ref>hymns to be sung by <persName>the priests</persName>, when going
-                in procession round <placeName>the altar</placeName>
-                  </ref>, arranged according to the eight tones</title>
+                <title xml:lang="en">Catchwords of <ref>hymns to be sung by <persName>the priests</persName>, when going in procession round <placeName>the altar</placeName></ref>, arranged according to the eight tones</title>
                 <rubric xml:lang="syr">ܝܕ̈ܥܐ ܕܩܘ̈ܩܠܝܘܢܐ ܒܬܡ̈ܢܐ ܩܝ̈ܢܬܐ</rubric>
                 <quote xml:lang="syr">܏ܩܝܢܬܐ ܏ܩܕܡܝܬܐ. ܩܡ ܓܒܪܐ ܏ܗܗ ܚܢܢ ܕܝܢ
                 ܗܐ ܡܬܒܩܝܢܢ ܏ܗܗܗ ܐܝܟ ܕܠܫܘܒܚܐ ܏ܗܗܗ ܡܫܝܚܐ ܡܬܝܠܕ ܏ܗܗܗ ܒܚܕ ܐܒܐ ܡܗܝܡܢܝܢܢ ܏ܗܗ ܒܪܬܗ ܕܫܐܘܠ.

--- a/data/tei/614.xml
+++ b/data/tei/614.xml
@@ -284,9 +284,7 @@
                   <author ref="http://syriaca.org/person/430">
                     <persName xml:lang="en">Cyril of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">On <ref>
-                      <persName>the Rich Man</persName> and <persName>Lazarus</persName>
-                    </ref>
+                  <title xml:lang="en">On <ref><persName>the Rich Man</persName> and <persName>Lazarus</persName></ref>
                   </title>
                   <title xml:lang="en">Hom. cxi. on <ref>the Gospel of S. Luke</ref>
                   </title>
@@ -694,9 +692,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p4a1" n="1" defective="true">
                 <locus from="100b"/>
-                <title xml:lang="en">Scholia on <ref>the Homilies of <persName>Gregory
-                                    Nazianzen</persName>
-                  </ref>
+                <title xml:lang="en">Scholia on <ref>the Homilies of <persName>Gregory Nazianzen</persName></ref>
                 </title>
                 <note>Each homily is preceded by a short introduction, giving an outline of its contents, and a list of the passages of Scripture which are cited in it.</note>
                 <note xml:lang="en">Though <persName>the author, or rather compiler, of these scholia</persName> is, so far
@@ -765,8 +761,7 @@
                     <author ref="http://syriaca.org/person/1016">
                       <persName xml:lang="en">Aitallāhā</persName>
                     </author>
-                    <title xml:lang="en">Another scholion, regarding the order of <ref>the homilies of <persName>Gregory Nazianzen</persName>
-                      </ref>
+                    <title xml:lang="en">Another scholion, regarding the order of <ref>the homilies of <persName>Gregory Nazianzen</persName></ref>
                     </title>
                     <rubric xml:lang="syr">ܣܟܠܝܘܢ ܐܝܟ ܕܒܦܣܝܩܘ ܕܡܚܘܐ ܥܠ ܡܐܡܪ̈ܐ
                                         ܕܓܪܝܓܪܝܘܣ ܬܐܘܠܓܣ ܕܐܝܠܝܢ ܐܡܝܪܝܢ ܠܗ ܩܕܡ ܕܢܗܘܐ ܩܫܝܫܐ. ܘܐܝܠܝܢ

--- a/data/tei/614.xml
+++ b/data/tei/614.xml
@@ -480,8 +480,7 @@
                 </msItem>
                 <msItem xml:id="p2b2" n="3">
                   <locus from="96b"/>
-                  <title xml:lang="en">On <persName>those who die in <placeName>foreign lands</placeName>
-                    </persName>
+                  <title xml:lang="en">On <persName>those who die in <placeName>foreign lands</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܛܠ ܗ̇ܢܘܢ ܕܒܐܟܣܢܝܐ ܥ̇ܢܕܝܢ. ܐܟܡ̇ܢ ܕܠܐ ܢܬܬܥܝܩ ܥܠܝܗܘܢ</rubric>
                 </msItem>
@@ -780,8 +779,7 @@
                     <author ref="http://syriaca.org/person/109">
                       <persName xml:lang="en">Athanasius (II., Baladensis), patriarch of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A scholion of <persName>Athanasius (II., Baladensis), patriarch of <placeName>Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A scholion of <persName>Athanasius (II., Baladensis), patriarch of <placeName>Antioch</placeName></persName>
                   </title>
                     <rubric xml:lang="syr">ܣ . ــܲـ . ܫܪܒܐ ܕܡܬܒܥܐ ܩܕܡ ܟܬܒܐ ܕܬܐܘܠܘܓܘܣ
                                         ܕܥܒܝܕ ܠܗ ܠܐܬܢܣܝܘܣ ܡܦܫܩܢܐ ܘܦܛܪܝܪܟܐ ܕܐܢܛܝܟܘܟܝܐ <foreign xml:lang="en">(sic)</foreign> ܕܣܘܪܝܐ.

--- a/data/tei/619.xml
+++ b/data/tei/619.xml
@@ -416,8 +416,7 @@
                 <author ref="http://syriaca.org/person/154">
                   <persName xml:lang="en">Antonius (Rhetor) the Tagritan</persName>
                 </author>
-                <title xml:lang="en">A treatise on the Holy Chrism by <persName ref="http://syriaca.org/person/154">Antonius (Rhetor) the Tagritan, of the family of <placeName>Beth-Gūrgīn</placeName> or <placeName>Gūrgān</placeName>
-                  </persName>
+                <title xml:lang="en">A treatise on the Holy Chrism by <persName ref="http://syriaca.org/person/154">Antonius (Rhetor) the Tagritan, of the family of <placeName>Beth-Gūrgīn</placeName> or <placeName>Gūrgān</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܣܝ̇ܡܐ ܕܒܪܚܡܬ݂ ܥܡܠܐ ܡ̇ܟܢܫ܆ ܡܢ ܡ̇ܦܘܚܝܬ݂ܐ ܕܟܬܒ̈ܐ ܐܠܗ̈ܝܐ܇ ܕܥܠ
                 ܡܝ̣ܘܪܘܢ ܩܕܝܫܐ.</rubric>
@@ -555,8 +554,7 @@
                 <author ref="http://syriaca.org/person/154">
                   <persName xml:lang="en">Antonius of Tagrit</persName>
                 </author>
-                <title xml:lang="en">A work of <persName ref="http://syriaca.org/person/154">Antonius of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                  </persName> on the good Providence of
+                <title xml:lang="en">A work of <persName ref="http://syriaca.org/person/154">Antonius of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName> on the good Providence of
                                 God, in four discourses</title>
                 <finalRubric xml:lang="syr">
                 <locus from="125a"/>ܫܠܡܘ ܐܪ̈ܒܥܐ ܡ̈ܐܡܪܐ ܕܥܠ ܒܛܝܠܘܬܐ. ܕܥܒ̣ܝܕܝܢ

--- a/data/tei/619.xml
+++ b/data/tei/619.xml
@@ -234,8 +234,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> to <persName>Mār
-                  Samuel</persName>, abbat of <placeName>the convent of Mār <persName>Isaac of Gabula</persName>
+                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> to <persName>Mār Samuel</persName>, abbat of <placeName>the convent of Mār <persName>Isaac of Gabula</persName>
                   </placeName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝܥܩܘܒ ܕܣܓܪܘܓ̣ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪܐ ܕܡܪܝ ܐܝܣܚܩ̇. ܕܓܒܘܠܐ̣.
@@ -351,9 +350,7 @@
                 <author ref="http://syriaca.org/person/141">
                   <persName xml:lang="en">Elias the Harrānite, of Salamya</persName>
                 </author>
-                <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/141">Elias the Harrānite, of
-                  Salamya</persName> (<foreign xml:lang="ar">سَلَمْيَة</foreign>), on the holy Eucharist, addressed to <persName>Dionysius the
-                  Edessene</persName>, of <placeName ref="http://syriaca.org/place/230">the convent of Kinnesrīn</placeName>
+                <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/141">Elias the Harrānite, of Salamya</persName> (<foreign xml:lang="ar">سَلَمْيَة</foreign>), on the holy Eucharist, addressed to <persName>Dionysius the Edessene</persName>, of <placeName ref="http://syriaca.org/place/230">the convent of Kinnesrīn</placeName>
                 </title>
                 <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 159</bibl>
                 </note>
@@ -419,8 +416,7 @@
                 <author ref="http://syriaca.org/person/154">
                   <persName xml:lang="en">Antonius (Rhetor) the Tagritan</persName>
                 </author>
-                <title xml:lang="en">A treatise on the Holy Chrism by <persName ref="http://syriaca.org/person/154">Antonius
-                  (Rhetor) the Tagritan, of the family of <placeName>Beth-Gūrgīn</placeName> or <placeName>Gūrgān</placeName>
+                <title xml:lang="en">A treatise on the Holy Chrism by <persName ref="http://syriaca.org/person/154">Antonius (Rhetor) the Tagritan, of the family of <placeName>Beth-Gūrgīn</placeName> or <placeName>Gūrgān</placeName>
                   </persName>
               </title>
                 <rubric xml:lang="syr">ܣܝ̇ܡܐ ܕܒܪܚܡܬ݂ ܥܡܠܐ ܡ̇ܟܢܫ܆ ܡܢ ܡ̇ܦܘܚܝܬ݂ܐ ܕܟܬܒ̈ܐ ܐܠܗ̈ܝܐ܇ ܕܥܠ

--- a/data/tei/619.xml
+++ b/data/tei/619.xml
@@ -234,8 +234,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> to <persName>Mār Samuel</persName>, abbat of <placeName>the convent of Mār <persName>Isaac of Gabula</persName>
-                  </placeName>
+                <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> to <persName>Mār Samuel</persName>, abbat of <placeName>the convent of Mār <persName>Isaac of Gabula</persName></placeName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝܥܩܘܒ ܕܣܓܪܘܓ̣ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪܐ ܕܡܪܝ ܐܝܣܚܩ̇. ܕܓܒܘܠܐ̣.
                 ܡܛܠ ܗܝܡܢܘܬܐ</rubric>

--- a/data/tei/622.xml
+++ b/data/tei/622.xml
@@ -269,8 +269,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">The second discourse on <persName ref="http://syriaca.org/person/2245">our
-                    Lord</persName>'s contest with <persName ref="http://syriaca.org/person/3651">Satan</persName>
+                <title xml:lang="en">The second discourse on <persName ref="http://syriaca.org/person/2245">our Lord</persName>'s contest with <persName ref="http://syriaca.org/person/3651">Satan</persName>
                   </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܬܟܬܘܫܗ ܕܡܪܢ ܕܥܡ ܣܛܢܐ</rubric>
                 <incipit xml:lang="syr">ܒܚܕܒܫܒܐ ܕܥܒ̣ܪ. ܟܠܝܠܐ ܩܕܡܝܐ ܕܙܟܘܬܗ ܕܡܪܢ ܫܩ̣ܠܢܢ.</incipit>
@@ -322,8 +321,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Against swearing, and on <persName ref="http://syriaca.org/person/2245">our
-                    Lord</persName>'s rising in three days</title>
+                <title xml:lang="en">Against swearing, and on <persName ref="http://syriaca.org/person/2245">our Lord</persName>'s rising in three days</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܥܠܝܗ̇ ܟܕ ܥܠܝܗ̇ ܕܥܠ̣ܬܐ ܟܕ ܡܚ̇ܘܐ ܕܠܐ ܗܘܐ ܕܓܠܘܬܐ ܒܠܚܘܕ
                     ܐܝܬܝܗ̇ ܚܛܗܐ̇. ܐܠܐ ܐܦ ܟܕ ܢܡ̇ܠܐ ܐܢܫ ܡܘܡܬܐ. ܡܛܠ ܕܝܡ̇ܐ ܡܬܬ̣ܣܝܡ ܒܪܝܫܗ ܘܕܦܩܚܐܝܬ ܡܫܝܚܐ
                     ܠܬܠܬܐ ܝܘܡ̈ܝܢ ܩ̣ܡ.</rubric>
@@ -412,8 +410,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the Resurrection of <persName ref="http://syriaca.org/person/2245">our
-                    Lord</persName>
+                <title xml:lang="en">On the Resurrection of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                   </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܚܕܒܫܒܐ ܕܩܝܡ̣ܬܐ</rubric>
                 <note>In the margin of the rubric, there is written <quote xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬܐ</quote>.</note>
@@ -435,8 +432,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On the Resurrection of <persName ref="http://syriaca.org/person/2245">our
-                    Lord</persName>
+                <title xml:lang="en">On the Resurrection of <persName ref="http://syriaca.org/person/2245">our Lord</persName>
                   </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܩܝܡ̣ܬܗ ܕܦܪܘܩܢ</rubric>
                 <note>In the margin of this item, there is written <quote xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ</quote>, but altered into

--- a/data/tei/622.xml
+++ b/data/tei/622.xml
@@ -157,9 +157,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">On <ref target="http://syriaca.org/work/9646">
-                  <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. x. 34
-                </ref>
+                <title xml:lang="en">On <ref target="http://syriaca.org/work/9646"><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch. x. 34 </ref>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܥܠܗ̇ܝ ܕܐܡ̣ܪ ܡܪܢ. ܕܠܐ ܐܬܝ̇ܬ ܕܐܪܡ̇ܐ ܫܝܢܐ ܐܠ̣ܐ ܚܲܪܒܐ.
                     ܘܬܘܒ ܕܢܘܪܐ ܐܬܝ̇ܬ ܕܐܪܡ̇ܐ ܒܐܪܥܐ</rubric>
@@ -173,10 +171,8 @@
                 <author ref="http://syriaca.org/person/430">
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Hom. xxxv. on <ref target="http://syriaca.org/work/9648">
-                  the Gospel of <persName ref="http://syriaca.org/person/1855">S.
-                        Luke</persName>
-                </ref>
+                <title xml:lang="en">Hom. xxxv. on <ref target="http://syriaca.org/work/9648">the Gospel of <persName ref="http://syriaca.org/person/1855">S.
+                        Luke</persName></ref>
                 </title>
                 <note>The title and the first few words are wanting. See <bibl>Dr. Payne
                       Smith's edition, p. 13</bibl>.</note>
@@ -229,8 +225,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Hom. lxxxiii. on <ref target="http://syriaca.org/work/9641">the Gospel of <persName ref="http://syriaca.org/person/1801">S.
-                      John</persName>
-                  </ref>
+                      John</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܡ̈ܢܝܢ ܘܬܠܬ̈ܐ ܕܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܝܘܚܢܢ</rubric>
                 <note>In the margin of the rubric, there is written <quote xml:lang="syr">ܕܬܫܡܫܬܐ ܩܕܡܝܬܐ ܕܠܠܝܐ</quote>.</note>
@@ -240,8 +235,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">Hom. lxxxv. on <ref target="http://syriaca.org/work/9641">the Gospel of <persName ref="http://syriaca.org/person/1801">S. John</persName>
-                  </ref>
+                <title xml:lang="en">Hom. lxxxv. on <ref target="http://syriaca.org/work/9641">the Gospel of <persName ref="http://syriaca.org/person/1801">S. John</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܡ̈ܢܝܢ ܘܚ̈ܡ̣ܫܐ ܕܦܘܫܩܐ ܕܝܘܚܢܢ ܐܘܢܓܠܝܣܛܐ</rubric>
                 <note>In the margin of the rubric, there is written <quote xml:lang="syr">ܕܬܫܡܫܬܐ ܕܬܪ̈ܬܝܢ ܕܠܠܝܐ ܕܫܒܬܐ ܕܣܒܪܬܐ</quote>.</note>
@@ -380,8 +374,7 @@
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
                 <title xml:lang="en">From his Commentary on <ref target="http://syriaca.org/work/9648">the Gospel of <persName ref="http://syriaca.org/person/1855">S.
-                      Luke</persName>
-                  </ref>
+                      Luke</persName></ref>
                   </title>
                 <rubric xml:lang="syr">ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ̇. ܕܥܒ̣ܝܕ ܠܦܝܠܟܣܝܢܘܣ ܕܡܒܘܓ. ܠܚ̇ܡ
                     ܕܢܬ̣ܩܪܐ ܒܥܐܕܐ <choice>
@@ -398,8 +391,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Part of hom. lxx. on <ref target="http://syriaca.org/work/9646">the Gospel of <persName ref="http://syriaca.org/person/2703">S.
-                      Matthew</persName>
-                  </ref>
+                      Matthew</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܪܬܝܢܘܬܐ ܕܡܢ ܦܘܫܩܐ ܕܡܬܝ ܕܠܚ̇ܡ ܕܢܬܩܪܐ ܒܕܘܟܪܢܐ ܕܐܚ̈ܐ.</rubric>
                 <note>See <bibl>Opera, t. vii., p. 779</bibl>, from the words <foreign xml:lang="grc">'Επεὶ οὖν τοιαύτη ἡ ἀνάστασις
@@ -468,8 +460,7 @@
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
                 <title xml:lang="en">Hom. vi. on <ref target="http://syriaca.org/work/9646">the Gospel of <persName ref="http://syriaca.org/person/2703">S.
-                      Matthew</persName>
-                  </ref>
+                      Matthew</persName></ref>
                   </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܐܫܬܐ ܡܢ ܦܘܫܩܐ ܕܐܘܢܓܠܝܘܢ ܕܡܬܝ</rubric>
               </msItem>
@@ -479,8 +470,7 @@
                   <persName xml:lang="en">S. Matthew</persName>
                 </author>
                 <title xml:lang="en">Hom. ix. on <ref target="http://syriaca.org/work/9646">the Gospel of <persName ref="http://syriaca.org/person/2703">S.
-                      Matthew</persName>
-                  </ref>
+                      Matthew</persName></ref>
                   </title>
                 <rubric xml:lang="syr">ܡܐܡܪ ܕܬܫܥܐ ܡܢ ܦܘܫܩܐ ܕܡܬܝ</rubric>
               </msItem>
@@ -490,8 +480,7 @@
                   <persName xml:lang="en">Cyril of Alexandria</persName>
                 </author>
                 <title xml:lang="en">Hom. xii. on <ref target="http://syriaca.org/work/9648">the Gospel of <persName ref="http://syriaca.org/person/1855">S.
-                      Luke</persName>
-                  </ref>
+                      Luke</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܪܓܡܐ ܕܬܪ̈ܥܣܪ ܡܢ ܦܘܫܩܐ ܗ̇ܘ ܕܐܘܢܓܠܝܘܢ ܕܠܘܩܐ. ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ
                     ܕܥܠ ܕܢܚܗ ܕܡܪܢ ܕܒܒܣܪ</rubric>

--- a/data/tei/623.xml
+++ b/data/tei/623.xml
@@ -177,8 +177,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName>John the
-                                    monk</persName> on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. v.
+                <title xml:lang="en">Discourse of <persName>John the monk</persName> on <ref target="http://syriaca.org/work/9646">S. Matthew, ch. v.
                                 3</ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܡܪܝ ܝܘܚܢܢ ܝܚܝܕܝܐ ܕܛܘܒܝܗܘܢ ܠܡ̈ܣܟܢܐ ܒܪܘܚ
@@ -275,8 +274,7 @@
               <msItem xml:id="p1a10" n="12">
                 <locus from="55b"/>
                 <title xml:lang="en">History of the <persName ref="http://syriaca.org/person/607">Man of God</persName> from the city
-                                of <placeName ref="http://syriaca.org/place/641">Rome</placeName>, in the time of <persName ref="http://syriaca.org/person/26">Rabulas of
-                                        <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                                of <placeName ref="http://syriaca.org/place/641">Rome</placeName>, in the time of <persName ref="http://syriaca.org/person/26">Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                 </persName>
               </title>
                 <note>See <bibl>Add. 14,649<ptr target="https://bl.syriac.uk/ms/416"/>, no. <citedRange>3</citedRange>
@@ -461,8 +459,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the monk</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName>John the
-                                    monk</persName>
+                <title xml:lang="en">An extract from <persName>John the monk</persName>
               </title>
                 <rubric xml:lang="syr">ܡܢ ܝܘܚܢܢ ܝܚܝܕܝܐ</rubric>
                 <incipit xml:lang="syr">ܡܢ ܚ̈ܘܫܒܐ ܒ̈ܝ̣ܫܐ ܕܪܥܝܢܐ ܐܙܕܗܪ<locus from="125a"/>
@@ -1130,8 +1127,7 @@
                 <author ref="http://syriaca.org/person/826">
                   <persName xml:lang="en">John Sābā</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/826">John
-                  Sābā</persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/826">John Sābā</persName>
               </title>
                 <rubric xml:lang="syr">ܒܝܕ ܐܠܗܐ ܡܪܟܐܠ <foreign xml:lang="en">(sic)</foreign> ܪܫܡ̇ܝܢܢ ܡܢ̇ܬܐ ܩـ[ܠܝܠ ܡܢ ܟـ]ܬܒܐ ܕܡܪܝ ܣܒܐ ܕܡܬ݂ܩܪܐ ܝܘܚܢܢ ܨܠܘܬܐ ܥܡܢ ܐܡܝܢ.</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 433 seqq.</bibl>

--- a/data/tei/623.xml
+++ b/data/tei/623.xml
@@ -228,8 +228,7 @@
               <msItem xml:id="p1a5" n="7">
                 <locus from="34a"/>
                 <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1356">Marcus</persName> the
-                                    solitary, who dwelt on the <placeName>hill of
-                                    Tharmaka</placeName>
+                                    solitary, who dwelt on the <placeName>hill of Tharmaka</placeName>
               </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܪܒܐ ܘܓܒ̣ܝܐ ܐܒܐ ܡܪܩܘܣ ܝܚܝܕܝܐ. ܗ̇ܘ ܕܥ̇ܡܪ
                                 ܗܘ̣ܐ ܒܛܘܼܪܐ ܕܬܪܡܩܐ. ܘܥܠ ܐܒܐ ܣܪܦܝܘܢ. ܐܝܟܢܐ ܐܙܠ̣ ܨܝܕܘܗܝ.</rubric>

--- a/data/tei/623.xml
+++ b/data/tei/623.xml
@@ -258,8 +258,7 @@
               <msItem xml:id="p1a8" n="10">
                 <locus from="49a"/>
                 <title xml:lang="en">Extracts from the history of Abba 
-                  <persName ref="http://syriaca.org/person/1175">
-                    Bishoi (Pisoes)
+                  <persName ref="http://syriaca.org/person/1175">Bishoi (Pisoes)
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܡܢ ܡܡܠܐ ܕܐܒܐ ܒܝܫܘܝ ܨܠܘܬܗ ܥܡܢ ܐܡܝܢ.</rubric>
@@ -274,8 +273,7 @@
               <msItem xml:id="p1a10" n="12">
                 <locus from="55b"/>
                 <title xml:lang="en">History of the <persName ref="http://syriaca.org/person/607">Man of God</persName> from the city
-                                of <placeName ref="http://syriaca.org/place/641">Rome</placeName>, in the time of <persName ref="http://syriaca.org/person/26">Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>
+                                of <placeName ref="http://syriaca.org/place/641">Rome</placeName>, in the time of <persName ref="http://syriaca.org/person/26">Rabulas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
               </title>
                 <note>See <bibl>Add. 14,649<ptr target="https://bl.syriac.uk/ms/416"/>, no. <citedRange>3</citedRange>
                   </bibl>.</note>
@@ -424,8 +422,7 @@
                 <author ref="http://syriaca.org/person/550">
                   <persName xml:lang="en">Isaac of Nineveh</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/550">Isaac of <placeName>Nineveh</placeName>
-                  </persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/550">Isaac of <placeName>Nineveh</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܐܝܚܩ ܕܢܝܢܘܐ ܩܠܝܠ</rubric>
                 <incipit xml:lang="syr">ܐܡ̇ܪ ܠܟ ܨܒܘܬ݂ܐ ܘܠܐ ܬܓܚܟ ܡܛܠ ܕܫܪܪܐ ܐܡ̇ܪ ܐܢܐ ܘܠܐ
@@ -437,8 +434,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
-                <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName>
-                  </persName>, addressed to one of his disciples,
+                <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName></persName>, addressed to one of his disciples,
                                 on the renunciation of the world and the life of the monastery and
                                 the cell</title>
                 <rubric xml:lang="syr">ܬܘܒ ܐܓܪܬܐ ܕܦܝܠܠܘܟܣܢܣ ܕܟܬܒ̣ ܠܚܕ ܡܢ ܬܠܡܝ̈ܕܘܗܝ. ܥܠ
@@ -631,8 +627,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah of Scete</persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>
+                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܕܐܒܐ ܐܫܥܝܐ</rubric>
                 <msItem xml:id="p3b5" n="8">
@@ -650,8 +645,7 @@
                   <author ref="http://syriaca.org/person/548">
                     <persName xml:lang="en">Isaiah of Scete</persName>
                   </author>
-                  <title xml:lang="en">Another work of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>
+                  <title xml:lang="en">Another work of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
                 </title>
                   <incipit xml:lang="syr">ܗܠܝܢ ܛܪ ܥܕܡܐ ܠܡܘܬܐ ܘܠܐ ܬܒ̇ܣܪ ܥܠܝܗܘܢ. ܗ̇ܝ ܕܠܐ ܬܠܥܣ ܥܡ
                            ܐܢܬܬܐ. ܘܕܠܐ ܬܗ̇ܘܐ ܠܟ ܪܚܡܘܬܐ ܥܡ ܛܠܝ̈ܐ</incipit>
@@ -661,8 +655,7 @@
                   <author ref="http://syriaca.org/person/548">
                     <persName xml:lang="en">Isaiah of Scete</persName>
                   </author>
-                  <title xml:lang="en">Another work of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>
+                  <title xml:lang="en">Another work of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
                 </title>
                   <incipit xml:lang="syr">ܗ̇ܝ ܕܢܚ̣ܒ ܠܡܥܩܒܘ ܠܟܬܒ̇ܐ̣. ܝ̇ܠܕܐ ܒܥܠܕܒܒܘܬܐ ܘܦܠܓܘܬܐ</incipit>
                   <note>Imperfect. See <bibl>Add. 14,575<ptr target="https://bl.syriac.uk/ms/311"/>, no. <citedRange>13</citedRange>
@@ -677,8 +670,7 @@
                   <author ref="http://syriaca.org/person/548">
                     <persName xml:lang="en">Isaiah of Scete</persName>
                   </author>
-                  <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>
+                  <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܡܡܠܠܐ ܕܐܒܐ ܐܫܥܝܐ ܝܚܝܕܝܐ ܣܘܪܝܝܐ</rubric>
                 </msItem>
@@ -707,8 +699,7 @@
                 <author ref="http://syriaca.org/person/2507">
                   <persName xml:lang="en">Theophilus of Alexandria</persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName> on the separation of the soul from the body</title>
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the separation of the soul from the body</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܬܐܘܦܝܠܐ ܕܥܠ ܦܘܪܫܢܐ ܕܢܦܫܐ ܡܢ ܦܓܪܐ</rubric>
                 <incipit xml:lang="syr">ܠܐ ܛܥܝܐ ܠܟܘܢ ܐܚ̈ܝ̣. ܏ܘܫ.</incipit>
               </msItem>
@@ -717,8 +708,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>
+                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ</rubric>
                 <incipit xml:lang="syr">ܐܚܒ ܫܠܝܐ ܐܘ ܬܠܡܝܕܐ. ܕܒܗ ܬܫܟܚ ܬܚܐ ܢܦܫܟ.</incipit>
@@ -728,8 +718,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabug</persName>
                 </author>
-                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                </persName>
+                <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
                 <msItem xml:id="p3b12" n="19">
@@ -777,8 +766,7 @@
               </msItem>
               <msItem xml:id="p3a10" n="26">
                 <locus from="192a"/>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName ref="http://syriaca.org/place/641">Rome</placeName>
-                </persName>,</title>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName ref="http://syriaca.org/place/641">Rome</placeName></persName>,</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܝܘܚܢܢ ܝܚܝܕܝܐ ܘܣܗܕܐ ܏ܩܕ.</rubric>
                 <note>See <bibl>Add. 14,649<ptr target="https://bl.syriac.uk/ms/416"/>, no. <citedRange>23</citedRange>
                   </bibl>.</note>
@@ -930,8 +918,7 @@
                 <author ref="http://syriaca.org/person/550">
                   <persName xml:lang="en">Isaac of Nineveh</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/550">Isaac of <placeName>Nineveh</placeName>
-                  </persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/550">Isaac of <placeName>Nineveh</placeName></persName>
               </title>
                 <msItem xml:id="p4b1" n="3">
                   <locus from="209b"/>

--- a/data/tei/629.xml
+++ b/data/tei/629.xml
@@ -1600,8 +1600,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">Extract from a metrical discourse of <persName ref="http://syriaca.org/person/33">
-                Isaac of Antioch</persName>
+                <title xml:lang="en">Extract from a metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of Antioch</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܢ ܡܐܡܪܐ ܕܡܪܝ ܐܝܣܚܩ</rubric>
                 <incipit xml:lang="syr">ܣܝ̣ܡ ܗܘ ܠܡ̈ܠܟܐ ܢܡܘܣܐ. ܠܚ̈ܝܠܘܬܗܘܢ ܘܡ̇ܬܚܡ.</incipit>

--- a/data/tei/629.xml
+++ b/data/tei/629.xml
@@ -1941,8 +1941,7 @@
                 <author ref="http://syriaca.org/person/826">
                   <persName xml:lang="en">John Saba</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/826">John
-                  Saba</persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/826">John Saba</persName>
               </title>
                 <rubric xml:lang="syr">ܥܠ ܚ̇ܝ̣ܠܐ ܘܣܘܝܥܐ ܕܐܒܐ ܘܕܒܪܐ ܘܕܪܘܚܐ ܩ܏ܕ. ܕܠܗ ܏ܫܘ ܡܢ ܦܘܡ ܟܠܢ܀
                 ܐܢ̇ܐ ܡܚܝ̣ܠܐ ܕܣ̇ܡ̣ܬ ܐܦ̈ܝ ܠܡܣܪܛ. ܡܢ ܟܬܒܐ ܗܢܐ. ܐܝܟ ܡܐ ܕܝܫܘܥ ܕܝܠܝ ܡܫܝܚܐ ܡܥܕܪ. ܗ̇ܘ ܕܕܝܠܗ

--- a/data/tei/635.xml
+++ b/data/tei/635.xml
@@ -398,8 +398,7 @@
               </msItem>
               <msItem xml:id="p2a8" n="10">
                 <locus from="154a"/>
-                <title xml:lang="en">Sentences from <ref>the Proverbs of <persName>Solomon</persName>
-                  </ref>, against different evil thoughts</title>
+                <title xml:lang="en">Sentences from <ref>the Proverbs of <persName>Solomon</persName></ref>, against different evil thoughts</title>
                 <rubric xml:lang="syr">ܡܢ ܡ̈ܬܠܐ</rubric>
               </msItem>
               <msItem xml:id="p2a9" n="11">

--- a/data/tei/635.xml
+++ b/data/tei/635.xml
@@ -164,8 +164,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah of Scete</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName>
-                  </persName> on humility</title>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName></persName> on humility</title>
                 <rubric xml:lang="syr">ܕܝܠܗ ܕܐܒܐ ܐܫܥܝܐ ܡ̇ܛܠ ܡܟܝܟܘܬܐ</rubric>
               </msItem>
               <msItem xml:id="p1a3" n="3">
@@ -191,8 +190,7 @@
               </msItem>
               <msItem xml:id="p1a5" n="5">
                 <locus from="83a"/>
-                <title xml:lang="en">Part of a discourse in the metre of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                  </persName>, on the Crucifixion of <persName>our Lord</persName> and the Dispersion of <placeName>the Apostles</placeName> to different countries</title>
+                <title xml:lang="en">Part of a discourse in the metre of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName>, on the Crucifixion of <persName>our Lord</persName> and the Dispersion of <placeName>the Apostles</placeName> to different countries</title>
               </msItem>
               <msItem xml:id="p1a6" n="6">
                 <locus from="84b"/>
@@ -358,8 +356,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
-                <title xml:lang="en">An excerpt from the history of <persName>Susanna</persName> by <persName>John of <placeName>Asia</placeName>
-                  </persName>
+                <title xml:lang="en">An excerpt from the history of <persName>Susanna</persName> by <persName>John of <placeName>Asia</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܡܢ ܬܫܥܝܬܐ ܕܫܘܫܢ ܡܢܗ ܕܟܬܒܐ ܕܝܘܚܢܢ ܕܐܣܝܐ</rubric>
                 <note>See <bibl>Add. 14,650, no. 18, h</bibl>, and <bibl>Land, Anecd. Syr., t. ii., p. 29 of the introduction</bibl>.</note>
@@ -369,8 +366,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
-                <title xml:lang="en">An excerpt from the history of <persName>Ḥarpaṭ</persName> by <persName>John of <placeName>Asia</placeName>
-                  </persName>
+                <title xml:lang="en">An excerpt from the history of <persName>Ḥarpaṭ</persName> by <persName>John of <placeName>Asia</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܡܢ ܬܫܥܝܬܐ ܕܚܪܦܛ</rubric>
                 <note>See <bibl>Add. 14,650, no. 18, k</bibl>, and <bibl>Land, loc. cit.</bibl>
@@ -378,16 +374,14 @@
               </msItem>
               <msItem xml:id="p2a4" n="6">
                 <locus from="129b"/>
-                <title xml:lang="en">The history of <persName>Paul the solitary, of the <placeName>Thebaid</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Paul the solitary, of the <placeName>Thebaid</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܐ ܕܐܒ̇ܐ ܦܘܠܐ ܝܚܝܕܝܐ: ܗ̇ܘ ܕܐܙ̣ܠ ܐܒ̇ܐ ܐܢܛܘܢ ܠܘܬܗ</rubric>
                 <note>See <bibl>Add. 14,653, no. 5</bibl>.</note>
               </msItem>
               <msItem xml:id="p2a5" n="7">
                 <locus from="137a"/>
-                <title xml:lang="en">The history of <persName>John of <placeName>Rome</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>John of <placeName>Rome</placeName></persName>
               </title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܥܠ ܢܨܝܚܐ ܘܝܚܝܕܝܐ ܝܘܚܢܢ: ܕܐܝܬܘܗܝ ܡܢ ܪܘܡܝ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Add. 14,649, no. 23</bibl>.</note>
@@ -433,9 +427,7 @@
               </msItem>
               <msItem xml:id="p2a13" n="15" defective="true">
                 <locus from="155b"/>
-                <title xml:lang="en">The history of <persName>Marcus, who dwelt on <placeName>the hill of <placeName>Tharmaḳā</placeName>
-                    </placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Marcus, who dwelt on <placeName>the hill of <placeName>Tharmaḳā</placeName></placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܐܒܐ ܡܪܩܘܣ ܕܒܛܘܪܐ ܕܬܪܡܩܐ ܥܡܪ ܒܩܕܝܫܘܬܐ</rubric>
                 <note>See <bibl>Add. 14,624, no. 4</bibl>.</note>

--- a/data/tei/638.xml
+++ b/data/tei/638.xml
@@ -114,8 +114,7 @@
                 <persName xml:lang="en">Moses bar Kipha, bishop of Mosul and
                 Nineveh</persName>
               </author>
-              <title xml:lang="en">A treatise of <persName>Moses bar Kipha, bishop of <placeName ref="http://syriaca.org/place/2346">Mosul</placeName> and <placeName ref="http://syriaca.org/place/144">Nineveh</placeName>
-                </persName>, on
+              <title xml:lang="en">A treatise of <persName>Moses bar Kipha, bishop of <placeName ref="http://syriaca.org/place/2346">Mosul</placeName> and <placeName ref="http://syriaca.org/place/144">Nineveh</placeName></persName>, on
                 freewill and predestination, divided into four discourses</title>
               <note>It is imperfect at the beginning, and has been left unfinished by the scribe;
                     but the name of the author appears from the marginal notes, e.g., fol. 1a,
@@ -176,9 +175,7 @@
                   </title>,
                   fol. <locus from="29b">29 b</locus>;
                   <title xml:lang="en">letter to 
-                    <persName>
-                      Bar-hadad, bishop of Tella, <foreign xml:lang="syr">ܒܪܗܕܕ ܐܦܝ܏ܣ ܕܬܠܠܐ</foreign>
-                    </persName>
+                    <persName>Bar-hadad, bishop of Tella, <foreign xml:lang="syr">ܒܪܗܕܕ ܐܦܝ܏ܣ ܕܬܠܠܐ</foreign></persName>
                   </title>, fol. <locus from="72b">72 b</locus>;
                   <title xml:lang="en">treatise on theology</title>, fol. <locus from="98b">98 b</locus>
                   <quote xml:lang="syr">
@@ -360,8 +357,7 @@
                 <persName xml:lang="en">Isidore of
                 Pelusium</persName>
               </author>
-              <title xml:lang="en">A selection from the Epistles of <persName ref="http://syriaca.org/person/564">Isidore of <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName>
-                </persName>
+              <title xml:lang="en">A selection from the Epistles of <persName ref="http://syriaca.org/person/564">Isidore of <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܕܝܢ ܥܠ ܣܒܪܐ ܘܬܘܟܠܢܐ ܐܠܗܝܐ ܟܬܒܝܢܢ ܐܓܪ̈ܬܐ ܕܐܝܣܝܕܝܪܘܣ ܩܕܝܫܐ
                 ܡܕܒܪܢܐ ܘܩܫܝܫܐ ܕܦܝܠܝܣܝܘܢ ܕܠܘܬ ܐܦܝ̈ܣ܏ܩܘ ܘܩܫܝ̈ܫܐ ܘܡܫܡ̈ܫܢܐ. ܘܗܘ̈ܦܕܝܩܢܘ ܘܡ̈ܠܟܐ ܘܝܚܝ̈ܕܝܐ

--- a/data/tei/638.xml
+++ b/data/tei/638.xml
@@ -114,8 +114,7 @@
                 <persName xml:lang="en">Moses bar Kipha, bishop of Mosul and
                 Nineveh</persName>
               </author>
-              <title xml:lang="en">A treatise of <persName>Moses bar Kipha, bishop of
-                <placeName ref="http://syriaca.org/place/2346">Mosul</placeName> and <placeName ref="http://syriaca.org/place/144">Nineveh</placeName>
+              <title xml:lang="en">A treatise of <persName>Moses bar Kipha, bishop of <placeName ref="http://syriaca.org/place/2346">Mosul</placeName> and <placeName ref="http://syriaca.org/place/144">Nineveh</placeName>
                 </persName>, on
                 freewill and predestination, divided into four discourses</title>
               <note>It is imperfect at the beginning, and has been left unfinished by the scribe;
@@ -361,8 +360,7 @@
                 <persName xml:lang="en">Isidore of
                 Pelusium</persName>
               </author>
-              <title xml:lang="en">A selection from the Epistles of <persName ref="http://syriaca.org/person/564">Isidore of
-                <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName>
+              <title xml:lang="en">A selection from the Epistles of <persName ref="http://syriaca.org/person/564">Isidore of <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName>
                 </persName>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܕܝܢ ܥܠ ܣܒܪܐ ܘܬܘܟܠܢܐ ܐܠܗܝܐ ܟܬܒܝܢܢ ܐܓܪ̈ܬܐ ܕܐܝܣܝܕܝܪܘܣ ܩܕܝܫܐ

--- a/data/tei/639.xml
+++ b/data/tei/639.xml
@@ -222,8 +222,7 @@
                 of the latter, some of them in a very fragmentary condition.</note>
                 <msItem xml:id="p1b1" n="3">
                   <locus from="2b"/>
-                  <title>The history of the Decease of the <persName>Virgin
-                    Mary</persName> in six books</title>
+                  <title>The history of the Decease of the <persName>Virgin Mary</persName> in six books</title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܝ̇ܠܕܬ݀ ܐܠܗܐ ܡ̇ܪܝܡ</rubric>
                   <finalRubric xml:lang="syr">
                     <locus from="16a"/>ܫܠ̣ܡܬ݀ ܬܫܥܝ̣ܬܗ̇ ܕܝ̇ܠܕܬ݀ ܐܠܗܐ ܡ̇ܪܝܡ. ܕܗ̇ܘܝܐ̣ ܣܦܪ̈ܐ ܐܫ̈ܬܐ. ܕܡ̇ܟܬܒܝܢ̣ ܠܫ̈ܠܝ̣ܚܐ ܩܕ̈ܝܫܐ. ܨܠܘܬܗܘܢ. ܥܡܢ</finalRubric>
@@ -291,8 +290,7 @@
                 </msItem>
                 <msItem xml:id="p1b7" n="9">
                   <locus from="90b"/>
-                  <title xml:lang="en">The history of <persName>John the Less, or
-                  the Younger</persName>, translated from the Arabic by <persName>Zachariah, bishop of <placeName>Sakhā</placeName>
+                  <title xml:lang="en">The history of <persName>John the Less, or the Younger</persName>, translated from the Arabic by <persName>Zachariah, bishop of <placeName>Sakhā</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܪܒܐ ܏ܘܩܕ ܘܡܥ̇ܠܝܐ ܒܐܒܗ̈ܬܐ܇ ܘܡܫ̇ܡܠܝܐ ܒܟܠܗܝܢ ܡܝ̇ܬܪ̈ܬܐ܇
@@ -348,8 +346,7 @@
                   <author ref="http://syriaca.org/person/668">
                     <persName xml:lang="en">Palladius</persName>
                   </author>
-                  <title xml:lang="en">The history of <persName>John the monk and
-                  seer, of <placeName>Lycopolis in <placeName>the Thebaid</placeName>
+                  <title xml:lang="en">The history of <persName>John the monk and seer, of <placeName>Lycopolis in <placeName>the Thebaid</placeName>
                       </placeName>
                     </persName>, written by
                   <persName ref="http://syriaca.org/person/2473">Palladius</persName>
@@ -373,8 +370,7 @@
                   <author ref="http://syriaca.org/person/29">
                     <persName xml:lang="en">Samuel</persName>
                   </author>
-                  <title xml:lang="en">The history of <persName>Bar-ṣauma</persName>, written by <persName>his disciple
-                  Samuel</persName>
+                  <title xml:lang="en">The history of <persName>Bar-ṣauma</persName>, written by <persName>his disciple Samuel</persName>
                   </title>
                   <rubric xml:lang="syr"> ܬܫܥܝ̣ܬܐ ܘܢ̣ܨܚ̈ܢܐ ܕܩܕܝܫܐ ܡܪܝ ܒܪܨܘܡܐ ܓܲܪܒܝܳܝܳܐ ܓܒ̣ܝܐ ܕܐܒ̈ܝ̣ܠܐ.
                   ܘܡ̇ܘܡܐ ܐܢ̣ܐ ܠܟܘܢ ܒܐܠܗܐ ܚܲܝܐ܇ ܕܠܐ ܐܢܫ ܢ̇ܡܪܚ ܘܢܠ̣ܚܐ ܐܘܿ ܢܚ̇ܠ̣ܦ ܐܘ ܢܚܲܒܠ ܣܟ ܡ̈ܠ̣ܘܗܝ

--- a/data/tei/639.xml
+++ b/data/tei/639.xml
@@ -256,8 +256,7 @@
                 </msItem>
                 <msItem xml:id="p1b4" n="6">
                   <locus from="52a"/>
-                  <title xml:lang="en">The history of <persName>Paul the Simple, the disciple of <persName>Antony</persName>
-                    </persName>
+                  <title xml:lang="en">The history of <persName>Paul the Simple, the disciple of <persName>Antony</persName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܦ݁ܰܘܼܠܷܐ ܦܫܝ̣ܛܐ ܬܠܡܝ̣ܕܐ ܕܝܠܗ ܕܡܪܝ ܐܢܛܘܢ</rubric>
                   <note>See <bibl>Add. 12,174, no. 10</bibl>.</note>
@@ -290,8 +289,7 @@
                 </msItem>
                 <msItem xml:id="p1b7" n="9">
                   <locus from="90b"/>
-                  <title xml:lang="en">The history of <persName>John the Less, or the Younger</persName>, translated from the Arabic by <persName>Zachariah, bishop of <placeName>Sakhā</placeName>
-                    </persName>
+                  <title xml:lang="en">The history of <persName>John the Less, or the Younger</persName>, translated from the Arabic by <persName>Zachariah, bishop of <placeName>Sakhā</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܪܒܐ ܏ܘܩܕ ܘܡܥ̇ܠܝܐ ܒܐܒܗ̈ܬܐ܇ ܘܡܫ̇ܡܠܝܐ ܒܟܠܗܝܢ ܡܝ̇ܬܪ̈ܬܐ܇
                   ܐܒ̇ܐ ܝܘ̣ܚܢܢ ܙܥܘܪܐ܇ ܡܕܒܪܢܐ ܕܡ̇ܕܒܪܐ ܩܕܝܫܐ ܕܐܣ̣ܩܝܛܝ. ܦܲܫܩܗ̇ ܕܝܢ ܐ̇ܘܟܝ̣ܬ ܬܪܓܡܗ̇܆ ܐܒܘܢ
@@ -315,8 +313,7 @@
                   <author ref="http://syriaca.org/person/857">
                     <persName xml:lang="en">Hieronymus</persName>
                   </author>
-                  <title xml:lang="en">The history of <persName>Macarius of <placeName>Alexandria</placeName>
-                    </persName>, written by <persName ref="http://syriaca.org/person/857">Hieronymus</persName>
+                  <title xml:lang="en">The history of <persName>Macarius of <placeName>Alexandria</placeName></persName>, written by <persName ref="http://syriaca.org/person/857">Hieronymus</persName>
                 </title>
                   <rubric xml:lang="syr">ܢ̣ܨܚ̈ܢܘܗܝ ܕܩܕܝܫܐ ܐܒ̇ܐ ܡ̇ܩ̣ܪܝܣ ܐܠܟܣܢܕܪܝܐ</rubric>
                   <finalRubric xml:lang="syr">
@@ -334,9 +331,7 @@
                 </msItem>
                 <msItem xml:id="p1b11" n="13">
                   <locus from="154a"/>
-                  <title xml:lang="en">The history of <persName>Marcus the monk, who dwelt on <placeName>the hill of <placeName>Tharmaḳa</placeName>
-                      </placeName>
-                    </persName>
+                  <title xml:lang="en">The history of <persName>Marcus the monk, who dwelt on <placeName>the hill of <placeName>Tharmaḳa</placeName></placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕܩܕܝܫܐ ܐܒ̇ܐ ܡ̇ܪܩܘܣ ܐܒܝ̣ܠܐ̣ ܕܥ̇ܡܪ ܗܘܐ ܒܛܘܼܪܐ ܕܬܰܪܡܩܳܐ</rubric>
                   <note>See <bibl>Add. 14,624, no. 4</bibl>.</note>
@@ -346,9 +341,7 @@
                   <author ref="http://syriaca.org/person/668">
                     <persName xml:lang="en">Palladius</persName>
                   </author>
-                  <title xml:lang="en">The history of <persName>John the monk and seer, of <placeName>Lycopolis in <placeName>the Thebaid</placeName>
-                      </placeName>
-                    </persName>, written by
+                  <title xml:lang="en">The history of <persName>John the monk and seer, of <placeName>Lycopolis in <placeName>the Thebaid</placeName></placeName></persName>, written by
                   <persName ref="http://syriaca.org/person/2473">Palladius</persName>
                 </title>
                   <rubric xml:lang="syr">ܬܫܥܝ̣ܬܐ ܕ܏ܩܕ ܐܒ̇ܐ ܝܘܚܢܢ ܝܚܝܕܝܐ ܘܚܲܰܙܳܝܳܐ ܕܰܒܬܷܐܒܰܐܝܻܣ. ܕܡ̇ܟܬܒܐ̣ ܠܦܷܠ̣ܰܐܕܻܝܣ. ܡ̇ܟܬܒܢܐ</rubric>
@@ -399,8 +392,7 @@
                   <msItem xml:id="p1c2" n="21">
                     <locus from="218" to="221"/>
                     <title xml:lang="en">Fragments of the history of
-                    <persName>Dioscorus of <placeName>Alexandria</placeName>
-                      </persName>
+                    <persName>Dioscorus of <placeName>Alexandria</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>

--- a/data/tei/647.xml
+++ b/data/tei/647.xml
@@ -559,8 +559,7 @@
               </msItem>
               <msItem xml:id="p4a6" n="6">
                 <locus from="121b"/>
-                <title xml:lang="en">The history of <persName>John of <placeName>Rome</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>John of <placeName>Rome</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܐ ܝܘܚܢܢ ܒܪ ܡ̈ܠܟܢܐ <foreign xml:lang="en">(<foreign xml:lang="syr">ܒܪ ܡ̣̈ܠܟܐ</foreign>)</foreign>
                 </rubric>
@@ -597,8 +596,7 @@
               </msItem>
               <msItem xml:id="p4a10" n="10">
                 <locus from="136b"/>
-                <title xml:lang="en">The history of <persName>Hilaria, the daughter of <persName>Zeno</persName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Hilaria, the daughter of <persName>Zeno</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܩܕܝܫܬܐ ܐܠܐܪܝܐ ܒܪܬܗ ܕܙܝܢܘܢ ܡ̇ܠ̣ܟܐ</rubric>
                 <note>See <bibl>Add. 14,641, no. 4, h</bibl>.</note>
@@ -616,16 +614,14 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>Mar Hala of <placeName>Amid</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>Mar Hala of <placeName>Amid</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܡܪܝ ܚ̇ܠܐ ܏ܩܕ ܕܝܪܝܐ ܒܚܝܪܐ ܘܡܢܝܚܢܐ ܕܐܟܣ̈ܢܝܐ ܕܐ܏ܝܬܘ ܒܚܕ ܡܢ ܥܘܡܪ̈ܐ ܕܐܡܕ</rubric>
                 <note>See <bibl>Add. 14,647, no. 33</bibl>; and <bibl>Land, Anecd. Syr., t. ii., p. 30 of the introduction, and p. 332</bibl>.</note>
               </msItem>
               <msItem xml:id="p4a13" n="13">
                 <locus from="159b"/>
-                <title xml:lang="en">The history of <persName>the forty martyrs of <placeName>Sebaste</placeName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>the forty martyrs of <placeName>Sebaste</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܟܬܒܝܢܢ ܬܫܥܝܬܐ ܕܐܪ̈ܒܥܝܢ ܣܗ̈ܕܐ ܩܕ̈ܝܫܐ ܕܐܬܟܠܠ ܒܝܡܬܐ ܕܣܒܣܛܝ</rubric>
                 <quote xml:lang="syr">
@@ -653,8 +649,7 @@
                 <author ref="http://syriaca.org/person/74">
                   <persName xml:lang="en">John of Asia</persName>
                 </author>
-                <title xml:lang="en">The history of <persName>a monk, who quitted <placeName>his convent</placeName>, and betook himself to <persName>another</persName>
-                  </persName>
+                <title xml:lang="en">The history of <persName>a monk, who quitted <placeName>his convent</placeName>, and betook himself to <persName>another</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܟܬܒܝܢܢ ܬܫܥܝܬܐ ܡܛܠ ܐܚܐ ܚܕ ܕܢܦ̣ܩ ܡܢ ܥܘܡܪܗ ܟܕ ܠܐ ܫ̣ܪܐ ܠܗ ܩܢܘܢܐ ܕܝܠܗ ܘܐܙ̣ܠ ܘܩ̇ܒ̣ܠ ܢܦܫܗ ܒܐܚܪܢܐ</rubric>
                 <note>See <bibl>Add. 14,647, no. 18</bibl>, and <bibl>Land, Anecd. Syr., t. ii., p. 30 of the introduction</bibl>.</note>

--- a/data/tei/652.xml
+++ b/data/tei/652.xml
@@ -643,8 +643,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p5a1" n="1">
                 <locus from="12a" to="12"/>
-                <title xml:lang="en">The conclusion of the history of <persName>the eight
-                  Youths of <placeName>Ephesus</placeName>
+                <title xml:lang="en">The conclusion of the history of <persName>the eight Youths of <placeName>Ephesus</placeName>
                 </persName>
                 </title>
               </msItem>
@@ -1894,8 +1893,7 @@
               <msItem xml:id="p17a1" n="1" defective="true">
                 <locus from="60" to="60"/>
                 <title xml:lang="en">Part of a litany of <persName>the Apostles</persName>,
-                  <persName>the seventy Disciples</persName>, and <persName>various Saints and
-                    Fathers</persName>
+                  <persName>the seventy Disciples</persName>, and <persName>various Saints and Fathers</persName>
                 </title>
               </msItem>
             </msContents>

--- a/data/tei/652.xml
+++ b/data/tei/652.xml
@@ -643,8 +643,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p5a1" n="1">
                 <locus from="12a" to="12"/>
-                <title xml:lang="en">The conclusion of the history of <persName>the eight Youths of <placeName>Ephesus</placeName>
-                </persName>
+                <title xml:lang="en">The conclusion of the history of <persName>the eight Youths of <placeName>Ephesus</placeName></persName>
                 </title>
               </msItem>
             </msContents>

--- a/data/tei/673.xml
+++ b/data/tei/673.xml
@@ -1783,8 +1783,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Part of a metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                  </persName> on Lent</title>
+                <title xml:lang="en">Part of a metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on Lent</title>
               </msItem>
             </msContents>
             <physDesc>

--- a/data/tei/69.xml
+++ b/data/tei/69.xml
@@ -116,8 +116,7 @@
                 <persName xml:lang="en">Palladius</persName>
               </author>
               <title xml:lang="en">Histories of the Solitary Brethren of the Egyptian
-                        Desert, composed, according to the Syriac title, by <persName ref="http://syriaca.org/person/668">Palladius, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName>
-                </persName>,
+                        Desert, composed, according to the Syriac title, by <persName ref="http://syriaca.org/person/668">Palladius, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName></persName>,
                         for the <persName>chamberlain Lausus</persName>.</title>
               <rubric xml:lang="syr">ܬܫ̈ܥܝܬܐ ܕܥܠ ܐܚ̈ܐ ܐܝܚܝ̈ܕܝܐ ܕܒܡܕܒܪܐ ܕܡܨܪܝܢ. ܕܟܬܒ̣ ܐܢܝܢ
                         ܦܠ[ܕܝܣ] ܬܠܡܝܕܗ ܕܡܪܝ ܐܘܓܪܝܣ ܠܠܘܣܐ ܪܝܫܢܐ.</rubric>
@@ -148,8 +147,7 @@
             <msItem xml:id="a2" n="4">
               <locus from="118" to="181">Foll. 118-181</locus>
               <title xml:lang="en">Histories of the Egyptian Fathers, composed by
-                           <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName>Helenopolis</placeName>, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName>
-                </persName>,
+                           <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName>Helenopolis</placeName>, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName></persName>,
                         at the request of <persName>Lausus the chamberlain</persName>
                         <!--missing greek from .pdf--> of the <persName>emperor Theodosius</persName>.</title>
               <rubric xml:lang="syr">ܦܢܩܝܬܐ ܕܐܒܗ̈ܬܐ ܡܨܪ̈ܝܐ ܕܦܠܕ ܐܦܣܩܘܦܐ ܕܗܠܢܦܘܠܝܣ. ܬܠܡܝܕܗ
@@ -157,8 +155,7 @@
                         ܩ̈ܕܝܫܐ.</rubric>
               <msItem xml:id="b3" n="5">
                 <locus from="118" to="181">Foll. 118-181</locus>
-                <title xml:lang="en">The epistle of <persName>Heraclides of <placeName ref="http://syriaca.org/place/2763">Cappadocia</placeName>
-                  </persName> to
+                <title xml:lang="en">The epistle of <persName>Heraclides of <placeName ref="http://syriaca.org/place/2763">Cappadocia</placeName></persName> to
                            <persName>Lausus</persName>.</title>
                 <rubric xml:lang="syr">
                   <locus from="118"/>ܝܗ̇ܒ ܐܢܐ ܛܘܒܐ̣ ܠܨܒܝܢܟ ܫܦܝܪܐ.
@@ -178,8 +175,7 @@
                 <locus from="118" to="181">Foll. 118-181</locus>
                 <title xml:lang="en"> As an appendix, fol. 180 a, the translator
                            gives a passage which he found, in a copy of the original, after the
-                           account of <persName>John of <placeName>Lycos</placeName>
-                  </persName>.</title>
+                           account of <persName>John of <placeName>Lycos</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܠܗܢܐ ܕܘܒܪܐ ܪܬܝܚܐ̣. ܒܟܬܒܐ ܐܚܪܢܐ ܐܫܟܚܬ݂. ܡܢ ܒܬܪ ܕܘܒܪܐ
                            ܕܛܘܒܢܐ ܝܘܚܢܢ ܚܒܝܫܐ ܗ̇ܘ ܕܒܠܘܩܣ</rubric>
                 <incipit xml:lang="syr">ܡܫܢܝܢܐ ܕܝܢ ܚܕ ܐܝܬ ܗܘܐ ܪܫܝܐ̣. ܕܒܢܟܦܘܬܐ ܪܒܐ ܗܘܐ

--- a/data/tei/69.xml
+++ b/data/tei/69.xml
@@ -148,19 +148,16 @@
             <msItem xml:id="a2" n="4">
               <locus from="118" to="181">Foll. 118-181</locus>
               <title xml:lang="en">Histories of the Egyptian Fathers, composed by
-                           <persName ref="http://syriaca.org/person/668">Palladius, bishop of
-                              <placeName>Helenopolis</placeName>, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName>
+                           <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName>Helenopolis</placeName>, the disciple of <persName ref="http://syriaca.org/person/483">Evagrius</persName>
                 </persName>,
                         at the request of <persName>Lausus the chamberlain</persName>
-                        <!--missing greek from .pdf--> of the <persName>emperor
-                           Theodosius</persName>.</title>
+                        <!--missing greek from .pdf--> of the <persName>emperor Theodosius</persName>.</title>
               <rubric xml:lang="syr">ܦܢܩܝܬܐ ܕܐܒܗ̈ܬܐ ܡܨܪ̈ܝܐ ܕܦܠܕ ܐܦܣܩܘܦܐ ܕܗܠܢܦܘܠܝܣ. ܬܠܡܝܕܗ
                         ܕܛܘܒܢܐ ܐܘܓܪܝܣ. ܕܟܬ݂ܒ̣ ܠܠܣܘ ܦܪܦܣܝܛܐ ܕܐܦܝܣܗ ܕܢܘܕܥܗ ܥܠ ܕܘܒܪ̈ܐ ܕܐܒܗ̈ܬܐ
                         ܩ̈ܕܝܫܐ.</rubric>
               <msItem xml:id="b3" n="5">
                 <locus from="118" to="181">Foll. 118-181</locus>
-                <title xml:lang="en">The epistle of <persName>Heraclides of
-                                 <placeName ref="http://syriaca.org/place/2763">Cappadocia</placeName>
+                <title xml:lang="en">The epistle of <persName>Heraclides of <placeName ref="http://syriaca.org/place/2763">Cappadocia</placeName>
                   </persName> to
                            <persName>Lausus</persName>.</title>
                 <rubric xml:lang="syr">
@@ -181,8 +178,7 @@
                 <locus from="118" to="181">Foll. 118-181</locus>
                 <title xml:lang="en"> As an appendix, fol. 180 a, the translator
                            gives a passage which he found, in a copy of the original, after the
-                           account of <persName>John of
-                           <placeName>Lycos</placeName>
+                           account of <persName>John of <placeName>Lycos</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܠܗܢܐ ܕܘܒܪܐ ܪܬܝܚܐ̣. ܒܟܬܒܐ ܐܚܪܢܐ ܐܫܟܚܬ݂. ܡܢ ܒܬܪ ܕܘܒܪܐ
                            ܕܛܘܒܢܐ ܝܘܚܢܢ ܚܒܝܫܐ ܗ̇ܘ ܕܒܠܘܩܣ</rubric>

--- a/data/tei/70.xml
+++ b/data/tei/70.xml
@@ -157,8 +157,7 @@
               </msItem>
               <msItem xml:id="b3" n="4">
                 <locus from="48a" to="78">Foll. 48a-78</locus>
-                <title>Life of <persName>Peter the Iberian (Petrus Iberus), bishop of <placeName>Gaza</placeName> and <placeName>Maiuma</placeName>
-                  </persName>
+                <title>Life of <persName>Peter the Iberian (Petrus Iberus), bishop of <placeName>Gaza</placeName> and <placeName>Maiuma</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܕܘܒܪ̈ܘܗܝ ܏ܕܩܕ ܦܛܪܘܣ ܐܝܒܪܝܐ. ܐܦܝܣܩܘܦܐ ܘܡܘܕܝܢܐ ܒܚ̣ܝܪܐ ܘܥ̇ܢܘܝܐ ܕܡܪܢ.<locus from="48a" to="48a"/>
                 </rubric>
@@ -177,8 +176,7 @@
               </msItem>
               <msItem xml:id="b5" n="6">
                 <locus from="84a" to="87">Foll. 84a-87</locus>
-                <title>Life of <persName>John, abbat of the convent of Aphtunaya, called in the subscription John bar Aphtunaya ,<foreign xml:lang="syr">ܝܘܚܢܢ ܒܪ ܐܦܬܘܢܝܐ</foreign>
-                  </persName>
+                <title>Life of <persName>John, abbat of the convent of Aphtunaya, called in the subscription John bar Aphtunaya ,<foreign xml:lang="syr">ܝܘܚܢܢ ܒܪ ܐܦܬܘܢܝܐ</foreign></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܪܒܐ ܝܘܚܢܢ ܪܝܫܕܝܪܐ ܕܥܘܡܪܐ ܩܕܝܫܐ̣ ܕܐܦܬܘܢܝܐ. ܕܐܬܟ̣ܬܒܬ̇ ܡܢ ܐܢܫ ܬܠܡܝܕܐ ܕܝܠܗ<locus from="84a" to="84a"/>
                 </rubric>
@@ -187,8 +185,7 @@
               </msItem>
               <msItem xml:id="b6" n="7">
                 <locus from="87b" to="90">Foll. 87b-90</locus>
-                <title>Anecdotes of <persName>Macarius of <placeName>Alexandria</placeName>
-                  </persName>
+                <title>Anecdotes of <persName>Macarius of <placeName>Alexandria</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܡܩܪܝܣ ܐܠܟܣܢܕܪܝܐ<locus from="87b" to="87b"/>
                 </rubric>
@@ -236,8 +233,7 @@
               </msItem>
               <msItem xml:id="b10" n="11">
                 <locus from="124a" to="125">Foll. 124a-125</locus>
-                <title>Life of <persName>Paul, surnamed the Simple (<foreign xml:lang="syr">ܦܫܝܛܐ</foreign>), the disciple of <persName>Antony</persName>
-                  </persName>
+                <title>Life of <persName>Paul, surnamed the Simple (<foreign xml:lang="syr">ܦܫܝܛܐ</foreign>), the disciple of <persName>Antony</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܛܘܒܢܐ ܦܘܠܐ. ܬܠܡܝܕܗ ܕܐܒ̇ܐ ܐܢܛܘܢܝܘܣ.<locus from="124a" to="124a"/>
                 </rubric>
@@ -250,8 +246,7 @@
                 <author ref="http://syriaca.org/person/2784">
                   <persName xml:lang="en" type="supplied">Amphilochius, bishop of Iconium</persName>
                 </author>
-                <title>Life of <persName>Basil, bishop of <placeName>Caesarea</placeName> in <placeName>Cappadocia</placeName>
-                  </persName>
+                <title>Life of <persName>Basil, bishop of <placeName>Caesarea</placeName> in <placeName>Cappadocia</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">
                   <sic>ܬܘܒ ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܡܪܝ ܒܐܣܝܠܠܝܘܣ ܐܦܝܣܩܘܦܐ ܏ܩܕ ܕܩܣܪܝܐ. ܕܩܦܕܘܩܝܐ. ܕܥܒܝܕܐ ܠ܏ܩܕ ܐܡܦܝܠܟܝܘܣ ܐܦܝܣܩܘܦܐ ܕܐܝܩܘܠܝܘܢ</sic>
@@ -278,8 +273,7 @@
               </msItem>
               <msItem xml:id="b13" n="14">
                 <locus from="138b" to="141">Foll. 138b-141</locus>
-                <title>Anecdotes of <persName>Nicolaus, bishop of <placeName>Myra</placeName>, in <placeName>Lycia</placeName>
-                  </persName>
+                <title>Anecdotes of <persName>Nicolaus, bishop of <placeName>Myra</placeName>, in <placeName>Lycia</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܡܪܝ ܢܝܩܘܠܐܘܣ ܐ܏ܦܝܣ ܕܡܘܪܐ ܡܕܝܢܬܐ. ܟܕ ܦܲܨܝ ܡܢ ܡ̇ܘ̣ܬܐ ܠܗܠܝܢ ܐܫ̈ܬܐ ܓܒܪ̈ܝܢ. ܘܡܛܠ ܗܠܝܢ ܚ̈ܛܐ ܕܫ̣ܩܠ<locus from="138b" to="138b"/>
                 </rubric>
@@ -289,8 +283,7 @@
               </msItem>
               <msItem xml:id="b14" n="15" defective="unknown">
                 <locus from="141a" to="142">Foll. 141a-142</locus>
-                <title>Narrative of the death of <persName>Theodosius, bishop of <placeName>Jerusalem</placeName>
-                  </persName>, and <persName>the monk Romanus</persName>
+                <title>Narrative of the death of <persName>Theodosius, bishop of <placeName>Jerusalem</placeName></persName>, and <persName>the monk Romanus</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܥܘܗܕܢܐ̣. ܕܐܝܟܢܐ ܫ̇ܢ̣ܝ ܠܘܬ ܡܪܢ̇ ܛܘܒܢܐ ܬܐܘܕܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܐܘܪܝܫܠܡ.<locus from="141a" to="141a"/>
                 </rubric>
@@ -301,8 +294,7 @@
                 <author ref="http://syriaca.org/person/58">
                   <persName>Zacharias Rhetor</persName>
                 </author>
-                <title>Life of <persName>Isaiah, abbat of <placeName>Scete</placeName>
-                  </persName>, with some account of <persName>his disciple Peter</persName> and of the <persName>monk Theodore</persName>
+                <title>Life of <persName>Isaiah, abbat of <placeName>Scete</placeName></persName>, with some account of <persName>his disciple Peter</persName> and of the <persName>monk Theodore</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܕܘܒܪ̈ܘܗܝ ܕܗ̇ܘ ܕܒܝܬ ܩܕܝ̈ܫܐ ܐܒ̇ܐ ܐܫܥܝܐ ܥ̇ܢܘܝܐ. ܬܠܝܬܝܐ ܢܣ̇ܒܬ ܠܬܫܥ̈ܝܬܐ ܕܩ̈ܕܡܝ ܐܬܐ̣ܡܪ̈ܝܢ. ܐܫܥܝܐ ܢܒܝܐ ܬܪܝܢܐ ܕܗܢܐ ܕܪܐ ܕܝܠܢ: ܗ̇ܘ ܕܒܗܝܡܢܘܬܐ ܘܒ܏ܫܘ ܬܪܝܨܐ ܘܒܕܘܒܪܐ. ܡܫ̇ܘܬܦܐ ܒܟܠܡܕܡ ܗܘ̣ܐ ܠܦܛܪܘܣ ܘܠܬܐܘܕܘܐܪܐ ܗܠܝܢ ܛܒܝ̈ܒܐ ܘܪ̈ܝܫܝ ܟܗ̈ܢܐ. ܏ܘܫ. ܟܬܒܗ̇ ܕܝܢ ܘܠܗܕܐ ܬܫܥܝܬܐ̣. ܙܟܪܝܐ ܣܟܘܠܣܛܝܩܐ ܗ̇ܘ ܕܐܟܬ݂ܒ ܐܩܠܣܝܣܛܝܩܐ<locus from="142b" to="142b"/>
                 </rubric>
@@ -699,8 +691,7 @@
                 <msItem xml:id="c29" n="47">
                   <locus from="285a" to="285">Fol. 285a-285</locus>
                   
-                  <title>Life of <persName ref="http://syriaca.org/person/42">Jacob, bishop of <placeName ref="http://syriaca.org/place/48">Batnae</placeName>
-                    </persName>
+                  <title>Life of <persName ref="http://syriaca.org/person/42">Jacob, bishop of <placeName ref="http://syriaca.org/place/48">Batnae</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܥܠ ܏ܩܕ ܘܓܒܝܐ ܘܠܒ̣ܝܫ ܠܐܠܗܐ̇. ܡܪܝ ܝܥܩܘܒ ܡ̇ܠܦܢܐ ܐܠܗܝܐ̇. ܘܐܦܝܣܩܘܦܐ ܕܒܛܢܢ ܕܣܪܘܓ.<locus from="285a"/>
                   </rubric>
@@ -839,8 +830,7 @@
                 <msItem xml:id="c37" n="59">
                   <locus from="316a" to="322">Fol. 316a-322</locus>
                   
-                  <title>Martyrdom of <persName>'Abdu 'l-Masih</persName>, formerly a <persName>Jew</persName> named <persName>Asher ben Levi, of <placeName ref="http://syriaca.org/place/184">Singar</placeName>
-                    </persName>, about the year 701,<date notBefore="0375" notAfter="0405" calendar="Gregorian">A.D. 390</date>
+                  <title>Martyrdom of <persName>'Abdu 'l-Masih</persName>, formerly a <persName>Jew</persName> named <persName>Asher ben Levi, of <placeName ref="http://syriaca.org/place/184">Singar</placeName></persName>, about the year 701,<date notBefore="0375" notAfter="0405" calendar="Gregorian">A.D. 390</date>
                   </title>
                   <incipit xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܐܘܟܝܬ ܣܗܕܘܬܐ̣. ܕܓܒܪܐ ܕܐܠܗܐ ܥ̣ܒܕܠܡܝܣܝܚ. ܕܗ̣ܘܐ ܥܒ̣ܕܐ ܕܡܫܝܚܐ. ܕܐܝ܏ܬܘ ܗܘܐ ܫܡܗ܆ ܐܫܝܪ ܒܪ ܠܘܝ ܝܘܕܝܐ̣. ܕܡܢ ܫܝܓܪ ܡܕܝܢܬܐ܀ ܒܫܢܬ̇ ܫܒܥܡܐܐ ܘܚܕܐ ܐܝܟ ܡܢ̣ܝܢܐ ܕܝܘ̈ܢܝܐ. ܟܕ ܥܕܟܝܠ ܡܓܘܫܘܬܐ ܢܨ̇ܚܐ ܗܘܬ ܒܐܬܪܐ ܕܦܪ̈ܣܝܐ: ܘܓ̈ܠ̣ܝܢ ܗ̈ܘܝ ܐܦܝ̈ܗ̇ ܕܝܘܕܝܘܬܐ ܐܦ ܒܐܬܪܐ ܕܫܝܓܪ̈ܝܐ̣. ܓܒܪܐ ܕܝܢ ܝܘܕܝܐ ܐܝܬ ܗܘܐ ܡܢ ܫܝܓܪ ܡܕܝܢܬܐ̇. ܘܐܝܬ ܗܘܐ ܠܗ ܩܢ̈ܝܢܐ̣ ܘܥ̇ܒܕܬܐ ܣܓܝܐܬܐ. ܘܡܫ̇ܪܬܚ ܗܘܐ ܒܥܘܬܪܐ ܪܒܐ. ܘܫܡܗ ܗܘܐ̣ ܠܘܝ. ܘܪܝܫܐ ܗܘܐ ܕܝܘ̈ܕܝܐ. ܘܐܝܬ ܗܘܐ ܠܗ ܒ̈ܢܝܐ. ܘܠܟܠܚܕ ܡܢܗܘܢ̣ ܪܥ̇ܝܘܬܐ ܡܢ ܩܢܝܢܗ ܐܓܥ̣ܠ. ܘܗ̇ܘ ܙܥܘܪܐ ܡܢܗܘܢ ܐܝܟ ܒܪ ܚܕܥܣܪ̈ܐ ܫ̈ܢܝܢ ܝܬܝܪ ܚܣܝܪܐ ܐܝܬܘܗܝ ܗܘܐ. ܘܫܡܗ ܗܘܐ̣ ܐܫܝܪ. ܏ܘܫ.<locus from="316a"/>
                   </incipit>
@@ -929,8 +919,7 @@
                 </msItem>
                 <msItem xml:id="c45" n="67">
                   <locus from="378a" to="380">Foll. 378a-380</locus>
-                  <title>Martyrdom of <persName>Martha, the daughter of <persName>Posī</persName>
-                    </persName>
+                  <title>Martyrdom of <persName>Martha, the daughter of <persName>Posī</persName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܒ ܣܗܕܘܬܐ ܕܡܪܬܐ̣ ܒܪܬܐ ܕܝܠܗ ܕܦܘܣܝ.<locus from="378a" to="378a"/>
                   </rubric>
@@ -947,8 +936,7 @@
                 </msItem>
                 <msItem xml:id="c47" n="69">
                   <locus from="381a" to="382">Foll. 381a-382</locus>
-                  <title>Martyrdom of <persName>Tarbū, or Tarbula, the sister of <persName>Simeon bar Sabbā'ē</persName>
-                    </persName>, her sister, and her maidservant</title>
+                  <title>Martyrdom of <persName>Tarbū, or Tarbula, the sister of <persName>Simeon bar Sabbā'ē</persName></persName>, her sister, and her maidservant</title>
                   <rubric xml:lang="syr">ܬܘܒ ܣܗܕܘܬܐ ܕܬܪܒܘ ܘܕܚܬܗ̇. ܕܐܝ̈ܬܝܗܝܢ ܐܚ̈ܘܬܗ ܕܫܡܥܘܢ ܒܪ ܨܒ̈ܥܐ. ܘܕܐܡܬܗ̇ ܕܪܕ̇ܝܐ ܗܘܬ ܠܗ̇ ܒܝܘܠܦܢܐ ܛ̇ܒܐ ܕܡܫܝܚܐ ܡܪܢ.<locus from="381a" to="381a"/>
                   </rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 187</bibl>.</note>
@@ -976,11 +964,9 @@
                 </msItem>
                 <msItem xml:id="c50" n="72">
                   <locus from="388a" to="395">Foll. 388a-395</locus>
-                  <title>Life of <persName>Ma'īn of <placeName ref="http://syriaca.org/place/184">Singar</placeName>
-                    </persName>, one of the generals of <persName>Sapor, king of Persia</persName>, who was converted by seeing the steadfastness of the Christian martyrs (in particular of <quote xml:lang="syr">
+                  <title>Life of <persName>Ma'īn of <placeName ref="http://syriaca.org/place/184">Singar</placeName></persName>, one of the generals of <persName>Sapor, king of Persia</persName>, who was converted by seeing the steadfastness of the Christian martyrs (in particular of <quote xml:lang="syr">
                       <persName>ܕܘܕܐ</persName>
-                    </quote>, whom <persName>Sapor</persName> had flayed alive), and became a disciple of <persName>Benjamin of <placeName>Dūra (ܕܘܪܐ)</placeName>
-                    </persName>
+                    </quote>, whom <persName>Sapor</persName> had flayed alive), and became a disciple of <persName>Benjamin of <placeName>Dūra (ܕܘܪܐ)</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܡܪܝ ܡܥܝܢ. ܕܐܝܬܘܗܝ ܡܢ ܫܝܓܪ ܡܕܝܢܬܐ ܕܒܝܬ ܦܪ̈ܣܝܐ.<locus from="388a" to="388a"/>
                   </rubric>

--- a/data/tei/70.xml
+++ b/data/tei/70.xml
@@ -774,8 +774,7 @@
                 <msItem xml:id="c35" n="57">
                   <locus from="306a" to="311">Fol. 306a-311</locus>
                   
-                  <title>Martyrdom of <persName>Christopher</persName> and others, in <date when="0251" calendar="Gregorian">the third year of the reign of <persName>Decius</persName>
-                    </date>
+                  <title>Martyrdom of <persName>Christopher</persName> and others, in <date when="0251" calendar="Gregorian">the third year of the reign of <persName>Decius</persName></date>
                   </title>
                   <rubric xml:lang="syr">ܬܫܥܝܬܐ ܐܘܟܝܬ ܣܗܕܘܬܐ ܏ܕܩܕ ܡܪܝ ܟܪܝܣܛܘܦܘܪܘܣ ܒܪܒܪܝܐ. ܘܕܣܗ̈ܕܐ ܩ̈ܕܝܫܐ ܕܥܡܗ.<locus from="306a"/>
                   </rubric>

--- a/data/tei/70.xml
+++ b/data/tei/70.xml
@@ -920,8 +920,7 @@
                 </msItem>
                 <msItem xml:id="c44" n="66" defective="true">
                   <locus from="372a" to="378">Foll. 372b-378a</locus>
-                  <title>Martyrdom of <persName>Posī, Pusices or
-                      Pusicius</persName> whose father was a Grecian captive</title>
+                  <title>Martyrdom of <persName>Posī, Pusices or Pusicius</persName> whose father was a Grecian captive</title>
                   <rubric xml:lang="syr">ܬܘܒ ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܦܘܣܝ ܕܐܬܟ̇ܠܠ ܒܝܘ̈ܡܝ ܫ̇ܒܘܪ ܡܲܠܟܐ.<locus from="372a" to="372a"/>
                   </rubric>
                   <note>See <bibl>Assemani, Bibl. Or., t. i., p. 185</bibl>.</note>

--- a/data/tei/71.xml
+++ b/data/tei/71.xml
@@ -176,8 +176,7 @@
                   <author ref="http://syriaca.org/person/668">
                     <persName xml:lang="en">Palladius of Aspuna</persName>
                   </author>
-                  <title>A passage found in some copies of the Paradise, after the account of <persName>John of <placeName>Lycos</placeName>
-                  </persName>
+                  <title>A passage found in some copies of the Paradise, after the account of <persName>John of <placeName>Lycos</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܠܗܢܐ ܕܘܒܪܐ ܪܬܚ̇ܐ ܒܟܬܒܐ ܐܚܪܢܐ ܐܫ̇ܟܚܬܐ ܡܢ ܒܬܪ ܕܘܒܪܐ ܕܛܘܒܢܐ ܝܘܚܢܢ ܚܒܝܫܐ ܗ̇ܘ ܕܒܠܘܩܘܣ.<locus from="35a" to="35a"/>
                   </rubric>

--- a/data/tei/720.xml
+++ b/data/tei/720.xml
@@ -301,8 +301,7 @@
               <msItem xml:id="p2a1" n="1" defective="true">
                 <locus from="7"/>
                 <title xml:lang="en">Part of the metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on
-                           <ref>the Rich Man and <persName>Lazarus</persName>
-                </ref>
+                           <ref>the Rich Man and <persName>Lazarus</persName></ref>
               </title>
               </msItem>
             </msContents>

--- a/data/tei/720.xml
+++ b/data/tei/720.xml
@@ -161,8 +161,7 @@
               </title>
                 <msItem xml:id="p1b1" n="2">
                   <locus from="1a"/>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/512">Gregory
-                           Nyssen</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName>
                 </title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܕܥܠ ܣܛܦܐܢܘܣ ܪܝܫܐ
                            ܕܣܗ̈ܕܐ.</rubric>
@@ -173,8 +172,7 @@
                 </msItem>
                 <msItem xml:id="p1b2" n="3">
                   <locus from="4"/>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/573">John
-                           Chrysostom</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>
                 </title>
                   <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܩܕܝܫܐ ܝܘܐܢܝܣ ܕܥܠ ܣܛܦܐܢܘܣ ܪܝܫܐ
                            ܕܣ̈ܗܕܐ</rubric>
@@ -185,8 +183,7 @@
                 </msItem>
                 <msItem xml:id="p1b3" n="4" defective="true">
                   <locus from="5"/>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                 </title>
                   <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ ܕܥܠ ܩܕܝܫܐ ܣܛܦܐܢܘܣ
                            ܪܝܫܐ ܕܡܫܡ̈ܫܢܐ ܘܩܕܡܝܐ ܕܣ̈ܗܕܐ</rubric>

--- a/data/tei/730.xml
+++ b/data/tei/730.xml
@@ -162,8 +162,7 @@
                   <editor role="translator" ref="http://syriaca.org/person/82">
                     <persName xml:lang="en">Paul of Tella</persName>
                   </editor>
-                  <title ref="http://syriaca.org/work/167">The book of Ruth, translated from the Septuagint version by <persName ref="http://syriaca.org/person/82">Paul of <placeName>Tella</placeName>
-                    </persName>
+                  <title ref="http://syriaca.org/work/167">The book of Ruth, translated from the Septuagint version by <persName ref="http://syriaca.org/person/82">Paul of <placeName>Tella</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܟܬܒܐ ܕܐܪܥܘܬ ܒܡܫܠܡܢܘܬܐ ܕܫܒܥܝܢ<locus from="62b" to="62b"/>
                   </rubric>

--- a/data/tei/738.xml
+++ b/data/tei/738.xml
@@ -335,8 +335,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">The Creed of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName>
-                </persName>
+              <title xml:lang="en">The Creed of <persName>Severus of <placeName ref="http://syriaca.org/person/51">Antioch</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܗܝܡܢܘܬܐ ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ</rubric>
               <incipit xml:lang="syr">ܡܗ̇ܝܡܢ ܐܢܐ ܒܬܘܕܝܬܐ ܕܚܕ ܐܠܗܐ ܫܪܝܪܐ. ܕܐܝܬܘܗܝ.

--- a/data/tei/739.xml
+++ b/data/tei/739.xml
@@ -630,8 +630,7 @@
                   </msItem>
                   <msItem xml:id="p2_1b2" n="3">
                     <locus from="73b"/>
-                    <title xml:lang="en">The song of <ref target="http://syriaca.org/work/9640">
-                        <persName>Isaiah</persName>,
+                    <title xml:lang="en">The song of <ref target="http://syriaca.org/work/9640"><persName>Isaiah</persName>,
                                     ch. xlii. 10—13 and xlv. 8</ref>.</title>
                   </msItem>
                   <msItem xml:id="p2_1b3" n="4">
@@ -640,21 +639,18 @@
                   </msItem>
                   <msItem xml:id="p2_1b4" n="5">
                     <locus from="75a"/>
-                    <title xml:lang="en">The song of the blessed <persName ref="http://syriaca.org/person/624">Virgin</persName>(Magnificat),<ref target="http://syriaca.org/work/9648">
-                        <persName>S.
+                    <title xml:lang="en">The song of the blessed <persName ref="http://syriaca.org/person/624">Virgin</persName>(Magnificat),<ref target="http://syriaca.org/work/9648"><persName>S.
                                         Luke</persName> i. 46—55.</ref>
                     </title>
                   </msItem>
                   <msItem xml:id="p2_1b5" n="6">
                     <locus from="75a"/>
-                    <title xml:lang="en">The Beatitudes,<ref target="http://syriaca.org/work/9646">
-                        <persName>S.
+                    <title xml:lang="en">The Beatitudes,<ref target="http://syriaca.org/work/9646"><persName>S.
                                         Matthew</persName> v. 3—12</ref>.</title>
                   </msItem>
                   <msItem xml:id="p2_1b6" n="7">
                     <locus from="75b"/>
-                    <title xml:lang="en">The hymn "Gloria in excelsis,"<ref target="http://syriaca.org/work/9648">
-                        <persName>S. Luke</persName> ii. 14</ref>.</title>
+                    <title xml:lang="en">The hymn "Gloria in excelsis,"<ref target="http://syriaca.org/work/9648"><persName>S. Luke</persName> ii. 14</ref>.</title>
                     <rubric xml:lang="syr">ܬܫܒܘܚܬܐ ܕܡܬܡܪܐ ܒܦܠܓܗ ܕܠܠܝܐ</rubric>
                   </msItem>
                   <msItem xml:id="p2_1b7" n="8">

--- a/data/tei/754.xml
+++ b/data/tei/754.xml
@@ -171,8 +171,7 @@
               </msItem>
               <msItem xml:id="b5" n="7">
                 <locus from="76a"/>
-                <title xml:lang="en">The song of the <persName>blessed
-                                        Virgin</persName> (Magnificat)</title>
+                <title xml:lang="en">The song of the <persName>blessed Virgin</persName> (Magnificat)</title>
               </msItem>
               <msItem xml:id="b6" n="8">
                 <locus from="76a"/>
@@ -191,8 +190,7 @@
                 <author ref="http://syriaca.org/person/513">
                   <persName xml:lang="en">Gregory Thaumaturgus</persName>
                 </author>
-                <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/513">Gregory
-                                        Thaumaturgus</persName>, sent to him from God by the hand of
+                <title xml:lang="en">The Creed of <persName ref="http://syriaca.org/person/513">Gregory Thaumaturgus</persName>, sent to him from God by the hand of
                                         <persName>S. John the Evangelist</persName> and the
                                         <persName>Virgin Mary</persName>, and handed down by
                                         <persName>Gregory Nazianzen</persName>.

--- a/data/tei/754.xml
+++ b/data/tei/754.xml
@@ -218,8 +218,7 @@
               <title xml:lang="en">Several prayers</title>
               <msItem xml:id="b11" n="14">
                 <locus from="78a"/>
-                <title xml:lang="en">A eucharistic prayer from <ref>the
-                                    Testament of our Lord</ref>
+                <title xml:lang="en">A eucharistic prayer from <ref>the Testament of our Lord</ref>
                 </title>
                 <rubric xml:lang="syr">ܕܝܬܝܩܝ ܕܡܪܢ ܕܒܝܕ ܩܠܝܡܝܣ</rubric>
                 <incipit xml:lang="syr">ܨܠܘܬܐ ܡܢ ܕܝܬܝܩܝ ܕܡܪܢ ܒܬܪ ܢܣܝܒܘܬܐ ܕܪ̈ܐܙܐ.
@@ -313,9 +312,7 @@
                 <persName xml:lang="en">Daniel of Salach</persName>
               </author>
               <title xml:lang="en">Extracts from, or rather an abridgement
-                                of, <ref>the Commentary of <persName>Daniel of Salach</persName> on <ref>the
-                                Psalms</ref>
-                </ref>
+                                of, <ref>the Commentary of <persName>Daniel of Salach</persName> on <ref>the Psalms</ref></ref>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܦܬܓ̈ܡܐ ܡ̈ܫܚܠܦܐ ܡܢ ܕܘܝܕ ܢܒܝܐ ܕܡܪܝ ܕܢܝܐܝܠ ܨܠܚܝܐ</rubric>
               <note>Imperfect at the end.</note>

--- a/data/tei/754.xml
+++ b/data/tei/754.xml
@@ -240,8 +240,7 @@
                   <persName xml:lang="en">Philoxenus of
                                     Mabūg</persName>
                 </author>
-                <title xml:lang="en">A eucharistic prayer of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName>
-                  </persName>
+                <title xml:lang="en">A eucharistic prayer of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܝܠܟܣܝܢܘܣ. ܡܐ ܕܒ̇ܥܐ ܐܢܫ ܕܢܬܩ̇ܪܒ ܠܪ̈ܐܙܐ
                                     ܩ̈ܕܝܫܐ̣. ܢܨܠܐ ܗܟܢܐ. ܠܘܬܟ ܡܨ̇ܠܐ ܐܢܐ ܒܥܕܢܐ ܗܢܐ ܒܕܚܠܬܐ ܡܫܝܚܐ ܐܡ̣ܪܗ
@@ -263,8 +262,7 @@
                 <author ref="http://syriaca.org/person/51">
                   <persName xml:lang="en">Severus of Antioch</persName>
                 </author>
-                <title xml:lang="en">A prayer of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">A prayer of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܨܠܘܬܐ ܕܩܕܝܫܐ ܡܪܝ ܣܐܘܪܐ. ܕܡ̇ܨܠܐ ܠܗ̇ ܕܝܪܝܐ̣
                                     ܠܘܩܒܠ ܟܠ ܢܣܝܘܢܐ ܘܚܫܐ ܕܡܩ̣ܪܒ ܥܡܗ. ܡܪܝܐ ܐܠܗܐ ܕܚ̈ܝܠܘܬܐ ܩ̈ܕܝܫܐ܇ ܗ̇ܘ
@@ -275,8 +273,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah of Scete</persName>
                 </author>
-                <title xml:lang="en">A prayer of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                <title xml:lang="en">A prayer of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܨܠܘܬܐ ܕܐܒ̇ܐ ܐܫܥܝܐ ܕܡܨ̇ܠܐ ܕܝܪܝܐ̣ ܒܟܠܥܕܢ. ܡܪܢ
                                     ܝܫܘܥ ܐܢܬ ܗܘ ܡܥܕܪܢܝ. ܒܐܝ̈ܕܝܟ ܐܝ̇ܬܝ. ܐܢܬ ܝܕܥ̇ ܐܢܬ ܡܕܡ ܕܦܩ̇ܚ ܠܝ.
@@ -289,8 +286,7 @@
                 <persName xml:lang="en">Eusebius of Caesarea</persName>
               </author>
               <title xml:lang="en">Extracts from the Commentary of
-                  <persName ref="http://syriaca.org/person/480">Eusebius of <placeName>Caesarea</placeName>
-                </persName> on <ref>the Psalms</ref>
+                  <persName ref="http://syriaca.org/person/480">Eusebius of <placeName>Caesarea</placeName></persName> on <ref>the Psalms</ref>
               </title>
               <rubric xml:lang="syr">ܬܘܒ ܡܚ̇ܘܝܢܘܬܐ ܘܫܪܒܐ ܕܥܠ ܡܙܡܘܪ̈ܐ ܕܐܘܣܒܝܣ ܕܩܣܪܝܐ ܕܦܠܣܛܝܢܝ</rubric>
               <incipit xml:lang="syr">ܠܐ ܗܘܐ ܐܝܟܢܐ ܕܡܣ̣ܒܪ ܐܢܫ: ܟܠܗܘܢ ܡܙܡܘܪ̈ܐ ܕܕܘܝܕ

--- a/data/tei/756.xml
+++ b/data/tei/756.xml
@@ -143,9 +143,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p1a1" n="1" defective="true">
                 <locus from="1"/>
-                <title xml:lang="en">A Commentary on <ref target="http://syriaca.org/work/9615">the Revelation of
-                                <persName>S. John</persName>
-                  </ref>, divided into 72 chapters</title>
+                <title xml:lang="en">A Commentary on <ref target="http://syriaca.org/work/9615">the Revelation of <persName>S. John</persName></ref>, divided into 72 chapters</title>
                 <note>Chapter 1 is wanting, and chapters 2, 52, and 53, are imperfect.</note>
                 <note>
                   <p>The text of each chapter is quoted in full, and agrees closely

--- a/data/tei/757.xml
+++ b/data/tei/757.xml
@@ -201,8 +201,7 @@
                   <author ref="http://syriaca.org/person/431">
                     <persName xml:lang="en">Cyril of Jerusalem</persName>
                   </author>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/431">Cyril of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
-                    </persName> (sic)</title>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/431">Cyril of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName></persName> (sic)</title>
                   <rubric xml:lang="syr">ܐܢܐܦܘܪܐ ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܐܦܝܣܩܘܦܐ ܕܐܘܪܫܠܡ. ܐܝܟ ܬܘܪܨܐ ܚ̇ܕܬܐ ܕܢܦܝܩ ܡܢ ܝܘܢܝܐ ܠܣܘܪܝܝܐ</rubric>
                 </msItem>
                 <msItem xml:id="c9" n="16">
@@ -226,8 +225,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">Of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">Of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫ̣ܡ ܟܣܐ ܕܩܕܝܫܐ ܡܪܝ ܣܐܝܘܪܐ</rubric>
                   </msItem>
@@ -271,8 +269,7 @@
                     <author ref="http://syriaca.org/person/792">
                       <persName xml:lang="en">Timothy of Alexandria</persName>
                     </author>
-                    <title xml:lang="en">Of <persName ref="http://syriaca.org/person/792">Timothy of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Of <persName ref="http://syriaca.org/person/792">Timothy of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܛܟܣܐ ܕܥܡܕܐ ܩܕܝܫܐ܇ ܕܡܪܝ ܛܝܡܬܐܘܣ ܦܛܪܝܪܟܐ ܕܐܠܟܣܢܕܪܝܐ ܪܒܬܐ</rubric>
                   </msItem>
@@ -329,8 +326,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -363,8 +359,7 @@
                     <author ref="http://syriaca.org/person/93">
                       <persName xml:lang="en">Mārūthā of Tagrit</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/93">Mārūthā of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/93">Mārūthā of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -384,8 +379,7 @@
                   <author ref="http://syriaca.org/person/92">
                     <persName xml:lang="en">John of Antioch</persName>
                   </author>
-                  <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>
+                  <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c28" n="45">
@@ -435,8 +429,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d13" n="55">
@@ -444,8 +437,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d14" n="56">
@@ -453,8 +445,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d15" n="57">
@@ -462,8 +453,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -481,8 +471,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d17" n="61">
@@ -490,8 +479,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                   <msItem xml:id="d18" n="62">
@@ -499,8 +487,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -517,8 +504,7 @@
                     <author ref="http://syriaca.org/person/92">
                       <persName xml:lang="en">John of Antioch</persName>
                     </author>
-                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">A sedra of <persName ref="http://syriaca.org/person/92">John of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>

--- a/data/tei/758.xml
+++ b/data/tei/758.xml
@@ -170,8 +170,7 @@
               <author ref="http://syriaca.org/person/792">
                 <persName xml:lang="en">Timotheus of Alexandria</persName>
               </author>
-              <title xml:lang="en">The Order of Baptism of <persName ref="http://syriaca.org/person/792">Timotheus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName>
+              <title xml:lang="en">The Order of Baptism of <persName ref="http://syriaca.org/person/792">Timotheus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
               </title>
               <finalRubric xml:lang="syr">
                 <locus from="40b"/>ܫܠ̣ܡ ܛܟܣ̣ܐ ܕܥܡܕܐ ܩܕܝܫܐ܀ ܕܩܕܝܫܐ ܘܠܒܝܫ ܠܐܠܗܐ ܚܣܝܐ ܡܪܝ ܛܝܡܬܐܘܣ.. ܐܦܝܣܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ ܪܒܬܐ܀</finalRubric>

--- a/data/tei/759.xml
+++ b/data/tei/759.xml
@@ -187,8 +187,7 @@
                     <author ref="http://syriaca.org/person/33">
                       <persName xml:lang="en">Isaac of Antioch</persName>
                     </author>
-                    <title xml:lang="en">Several madrāshē and sūgyāthā, ascribed to <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">Several madrāshē and sūgyāthā, ascribed to <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -222,8 +221,7 @@
                     <author ref="http://syriaca.org/person/42">
                       <persName xml:lang="en">Jacob of Batnae</persName>
                     </author>
-                    <title xml:lang="en">Several madrāshē and sūgyāthā, ascribed to <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                      </persName>
+                    <title xml:lang="en">Several madrāshē and sūgyāthā, ascribed to <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
                     </title>
                   </msItem>
                 </msItem>
@@ -247,8 +245,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName>
+                <title xml:lang="en">Of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ. ܕܥܠ ܒܘܝܐܐ ܕܥ̈ܢܝܕܐ</rubric>
                 <incipit xml:lang="syr">ܐܠܘ ܐܝܬ ܠܝ ܡܠܬܐ ܚܠܝܡܬܐ ܕܩ̇ܢܝܐ ܫܘܦܪ̈ܐ. ܪܓܝܓ ܗܘܝܬ ܗܫܐ ܠܡܒܝܐܐܘ ܠܟܘܢ ܦ̇ܪ̈ܘܫܐ</incipit>

--- a/data/tei/759.xml
+++ b/data/tei/759.xml
@@ -151,8 +151,7 @@
                 </msItem>
                 <msItem xml:id="c3" n="7">
                   <locus from="15b"/>
-                  <title xml:lang="en">Appropriate lessons from <ref>the Old</ref> and <ref>New
-                    Testaments</ref>
+                  <title xml:lang="en">Appropriate lessons from <ref>the Old</ref> and <ref>New Testaments</ref>
                   </title>
                 </msItem>
                 <msItem xml:id="c4" n="8">
@@ -227,8 +226,7 @@
                 </msItem>
                 <msItem xml:id="c8" n="18">
                   <locus from="51b"/>
-                  <title xml:lang="en">Appropriate lessons from <ref>the Old</ref> and <ref>New
-                    Testaments</ref>
+                  <title xml:lang="en">Appropriate lessons from <ref>the Old</ref> and <ref>New Testaments</ref>
                   </title>
                 </msItem>
                 <msItem xml:id="c9" n="19">

--- a/data/tei/761.xml
+++ b/data/tei/761.xml
@@ -118,8 +118,7 @@
               <author ref="http://syriaca.org/person/2507">
                 <persName xml:lang="en">Theophilus of Alexandria</persName>
               </author>
-              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName>
+              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܕܬܐܘܦܝܠܐ ܕܥܠ ܦܘܪܫܐ ܕܢܦܫܐ ܡܢ ܦܓܪܐ </rubric>
               <incipit xml:lang="syr">ܠܐ ܛܥܝܐ ܠܟܘܢ ܐܚ̈ܝ ܏ܘܫ</incipit>
@@ -129,8 +128,7 @@
               <author ref="http://syriaca.org/person/33">
                 <persName xml:lang="en">Isaac of Antioch</persName>
               </author>
-              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>
+              <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
               </title>
               <rubric xml:lang="syr">ܕܡܪܝ ܝܣܚܩ <foreign xml:lang="en">(sic)</foreign> ܡܠܦܢܐ</rubric>
               <incipit xml:lang="syr">ܐܝܢܐ ܕܐܝ܏ܬܘ ܬܝܒܐ. ܢܗ̣ܘܐ ܚ̇ܐܪ ܒܟܠܙܒܢ ܒܕܡ̈ܥܘܗܝ ܕܗ̇ܘ ܡܟܣܐ ܏ܘܫ</incipit>

--- a/data/tei/768.xml
+++ b/data/tei/768.xml
@@ -146,8 +146,7 @@
               </msItem>
               <msItem xml:id="b7" n="8">
                 <locus from="22b"/>
-                <title xml:lang="en">The <persName>Wife of <persName>Pilate</persName>
-                  </persName>
+                <title xml:lang="en">The <persName>Wife of <persName>Pilate</persName></persName>
                 </title>
               </msItem>
               <msItem xml:id="b8" n="9">

--- a/data/tei/77.xml
+++ b/data/tei/77.xml
@@ -243,8 +243,7 @@
                 </msItem>
                 <msItem xml:id="c23" n="29">
                   <locus from="144a">Fol. 144a</locus>
-                  <title>Eccelesiasticus, or the Wisdom of <persName>Jesus the son of
-                        <persName>Sirach</persName>
+                  <title>Eccelesiasticus, or the Wisdom of <persName>Jesus the son of <persName>Sirach</persName>
                     </persName>
                   </title>
                 </msItem>
@@ -368,8 +367,7 @@
                 <author ref="http://syriaca.org/person/113">
                   <persName xml:lang="en">Jacob of Edessa</persName>
                 </author>
-                <title xml:lang="en">A letter to <persName>George, bishop of
-                      <placeName>Sarūg</placeName>
+                <title xml:lang="en">A letter to <persName>George, bishop of <placeName>Sarūg</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܕܝܫܐ ܘܚܟܝܡ ܒܐܠܗ̈ܝܬܐ ܡܪܝ ܝܥܩ݊ܘܒ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ ܠܘܬ
@@ -439,8 +437,7 @@
                 </author>
                 <title xml:lang="en">1. The names of the signs of punctuation, according to
                     <persName ref="http://syriaca.org/person/83">Thomas the deacon</persName>
-                    (<persName ref="http://syriaca.org/person/87">Thomas of
-                      <placeName>Heraclea</placeName>?</persName>)</title>
+                    (<persName ref="http://syriaca.org/person/87">Thomas of <placeName>Heraclea</placeName>?</persName>)</title>
                 <rubric xml:lang="syr">ܫ̈ܡܗܐ ܕܢܘ̈ܩܙܐ ܕܥܒ̣ܝܕܝܢ ܠܬܐܘܡܐ ܡܫܡܫܢܐ</rubric>
               </msItem>
               <msItem xml:id="b8" n="51">

--- a/data/tei/77.xml
+++ b/data/tei/77.xml
@@ -243,8 +243,7 @@
                 </msItem>
                 <msItem xml:id="c23" n="29">
                   <locus from="144a">Fol. 144a</locus>
-                  <title>Eccelesiasticus, or the Wisdom of <persName>Jesus the son of <persName>Sirach</persName>
-                    </persName>
+                  <title>Eccelesiasticus, or the Wisdom of <persName>Jesus the son of <persName>Sirach</persName></persName>
                   </title>
                 </msItem>
               </msItem>
@@ -296,8 +295,7 @@
                   <author ref="http://syriaca.org/person/2703">
                     <persName xml:lang="en">S. Matthew</persName>
                   </author>
-                  <title xml:lang="en">The Gospel of <persName ref="http://syriaca.org/person/2703">
-                      S. Matthew</persName>
+                  <title xml:lang="en">The Gospel of <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>
                   </title>
                 </msItem>
                 <msItem xml:id="c27" n="37">
@@ -359,16 +357,14 @@
               <author ref="http://syriaca.org/person/113">
                 <persName xml:lang="en">Jacob of Edessa</persName>
               </author>
-              <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                </persName>
+              <title xml:lang="en">Writings of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
               </title>
               <msItem xml:id="b4" n="45">
                 <locus from="223b">Fol. 223b</locus>
                 <author ref="http://syriaca.org/person/113">
                   <persName xml:lang="en">Jacob of Edessa</persName>
                 </author>
-                <title xml:lang="en">A letter to <persName>George, bishop of <placeName>Sarūg</placeName>
-                  </persName>
+                <title xml:lang="en">A letter to <persName>George, bishop of <placeName>Sarūg</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪܬܐ ܕܩܕܝܫܐ ܘܚܟܝܡ ܒܐܠܗ̈ܝܬܐ ܡܪܝ ܝܥܩ݊ܘܒ ܐܦܝܣܩܘܦܐ ܕܐܘܪܗܝ ܠܘܬ
                   ܚܣ̣ܝܐ ܘܩܕܝܫܐ ܡܪܝ ܓܶܐ݊ܘܪܓܺܝ ܐܦܝܣܩܘܦܐ ܕܣܪܘܓ ܘܒܐܝ̈ܕܘܗܝ ܠܟܠܗܘܢ ܟܬܘ̈ܒܐ܇ ܐܝܠܝܢ ܕܒܟܬܒܐ

--- a/data/tei/770.xml
+++ b/data/tei/770.xml
@@ -698,9 +698,7 @@
                 </msItem>
                 <msItem xml:id="c43" n="70">
                   <locus from="109b" to="110a"/>
-                  <title xml:lang="en">A sūgīthā on <placeName ref="http://syriaca.org/place/2927">
-                      <!-- WLP: check URI because unsure which church this refers to. -->the Great Church of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                    </placeName>, built by
+                  <title xml:lang="en">A sūgīthā on <placeName ref="http://syriaca.org/place/2927"><!-- WLP: check URI because unsure which church this refers to. -->the Great Church of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></placeName>, built by
                     <persName ref="http://syriaca.org/person/2823">king Abgar</persName> and <persName ref="http://syriaca.org/person/1118">Addai the Apostle</persName>
                   </title>
                   <rubric xml:lang="syr">ܣܘܓܝܬܐ ܥܠ ܥܕܬܐ ܪܒܬܐ ܕܐܘܪܗܝ (<foreign xml:lang="en">marg.</foreign>ܥܠ ܗܝܟܠܐ ܕܒܢܐ ܐܒܓܪ ܘܐܕܝ ܫܠܝܚܐ(</rubric>

--- a/data/tei/770.xml
+++ b/data/tei/770.xml
@@ -142,8 +142,7 @@
                 <author ref="http://syriaca.org/person/13">
                   <persName xml:lang="en">Ephraim</persName>
                 </author>
-                <title xml:lang="en">Madrāshē of <persName ref="http://syriaca.org/person/13">Ephraim</persName> for the Vigils of <persName>the
-                  brethren</persName>
+                <title xml:lang="en">Madrāshē of <persName ref="http://syriaca.org/person/13">Ephraim</persName> for the Vigils of <persName>the brethren</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܕܪ̈ܫܐ ܕܫܗܪܐ ܕܐܚ̈ܐ ܕܡܪܝ ܐܦܪܝܡ</rubric>
                 <note>21 in number</note>
@@ -232,8 +231,7 @@
               </msItem>
               <msItem xml:id="b7" n="16">
                 <locus from="24b"/>
-                <title xml:lang="en">An alphabetical sūgīthā on <persName>Mary, the niece
-                  of <persName ref="http://syriaca.org/person/1113">Abraham Kīdūnāyā</persName>
+                <title xml:lang="en">An alphabetical sūgīthā on <persName>Mary, the niece of <persName ref="http://syriaca.org/person/1113">Abraham Kīdūnāyā</persName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܣܘܓܝܬܐ ܕܥܠ ܡܪܝܡ ܒܪܬ ܐܚܘܗܝ ܕܐܒܪܗܡ ܩܝܕܘܢܝܐ</rubric>
@@ -312,8 +310,7 @@
                   <author ref="http://syriaca.org/person/13">
                     <persName xml:lang="en">Ephraim</persName>
                   </author>
-                  <title xml:lang="en">On <persName ref="http://syriaca.org/person/1550">Abraham, bishop of
-                    <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
+                  <title xml:lang="en">On <persName ref="http://syriaca.org/person/1550">Abraham, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܐܒܪܗܡ ܐܦܝܣܩܘܦܐ ܕܢܨܝܒܝܢ</rubric>

--- a/data/tei/770.xml
+++ b/data/tei/770.xml
@@ -123,9 +123,7 @@
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
               <title xml:lang="en">A large collection of hymns (<foreign xml:lang="syr">ܩ̈ܠܐ</foreign>, <foreign xml:lang="syr">ܡܕܪ̈ܫܐ</foreign> and <foreign xml:lang="syr">ܣܘ̈ܓܝܬܐ</foreign>),
-                ascribed to <persName ref="http://syriaca.org/person/13">Ephraim</persName>, <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>, and <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                </persName>
+                ascribed to <persName ref="http://syriaca.org/person/13">Ephraim</persName>, <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, and <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
               </title>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a"/>
@@ -231,8 +229,7 @@
               </msItem>
               <msItem xml:id="b7" n="16">
                 <locus from="24b"/>
-                <title xml:lang="en">An alphabetical sūgīthā on <persName>Mary, the niece of <persName ref="http://syriaca.org/person/1113">Abraham Kīdūnāyā</persName>
-                  </persName>
+                <title xml:lang="en">An alphabetical sūgīthā on <persName>Mary, the niece of <persName ref="http://syriaca.org/person/1113">Abraham Kīdūnāyā</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܣܘܓܝܬܐ ܕܥܠ ܡܪܝܡ ܒܪܬ ܐܚܘܗܝ ܕܐܒܪܗܡ ܩܝܕܘܢܝܐ</rubric>
                 <incipit xml:lang="syr">ܐ̇ܬܒ ܘܐ̇ܠܐ ܘܐ̇ܒܟܐ ܥܠ ܚ̈ܝܝ. ܘܝ ܠܝ ܕܡܢܐ ܓܕܫܢܝ. ܘܐܝܟܢܐ ܢܦ̇ܠܬ.
@@ -247,9 +244,7 @@
               </msItem>
               <msItem xml:id="b9" n="18">
                 <locus from="25b"/>
-                <title xml:lang="en">Three madrāshē on <persName ref="http://syriaca.org/person/145">
-                    <!-- WLP - double check this URI as the abstract cited from GEDSH states he came from Tagrit but became patriarch of Antioch. Is this a different Cyriacus or is Wright (or the ms's rubric) mistaken? -->Cyriacus, patriarch of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                  </persName>,</title>
+                <title xml:lang="en">Three madrāshē on <persName ref="http://syriaca.org/person/145"><!-- WLP - double check this URI as the abstract cited from GEDSH states he came from Tagrit but became patriarch of Antioch. Is this a different Cyriacus or is Wright (or the ms's rubric) mistaken? -->Cyriacus, patriarch of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName>,</title>
                 <rubric xml:lang="syr">ܡܕܪ̈ܫܐ ܕܥܠ ܩܘܪܝܩܘܣ ܦܐܛܪܝܐܪܟܐ ܕܬܓܪܝܬ</rubric>
               </msItem>
               <msItem xml:id="b10" n="19">
@@ -310,8 +305,7 @@
                   <author ref="http://syriaca.org/person/13">
                     <persName xml:lang="en">Ephraim</persName>
                   </author>
-                  <title xml:lang="en">On <persName ref="http://syriaca.org/person/1550">Abraham, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                    </persName>
+                  <title xml:lang="en">On <persName ref="http://syriaca.org/person/1550">Abraham, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܐܒܪܗܡ ܐܦܝܣܩܘܦܐ ܕܢܨܝܒܝܢ</rubric>
                   <note>Five hymns; see <bibl>Bickell, nos. xvii—xxi</bibl>.</note>
@@ -646,8 +640,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob</persName>
                   </author>
-                  <title xml:lang="en">On <persName>those who disputed against <persName ref="http://syriaca.org/person/624">Mary</persName>
-                    </persName>
+                  <title xml:lang="en">On <persName>those who disputed against <persName ref="http://syriaca.org/person/624">Mary</persName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܥܠ ܕܪ̈ܘܫܐ ܕܠܘܩܒܠ ܡܪܝܡ: ܕܡܪܝܥܩܘܒ</rubric>
                   <incipit xml:lang="syr">ܒܬܘܠܬܐ ܒܪ̣ܬ݁ ܕܘܝܕ ܗܐ ܩ̇ܝܡܐ ܗ̣ܘܬ݁ ܒܝܬ ܟܢ̈ܫܐ. ܘܛܥܝܢܐ ܛܠܝܐ.

--- a/data/tei/770.xml
+++ b/data/tei/770.xml
@@ -278,9 +278,7 @@
                 <author ref="http://syriaca.org/person/13">
                   <persName xml:lang="en">Ephraim</persName>
                 </author>
-                <title xml:lang="en">Madrāshē from the collection entitled <ref>the Hymns of
-                  <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                  </ref>
+                <title xml:lang="en">Madrāshē from the collection entitled <ref>the Hymns of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></ref>
                 </title>
                 <note>See <bibl>Add. 14,572</bibl>, and <bibl>the edition of Dr. Bickell, S. Ephraemi Syri
                     Carmina Nisibena (Leipzig, 1866), p. 2</bibl>.</note>

--- a/data/tei/773.xml
+++ b/data/tei/773.xml
@@ -376,8 +376,7 @@
                                     <persName xml:lang="en" type="uniform">Gregory of Nazianzus</persName>
                                     <persName xml:lang="en">Gregory Nazianzen</persName>
                                 </author>
-                <title>Extracts from funeral discourses of <persName xml:lang="en" ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                <title>Extracts from funeral discourses of <persName xml:lang="en" ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                                 </title>
                 <msItem xml:id="c18" n="25" defective="false">
                   <locus from="115b" to="116">Foll. 115b-116</locus>

--- a/data/tei/776.xml
+++ b/data/tei/776.xml
@@ -625,8 +625,7 @@
                       Chrysostom</persName>
                   </author>
                   <title xml:lang="en">
-                    <persName ref="http://syriaca.org/person/573">John
-                      Chrysostom</persName>, hom. xi. on <ref target="http://syriaca.org/work/9598">the epist. to the Ephesians</ref>
+                    <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>, hom. xi. on <ref target="http://syriaca.org/work/9598">the epist. to the Ephesians</ref>
                   </title>
                   <rubric xml:lang="syr">ܕܝܘܚܢܢ ܡܢ ܡܐܡܪܐ ܕܝܐ ܕܦܘܫܩܐ ܕܫܠܝܚܐ</rubric>
                 </msItem>

--- a/data/tei/776.xml
+++ b/data/tei/776.xml
@@ -399,13 +399,9 @@
                 <msItem xml:id="c7" n="25">
                   <locus from="61b"/>
                   <title>Translation of <ref target="http://syriaca.org/work/9535">Job</ref> by 
-                    <persName ref="http://syriaca.org/person/842">
-                      Symmachus, <foreign xml:lang="syr">ܣܘܡܟܘܣ</foreign>
-                    </persName>,
+                    <persName ref="http://syriaca.org/person/842">Symmachus, <foreign xml:lang="syr">ܣܘܡܟܘܣ</foreign></persName>,
                     and 
-                    <persName>
-                      Theodotion, <foreign xml:lang="syr">ܬܐܘܪܘܛܝܘܢ</foreign>
-                    </persName>
+                    <persName>Theodotion, <foreign xml:lang="syr">ܬܐܘܪܘܛܝܘܢ</foreign></persName>
                   </title>
                 </msItem>
               </msItem>

--- a/data/tei/777.xml
+++ b/data/tei/777.xml
@@ -113,8 +113,7 @@
               <author ref="http://syriaca.org/person/786">
                 <persName xml:lang="en">Theodotus bishop of Ancyra</persName>
               </author>
-              <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/786">Theodotus, bishop of <placeName>Ancyra</placeName>
-                </persName>, against
+              <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/786">Theodotus, bishop of <placeName>Ancyra</placeName></persName>, against
                 <persName ref="http://syriaca.org/person/655">Nestorius</persName>
               </title>
               <note>It is written in the form of a dialogue between
@@ -152,8 +151,7 @@
               <author ref="http://syriaca.org/person/477">
                 <persName xml:lang="en">Epiphanius of Cyprus</persName>
               </author>
-              <title xml:lang="en">The treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName>Cyprus</placeName>
-                </persName> on "Weights and Measures"</title>
+              <title xml:lang="en">The treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName>Cyprus</placeName></persName> on "Weights and Measures"</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܐܦܝܦܢܝܘܣ̣. ܕܡܛܠ ܟܝ̈ܠܐ ܘܡ̈ܬܩܠܐ</rubric>
               <note>The text agrees substantially with that of <bibl>Add. 14,620<ptr target="https://bl.syriac.uk/ms/360"/>, no. <citedRange unit="entry">6</citedRange>
                 </bibl>; and the margins

--- a/data/tei/777.xml
+++ b/data/tei/777.xml
@@ -113,8 +113,7 @@
               <author ref="http://syriaca.org/person/786">
                 <persName xml:lang="en">Theodotus bishop of Ancyra</persName>
               </author>
-              <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/786">Theodotus, bishop of
-                    <placeName>Ancyra</placeName>
+              <title xml:lang="en">A treatise of <persName ref="http://syriaca.org/person/786">Theodotus, bishop of <placeName>Ancyra</placeName>
                 </persName>, against
                 <persName ref="http://syriaca.org/person/655">Nestorius</persName>
               </title>
@@ -153,8 +152,7 @@
               <author ref="http://syriaca.org/person/477">
                 <persName xml:lang="en">Epiphanius of Cyprus</persName>
               </author>
-              <title xml:lang="en">The treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of
-                    <placeName>Cyprus</placeName>
+              <title xml:lang="en">The treatise of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName>Cyprus</placeName>
                 </persName> on "Weights and Measures"</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܐܦܝܦܢܝܘܣ̣. ܕܡܛܠ ܟܝ̈ܠܐ ܘܡ̈ܬܩܠܐ</rubric>
               <note>The text agrees substantially with that of <bibl>Add. 14,620<ptr target="https://bl.syriac.uk/ms/360"/>, no. <citedRange unit="entry">6</citedRange>

--- a/data/tei/778.xml
+++ b/data/tei/778.xml
@@ -179,8 +179,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en" type="supplied">Severus of Antioch</persName>
                   </author>
-                  <title>To <persName>Joannes Scholasticus of <placeName ref="http://syriaca.org/place/40">Bostra</placeName>
-                    </persName>
+                  <title>To <persName>Joannes Scholasticus of <placeName ref="http://syriaca.org/place/40">Bostra</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ ܐܓܪܬܐ ܕܠܘܬ ܝܘܚܢܢ
                     ܣܟܠܣܛܝܩܐ ܒܘܨܪܐ. ܕܟܬܒܗ̣̇ ܟܕ ܐܝܬܘܗܝ ܒܐܪܕܘܦܝܐ.<locus from="72b" to="72b"/>

--- a/data/tei/785.xml
+++ b/data/tei/785.xml
@@ -188,8 +188,7 @@
                   <author ref="http://syriaca.org/person/99">
                     <persName xml:lang="en" type="supplied">Severus Sabocht, bishop of Kinnesrin</persName>
                   </author>
-                  <title xml:lang="en">A letter to <persName>Jonas, the
-                                        periodeutes</persName>, explanatory of some points in the
+                  <title xml:lang="en">A letter to <persName>Jonas, the periodeutes</persName>, explanatory of some points in the
                                     <title xml:lang="la">Ars Rhetorica</title> of <persName ref="http://syriaca.org/person/342">Aristotle</persName>
                 </title>
                   <rubric xml:lang="syr">
@@ -516,8 +515,7 @@
                     <persName xml:lang="en">Jacob of
                                         Batnae</persName>
                   </author>
-                  <title xml:lang="en">A sūgīthā of <persName>Jacob of
-                                            Batnae</persName>
+                  <title xml:lang="en">A sūgīthā of <persName>Jacob of Batnae</persName>
                   </title>
                   <rubric xml:lang="syr">ܣܘܓܝܬܐ ܕܡܪܝܥܩܘܒ</rubric>
                 </msItem>

--- a/data/tei/80.xml
+++ b/data/tei/80.xml
@@ -217,8 +217,7 @@
                   </msItem>
                   <msItem xml:id="d11" n="14">
                     <locus from="17b" to="19">Foll. 17b-19</locus>
-                    <title xml:lang="en">To the abbat of <placeName ref="http://syriaca.org/place/343">the convent of
-                                    Bassus</placeName>.</title>
+                    <title xml:lang="en">To the abbat of <placeName ref="http://syriaca.org/place/343">the convent of Bassus</placeName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܪܝܫ ܕܝܪܐ ܕܕܝܪܐ ܕܒܣܘܣ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܓ ܗ̇ܝ
                                     ܕܫ܏ܡܗ.
@@ -365,9 +364,7 @@
                   </msItem>
                   <msItem xml:id="d29" n="32">
                     <locus from="33a" to="33">Foll. 33a-33</locus>
-                    <title xml:lang="en">To the monks of the <placeName>convent of
-                                       <persName>Mār Isaac</persName>
-                      </placeName>.</title>
+                    <title xml:lang="en">To the monks of the <placeName>convent of <persName>Mār Isaac</persName></placeName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܪ̈ܝܐ ܢܟ̈ܦܐ ܕܛܘܒܢܐ ܡܪܝ ܐܝܣܚܩ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܗ ܗ̇ܝ
                                     ܕ܏ܨܙ.
@@ -481,9 +478,7 @@
                   </msItem>
                   <msItem xml:id="d43" n="46">
                     <locus from="43b" to="44">Foll. 43b-44</locus>
-                    <title xml:lang="en">To the abbat of the <placeName ref=" http://syriaca.org/place/635">convent of <persName ref="http://syriaca.org/person/744">Mār
-                                    Simeon</persName>
-                      </placeName>.</title>
+                    <title xml:lang="en">To the abbat of the <placeName ref=" http://syriaca.org/place/635">convent of <persName ref="http://syriaca.org/person/744">Mār Simeon</persName></placeName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܪܝܫ ܕܝܪܐ ܕܕܝܪܗ ܕܩܕܝܫܐ ܡܪܝ
                                  ܫܡܥܘܢ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
@@ -781,8 +776,7 @@
                   </msItem>
                   <msItem xml:id="d73" n="80">
                     <locus from="91a" to="91">Foll. 91a-91</locus>
-                    <title xml:lang="en">To the <placeName>convent at
-                                    Tagae</placeName>.</title>
+                    <title xml:lang="en">To the <placeName>convent at Tagae</placeName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܪܐ ܕܒܛܐܓܐܝܣ (<foreign xml:lang="grc">ΤΑΓΑΙⲤ</foreign>). </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ. ܗ̇ܝ
                                     ܕܪ܏ܡܚ.

--- a/data/tei/80.xml
+++ b/data/tei/80.xml
@@ -115,9 +115,7 @@
               <author ref="http://syriaca.org/person/51">
                 <persName xml:lang="en">Severus of Antioch</persName>
               </author>
-              <title xml:lang="en">The sixth book of the select epistles of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>, translated from the Greek by the <persName ref="http://syriaca.org/person/1014">priest Athanasius of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                </persName>, A.Gr. 980, A.D. 669. </title>
+              <title xml:lang="en">The sixth book of the select epistles of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, translated from the Greek by the <persName ref="http://syriaca.org/person/1014">priest Athanasius of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName>, A.Gr. 980, A.D. 669. </title>
               <rubric xml:lang="syr">ܟܬܒܐ ܕܫܬܐ ܕܐܓܪ̈ܬܐ ܗܩ̈ܠܘܓܐ ܐܘܟܝܬ ܡ̈ܓܒܝܬܐ̣. ܕܡܢ
                         ܐܓܪ̈ܬܗ ܕܩܕܝܫܐ ܣܐܘܪܐ ܦܛܪܝܪܟܝܣ ܕܐܢܛܝܘܟܝܐ ܕܣܘܪܝܐ</rubric>
               <msItem xml:id="b1" n="2" defective="true">
@@ -148,9 +146,7 @@
                   </msItem>
                   <msItem xml:id="d2" n="5">
                     <locus from="4b" to="6">Foll. 4b-6</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop and metropolitan of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
-                        </placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop and metropolitan of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName></placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝܣܩܘܦܐ (marg. <foreign xml:lang="grc">ⲤΟΛⲰΝ</foreign>) ܘܡܝܛܪܦܘܠܝܛܝܣ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܩܕܡ ܏ܐܦܝܣ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ ܕ܏ܩܗ
                                     ܏ܕܩܘ..
@@ -174,8 +170,7 @@
                   </msItem>
                   <msItem xml:id="d5" n="8">
                     <locus from="13a" to="14">Foll. 13a-14</locus>
-                    <title xml:lang="en">To <persName>Peter, bishop of <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Peter, bishop of <placeName ref="http://syriaca.org/place/11">Apamea</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܛܪܘܣ ܐܦܝ܏ܣ ܕܐܦܡܝܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܓ ܗ̇ܝ ܕܚܡܫ.
                     </quote>
@@ -190,8 +185,7 @@
                   </msItem>
                   <msItem xml:id="d7" n="10">
                     <locus from="15a" to="15">Foll. 15a-15</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2527">Castor, bishop of <placeName>Perge</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2527">Castor, bishop of <placeName>Perge</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܐܣܛܘܪ ܐܦܝܣܩܘܦܐ ܕܦܪܓܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ. ܡܢ ܟܬܒܐ ܏ܕܓ ܗ̇ܝ
                                     ܕܪ܏ܠܒ.
@@ -207,8 +201,7 @@
                   </msItem>
                   <msItem xml:id="d9" n="12">
                     <locus from="16b" to="17">Foll. 16b-17</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2533">Stephen, bishop of <placeName ref="http://syriaca.org/place/203">Tripolis</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2533">Stephen, bishop of <placeName ref="http://syriaca.org/place/203">Tripolis</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܛܦܢܘܣ ܐܦܝܣܩܘܦܐ ܕܛܪܝܦܘܠܝܣ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ ܕܪܥ܏ܘ.
                                     ܕܪ܏ܥܙ.
@@ -243,8 +236,7 @@
                   </msItem>
                   <msItem xml:id="d13" n="16">
                     <locus from="19b" to="20">Foll. 19b-20</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546"> Entrechius (<foreign xml:lang="grc">᾿Εντρέχιος</foreign>), bishop of <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546"> Entrechius (<foreign xml:lang="grc">᾿Εντρέχιος</foreign>), bishop of <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܛܪܟܝܘܣ ܐܦܝܣܩܘܦܐ ܕܐܢܙܪܒܐ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܓ. ܗ̇ܝ
                                  ܏ܕܫܨܙ. ܕ܏ܫܨܚ.
@@ -252,8 +244,7 @@
                   </msItem>
                   <msItem xml:id="d14" n="17">
                     <locus from="21a" to="21">Foll. 21a-21</locus>
-                    <title xml:lang="en">To <persName>Antonine, bishop of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Antonine, bishop of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܛܘܢܝܢܘܣ ܐܦܝܣܩܘܦܐ ܕܚܠܒ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܕ܏ܣܗ.
@@ -284,8 +275,7 @@
                   </msItem>
                   <msItem xml:id="d18" n="21">
                     <locus from="24b" to="24">Foll. 24b-24</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546">Entrechius, bishop of <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546">Entrechius, bishop of <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܛܪܟܝܘܣ ܐܦܝܣܩܦܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܏ܕܩܟܓ.
@@ -293,9 +283,7 @@
                   </msItem>
                   <msItem xml:id="d19" n="22">
                     <locus from="25a" to="25">Foll. 25a-25</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
-                        </placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName></placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝ܏ܣ ܕܣܠܘܩܝܐ ܕܐܝܣܘܪܝܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܕ܏ܩܡܛ.
@@ -330,9 +318,7 @@
                   </msItem>
                   <msItem xml:id="d23" n="26">
                     <locus from="29b" to="30">Foll. 29b-30</locus>
-                    <title xml:lang="en">To <persName>Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
-                        </placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName></placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝܣܩܘܦܐ ܕܣܠܘܩܝܐ ܕܐܝܣܘܪܝܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܏ܕܪܥ.
@@ -346,8 +332,7 @@
                   </msItem>
                   <msItem xml:id="d25" n="28">
                     <locus from="31a" to="31">Foll. 31a-31</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ. </rubric>
                     <quote xml:lang="syr">ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܕܫ܏ܠܐ.
@@ -355,9 +340,7 @@
                   </msItem>
                   <msItem xml:id="d26" n="29">
                     <locus from="31b" to="31">Foll. 31b-31</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Selcucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
-                        </placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Selcucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName></placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝܣܩܘܦܐ ܕܣܠܘܩܝܐ ܕܐܝܣܘܪܝܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܕܫ܏ܠܚ.
@@ -374,8 +357,7 @@
                   </msItem>
                   <msItem xml:id="d28" n="31">
                     <locus from="32b" to="32">Foll. 32b-32</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2574">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/75">Doliche</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2574">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/75">Doliche</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܝܠܘܟܣܝܢܘܣ ܐܦܝܣܩܦܐ ܕܕܠܝܟ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܗ ܗ̇ܝ
                                     ܏ܕܣܘ.
@@ -409,8 +391,7 @@
                   </msItem>
                   <msItem xml:id="d32" n="35">
                     <locus from="36a" to="36">Foll. 36a-36</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2581">John, bishop of <placeName>Alexandria the less (Alexandretta or Scandarūn)</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2581">John, bishop of <placeName>Alexandria the less (Alexandretta or Scandarūn)</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܝܘܚܢܢ ܐܦܝܣܩܦܐ ܕܐܠܟܣܢܕܪܝܐ
                                  ܙܥܘܪܬܐ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ ܗ̇ܝ
@@ -419,8 +400,7 @@
                   </msItem>
                   <msItem xml:id="d33" n="36">
                     <locus from="36b" to="36">Foll. 36b-36</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ ܗ̇ܝ
                                     ܕ܏ܩܦܘ.
@@ -446,16 +426,14 @@
                   </msItem>
                   <msItem xml:id="d36" n="39">
                     <locus from="37b" to="37">Foll. 37b-37</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2404">deacon Eusebius of <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2404">deacon Eusebius of <placeName ref="http://syriaca.org/place/11">Apamea</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܘܣܒܝܘܣ ܡܫܡܫܢܐ ܕܒܐܦܡܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕܪ܏ܝܚ
                     </quote>
                   </msItem>
                   <msItem xml:id="d37" n="40">
                     <locus from="37b" to="38">Foll. 37b-38</locus>
-                    <title xml:lang="en">To <persName>Simeon, bishop of <placeName>Kinnesrīn</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Simeon, bishop of <placeName>Kinnesrīn</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܫܡܥܘܢ ܐܦ܏ܝܣ ܕܩܢܫܪܝܢ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦ܏ܝܣܩܘܦܘ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕܪ܏ܠܚ
                                     ܕ܏ܪܡ.
@@ -487,9 +465,7 @@
                   </msItem>
                   <msItem xml:id="d41" n="44">
                     <locus from="41b" to="42">Foll. 41b-42</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
-                        </placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName></placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝܣܩܘܦܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕ܏ܢܐ.
                                     ܕ܏ܡܒ.
@@ -516,8 +492,7 @@
                   </msItem>
                   <msItem xml:id="d44" n="47">
                     <locus from="44b" to="44">Foll. 44b-44</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2420">Eutychianus, magistrate of <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2420">Eutychianus, magistrate of <placeName ref="http://syriaca.org/place/11">Apamea</placeName></persName>.</title>
                     <rubric xml:lang="syr">(<foreign xml:lang="grc">ΕΥΤΥΧΙΑΝΟⲤ</foreign>) ܠܘܬ ܐܘܛܘܟܝܢܘܣ ܪܝܫܐ ܕܐܦܡܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
                                     ܕ܏ܩܨ
@@ -541,8 +516,7 @@
                   </msItem>
                   <msItem xml:id="d47" n="50">
                     <locus from="46b" to="46">Foll. 46b-46</locus>
-                    <title xml:lang="en">To <persName>Cassianus, bishop of <placeName>Bostra</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Cassianus, bishop of <placeName>Bostra</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܣܝܢܐ ܐܦܝܣܩܘܦܐ ܕܒܘܨܛܪܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
                                     ܕ܏ܪܦܚ.
@@ -550,8 +524,7 @@
                   </msItem>
                   <msItem xml:id="d48" n="51">
                     <locus from="47a" to="47">Foll. 47a-47</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/44">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/44">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܝܠܘܟܣܝܢܘܣ ܐܦܝܣܩܘܦܐ ܕܡܒܘܓ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܝ ܗ̇ܝ
                                     ܕܪ܏ܨܗ.
@@ -654,8 +627,7 @@
                               ܐܢܘܢ</rubric>
                   <msItem xml:id="d57" n="62">
                     <locus from="71a" to="71">Foll. 71a-71</locus>
-                    <title xml:lang="en">To the <persName>Comes Anastasius, the son of <persName>Sergius</persName>
-                      </persName>.</title>
+                    <title xml:lang="en">To the <persName>Comes Anastasius, the son of <persName>Sergius</persName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܣܛܐܣܝܣ ܩܘܡܝܣ ܒܪܗ ܕܣܪܓܝܣ</rubric>
                     <quote xml:lang="syr">
                       ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ.
@@ -698,8 +670,7 @@
                               ܡܐ ܕܡܨ̇ܠܝܢ</rubric>
                   <msItem xml:id="d61" n="67">
                     <locus from="78b" to="79">Foll. 78b-79</locus>
-                    <title xml:lang="en">To <persName>Zachariah of <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Zachariah of <placeName ref="http://syriaca.org/place/1473">Pelusium</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܙܟܪܝܐ ܗ̇ܘ ܕܒܦܝܠܘܣܝܘܢ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ. ܡܢ ܟܬܒܐ ܏ܐ. ܗ̇ܝ ܕ܏ܪܚ.
                                     ܪ܏ܛ.
@@ -707,8 +678,7 @@
                   </msItem>
                   <msItem xml:id="d62" n="68">
                     <locus from="80a" to="81">Foll. 80a-81</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/839">priest Ammonius, of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                      </persName>, concerning the naming of
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/839">priest Ammonius, of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>, concerning the naming of
                                     <persName>Peter (Mongus)</persName>, who was bishop of
                                     <placeName>Alexandrias</placeName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܡܘܢܝܘܣ ܩܫܝܫܐ ܕܐܠܟܣܢܕܪܝܐ ܕܒܗ̇ ܫܘܕܥܗ̣
@@ -719,8 +689,7 @@
                   <msItem xml:id="d63" n="69">
                     <locus from="81b" to="82">Foll. 81b-82</locus>
                     <title xml:lang="en">To <persName ref="http://syriaca.org/person/2430">Dioscorus (II.),
-                                    archbishop of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                      </persName>.</title>
+                                    archbishop of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܣܩܘܪܘܣ ܪܝܫ ܏ܐܦܝ̈ܣ
                                  ܕܐܠܟܣܢܕܪܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܐ. ܗ̇ܝ
@@ -729,8 +698,7 @@
                   </msItem>
                   <msItem xml:id="d64" n="70">
                     <locus from="82b" to="82">Foll. 82b-82</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܒ. ܗ̇ܝ
                                     ܏ܕ.
@@ -747,8 +715,7 @@
                   </msItem>
                   <msItem xml:id="d66" n="72">
                     <locus from="83b" to="84">Foll. 83b-84</locus>
-                    <title xml:lang="en">To the <persName>Comes John of <placeName ref="http://syriaca.org/place/1471">Antaradus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To the <persName>Comes John of <placeName ref="http://syriaca.org/place/1471">Antaradus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܝܘܚܢܢ ܩܘܡܝܣ ܕܡܢ ܐܢܛܐܪܕܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܓ. ܗ̇ܝ
                                     ܕ܏ܫܨ.
@@ -831,8 +798,7 @@
                   </msItem>
                   <msItem xml:id="d75" n="82">
                     <locus from="93b" to="94">Foll. 93b-94</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
-                      </persName>.</title>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName></persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ. ܗ̇ܝ
                                     ܕ܏ܩܥܚ.

--- a/data/tei/80.xml
+++ b/data/tei/80.xml
@@ -140,8 +140,7 @@
                               ܕܝܠܗܘܢ.</rubric>
                   <msItem xml:id="d1" n="4">
                     <locus from="1b" to="4">Foll. 1b-4</locus>
-                    <title xml:lang="en">To the <persName>bishop
-                                    Constantine</persName>.</title>
+                    <title xml:lang="en">To the <persName>bishop Constantine</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܘܣܛܢܛܝܢܘܣ ܐܦܝܣܩܘܦܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܩܕܡ ܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕܬܪܝܢ ܗ̇ܝ
                                     ܕܬܪܬܥܣܪ̈ܐ.
@@ -149,8 +148,7 @@
                   </msItem>
                   <msItem xml:id="d2" n="5">
                     <locus from="4b" to="6">Foll. 4b-6</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop and
-                                    metropolitan of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2417">Solon, bishop and metropolitan of <placeName ref="http://syriaca.org/place/174">Seleucia in <placeName ref="http://syriaca.org/place/99">Isauria</placeName>
                         </placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܣܘܠܘܢ ܐܦܝܣܩܘܦܐ (marg. <foreign xml:lang="grc">ⲤΟΛⲰΝ</foreign>) ܘܡܝܛܪܦܘܠܝܛܝܣ.</rubric>
@@ -184,8 +182,7 @@
                   </msItem>
                   <msItem xml:id="d6" n="9">
                     <locus from="14b" to="14">Foll. 14b-14</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2526">bishop
-                                 Nicias</persName>.</title>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2526">bishop Nicias</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܢܝܩܝܐ ܐܦܝܣܩܘܦܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ. ܡܢ ܟܬܒܐ ܏ܕܓ ܗ̇ܝ
                                     ܕ܏ܩܥܐ.
@@ -219,8 +216,7 @@
                   </msItem>
                   <msItem xml:id="d10" n="13">
                     <locus from="17b" to="17">Foll. 17b-17</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2536">bishop
-                                 Eucharius</persName>.</title>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2536">bishop Eucharius</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܦܝܣܩܘܦܐ <foreign xml:lang="grc">ΕΥΧΑΡΙΟⲤ</foreign>) ܐܘܟܐܪܝܘܣ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ (sic) ܗ̇ܝ
                                  ܕ܏ܩܡܒ ܕ܏ܫܡܓ.
@@ -256,8 +252,7 @@
                   </msItem>
                   <msItem xml:id="d14" n="17">
                     <locus from="21a" to="21">Foll. 21a-21</locus>
-                    <title xml:lang="en">To <persName>Antonine, bishop of
-                                       <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
+                    <title xml:lang="en">To <persName>Antonine, bishop of <placeName ref="http://syriaca.org/place/18">Aleppo</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܛܘܢܝܢܘܣ ܐܦܝܣܩܘܦܐ ܕܚܠܒ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
@@ -289,8 +284,7 @@
                   </msItem>
                   <msItem xml:id="d18" n="21">
                     <locus from="24b" to="24">Foll. 24b-24</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546">Entrechius, bishop of
-                                       <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2546">Entrechius, bishop of <placeName ref="http://syriaca.org/place/9">Anazarbus</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܛܪܟܝܘܣ ܐܦܝܣܩܦܐ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
@@ -346,15 +340,13 @@
                   </msItem>
                   <msItem xml:id="d24" n="27">
                     <locus from="30b" to="30">Foll. 30b-30</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2568">Theotecnus the
-                                    archiater</persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2568">Theotecnus the archiater</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܬܐܘܛܩܢܘܣ (<foreign xml:lang="grc">ΘΕΟΤΕΚΝΟⲤ</foreign>) ܐܪܟܝܛܐܛܪܘܣ ܐܘܟܝܬ ܪܝܫ ܐܣܘ̈ܬܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣ܏ܩܘ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ ܕܪ܏ܨܓ. </quote>
                   </msItem>
                   <msItem xml:id="d25" n="28">
                     <locus from="31a" to="31">Foll. 31a-31</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of
-                                       <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ. </rubric>
                     <quote xml:lang="syr">ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
@@ -382,8 +374,7 @@
                   </msItem>
                   <msItem xml:id="d28" n="31">
                     <locus from="32b" to="32">Foll. 32b-32</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2574">Philoxenus, bishop of
-                                       <placeName ref="http://syriaca.org/place/75">Doliche</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2574">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/75">Doliche</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܝܠܘܟܣܝܢܘܣ ܐܦܝܣܩܦܐ ܕܕܠܝܟ. </rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܗ ܗ̇ܝ
@@ -418,9 +409,7 @@
                   </msItem>
                   <msItem xml:id="d32" n="35">
                     <locus from="36a" to="36">Foll. 36a-36</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2581">John, bishop of
-                                       <placeName>Alexandria the less (Alexandretta or
-                                       Scandarūn)</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2581">John, bishop of <placeName>Alexandria the less (Alexandretta or Scandarūn)</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܝܘܚܢܢ ܐܦܝܣܩܦܐ ܕܐܠܟܣܢܕܪܝܐ
                                  ܙܥܘܪܬܐ.</rubric>
@@ -430,8 +419,7 @@
                   </msItem>
                   <msItem xml:id="d33" n="36">
                     <locus from="36b" to="36">Foll. 36b-36</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of
-                                       <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ ܗ̇ܝ
@@ -450,8 +438,7 @@
                   </msItem>
                   <msItem xml:id="d35" n="38">
                     <locus from="37a" to="37">Foll. 37a-37</locus>
-                    <title xml:lang="en">To the <persName>priest
-                                    Eustathius</persName>.</title>
+                    <title xml:lang="en">To the <persName>priest Eustathius</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܘܣܛܬܝܘܣ ܩܫܝܫܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕ܏ܩܡ.
                                  ܕ܏ܩܡܒ. 
@@ -459,8 +446,7 @@
                   </msItem>
                   <msItem xml:id="d36" n="39">
                     <locus from="37b" to="37">Foll. 37b-37</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2404">deacon Eusebius of
-                                       <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2404">deacon Eusebius of <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܘܣܒܝܘܣ ܡܫܡܫܢܐ ܕܒܐܦܡܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕܪ܏ܝܚ
@@ -468,8 +454,7 @@
                   </msItem>
                   <msItem xml:id="d37" n="40">
                     <locus from="37b" to="38">Foll. 37b-38</locus>
-                    <title xml:lang="en">To <persName>Simeon, bishop of
-                                       <placeName>Kinnesrīn</placeName>
+                    <title xml:lang="en">To <persName>Simeon, bishop of <placeName>Kinnesrīn</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܫܡܥܘܢ ܐܦ܏ܝܣ ܕܩܢܫܪܝܢ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦ܏ܝܣܩܘܦܘ ܡܢ ܟܬܒܐ ܏ܕܙ ܗ̇ܝ ܕܪ܏ܠܚ
@@ -531,8 +516,7 @@
                   </msItem>
                   <msItem xml:id="d44" n="47">
                     <locus from="44b" to="44">Foll. 44b-44</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2420">Eutychianus, magistrate of
-                                       <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2420">Eutychianus, magistrate of <placeName ref="http://syriaca.org/place/11">Apamea</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">(<foreign xml:lang="grc">ΕΥΤΥΧΙΑΝΟⲤ</foreign>) ܠܘܬ ܐܘܛܘܟܝܢܘܣ ܪܝܫܐ ܕܐܦܡܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
@@ -541,8 +525,7 @@
                   </msItem>
                   <msItem xml:id="d45" n="48">
                     <locus from="45a" to="45">Foll. 45a-45</locus>
-                    <title xml:lang="en">To <persName>Conon, the chief officer of
-                                    police</persName>.</title>
+                    <title xml:lang="en">To <persName>Conon, the chief officer of police</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܘܢܘܢ ܪܕ̇ܦ ܠܣ̈ܛܝܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
                                     ܕ܏ܪܠܙ.
@@ -558,8 +541,7 @@
                   </msItem>
                   <msItem xml:id="d47" n="50">
                     <locus from="46b" to="46">Foll. 46b-46</locus>
-                    <title xml:lang="en">To <persName>Cassianus, bishop of
-                          <placeName>Bostra</placeName>
+                    <title xml:lang="en">To <persName>Cassianus, bishop of <placeName>Bostra</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܣܝܢܐ ܐܦܝܣܩܘܦܐ ܕܒܘܨܛܪܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܘܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܚ ܗ̇ܝ
@@ -568,8 +550,7 @@
                   </msItem>
                   <msItem xml:id="d48" n="51">
                     <locus from="47a" to="47">Foll. 47a-47</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/44">Philoxenus, bishop of
-                                       <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/44">Philoxenus, bishop of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܝܠܘܟܣܝܢܘܣ ܐܦܝܣܩܘܦܐ ܕܡܒܘܓ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܝ ܗ̇ܝ
@@ -596,8 +577,7 @@
                   </msItem>
                   <msItem xml:id="d51" n="54">
                     <locus from="52b" to="53">Foll. 52b-53</locus>
-                    <title xml:lang="en">To the <persName>priest
-                                 Philip</persName>.</title>
+                    <title xml:lang="en">To the <persName>priest Philip</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܦܝܠܝܦܘܣ ܩܫܝܫܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܬܪ ܪܕܘܦܝܐ ܡܢ ܟܬܒܐ ܏ܕܒ ܗ̇ܝ
                                     ܕ܏ܡ.
@@ -674,8 +654,7 @@
                               ܐܢܘܢ</rubric>
                   <msItem xml:id="d57" n="62">
                     <locus from="71a" to="71">Foll. 71a-71</locus>
-                    <title xml:lang="en">To the <persName>Comes Anastasius, the son
-                                    of <persName>Sergius</persName>
+                    <title xml:lang="en">To the <persName>Comes Anastasius, the son of <persName>Sergius</persName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܣܛܐܣܝܣ ܩܘܡܝܣ ܒܪܗ ܕܣܪܓܝܣ</rubric>
                     <quote xml:lang="syr">
@@ -693,8 +672,7 @@
                   </msItem>
                   <msItem xml:id="d59" n="64">
                     <locus from="72b" to="75">Foll. 72b-75</locus>
-                    <title xml:lang="en">To the <persName>deacon
-                                 Mishael</persName>.</title>
+                    <title xml:lang="en">To the <persName>deacon Mishael</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܡܝܫܐܝܠ ܡܫܡܫܢܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܬܪ ܪܕܘܦܝܐ ܡܢ ܟܬܒܐ ܏ܕܙ. ܗ̇ܝ
                                     ܏ܕܠ.
@@ -729,8 +707,7 @@
                   </msItem>
                   <msItem xml:id="d62" n="68">
                     <locus from="80a" to="81">Foll. 80a-81</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/839">priest Ammonius, of
-                                       <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/839">priest Ammonius, of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                       </persName>, concerning the naming of
                                     <persName>Peter (Mongus)</persName>, who was bishop of
                                     <placeName>Alexandrias</placeName>.</title>
@@ -752,8 +729,7 @@
                   </msItem>
                   <msItem xml:id="d64" n="70">
                     <locus from="82b" to="82">Foll. 82b-82</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of
-                                       <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܢܘܣܝܘܣ ܐܦܝܣܩܘܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܒ. ܗ̇ܝ
@@ -762,9 +738,7 @@
                   </msItem>
                   <msItem xml:id="d65" n="71">
                     <locus from="83a" to="83">Foll. 83a-83</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/31">Cosmas, abbat of the
-                                       <placeName ref="http://syriaca.org/place/1474">convent of
-                                       Cyrus</placeName> (?)</persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/31">Cosmas, abbat of the <placeName ref="http://syriaca.org/place/1474">convent of Cyrus</placeName> (?)</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܩܘܣܡܐ ܪܝܫܕܝܪܐ ܕܕܝܪܗ ܕܛܘܒܢܐ ܩܘܪܘܣ ܐܘܟܝܬ
                                  ܟܘܪܝܫ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܒ. ܗ̇ܝ
@@ -782,8 +756,7 @@
                   </msItem>
                   <msItem xml:id="d67" n="73">
                     <locus from="85a" to="85">Foll. 85a-85</locus>
-                    <title xml:lang="en">To the <persName>abbat
-                                 John</persName>.</title>
+                    <title xml:lang="en">To the <persName>abbat John</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܒܐ ܝܘܚܢܢ ܗ̇ܘ ܩܢܘܦܛܝܣ(?).</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܐܫܬܟܚ ܠܒܪ ܡܢ ܏ܟܓ ܟܬܒ̈ܐ. ܗ̇ܝ
                                     ܏ܕ.
@@ -799,9 +772,7 @@
                   </msItem>
                   <msItem xml:id="d69" n="75">
                     <locus from="86b" to="86">Foll. 86b-86</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2480">Andrew the reader
-                                       (<foreign xml:lang="grc">ἀναγνώστης</foreign>) and notary
-                                       (<foreign xml:lang="grc">νοτάριος</foreign>)</persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2480">Andrew the reader (<foreign xml:lang="grc">ἀναγνώστης</foreign>) and notary (<foreign xml:lang="grc">νοτάριος</foreign>)</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܐܢܕܪܐܐ ܩܪܘܝܐ ܘܢܘܿܛܪܐ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܬܪ ܪܕܘܦܝܐ. ܡܢ ܟܬܒܐ ܏ܕܛ. ܗ̇ܝ
                                     ܏ܕܣܒ.
@@ -835,8 +806,7 @@
                   </msItem>
                   <msItem xml:id="d72" n="79">
                     <locus from="91a" to="91">Foll. 91a-91</locus>
-                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2526">bishop
-                                 Nicias</persName>.</title>
+                    <title xml:lang="en">To the <persName ref="http://syriaca.org/person/2526">bishop Nicias</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܢܝܩܝܐ ܐܦܝܣܩܘܦܐ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܏ܕܓ ܗ̇ܝ
                                     ܕ܏ܫܟܓ.
@@ -853,8 +823,7 @@
                   </msItem>
                   <msItem xml:id="d74" n="81">
                     <locus from="92a" to="93">Foll. 92a-93</locus>
-                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2568">Theotecnus, the priest and
-                                    archiater</persName>.</title>
+                    <title xml:lang="en">To <persName ref="http://syriaca.org/person/2568">Theotecnus, the priest and archiater</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܬܐܘܛܩܢܘܣ ܩܫܝܫܐ ܘܐܪܟܝܐܛܪܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ. ܗ̇ܝ
                                     ܕ܏ܩܣܐ.
@@ -862,8 +831,7 @@
                   </msItem>
                   <msItem xml:id="d75" n="82">
                     <locus from="93b" to="94">Foll. 93b-94</locus>
-                    <title xml:lang="en">To <persName>Dionysius, bishop of
-                                       <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
+                    <title xml:lang="en">To <persName>Dionysius, bishop of <placeName ref="http://syriaca.org/place/196">Tarsus</placeName>
                       </persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܕܝܘܢܘܣܝܘܣ ܐܦܝܣܩܦܐ ܕܛܐܪܣܘܣ</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐܦܝܣܩܦܘܬܐ ܡܢ ܟܬܒܐ ܕ܏ܘ. ܗ̇ܝ
@@ -875,8 +843,7 @@
                     <title xml:lang="en">To those who say that it is necessary that
                                  persons who have participated in the doctrines of the council of
                                     <placeName ref="http://syriaca.org/place/622">Chalcedon</placeName>, but who repent and anathematize the
-                                 upholders of the doctrine of the two natures in our <persName ref="http://syriaca.org/person/2245">Lord Jesus
-                                    Christ</persName> after the ineffable union, and run after the
+                                 upholders of the doctrine of the two natures in our <persName ref="http://syriaca.org/person/2245">Lord Jesus Christ</persName> after the ineffable union, and run after the
                                  orthodox faith, should be anointed (baptised) afresh.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܗ̇ܢܘܢ ܕܐܡܪܝܢ ܕܙܕܩ̇ ܕܢܬܡܫܚܘܢ ܡܢܕܪܝܫ
                                  ܐܝܠܝܢ ܕܐܫܬܘܬܦܘ ܠܣܘܢܕܘܣ ܗ̇ܝ ܕܒܟܠܩܝܕܘܢܐ̇. ܘܡܬܬܘܝܢ ܘܡܚܪܡܝܢ ܠܐܝܠܝܢ
@@ -902,8 +869,7 @@
                   <note>It consists of only one letter.</note>
                   <msItem xml:id="d77" n="85">
                     <locus from="99a" to="100">Foll. 99a-100</locus>
-                    <title xml:lang="en">To the <persName>chamberlain
-                                    Mishael</persName>.</title>
+                    <title xml:lang="en">To the <persName>chamberlain Mishael</persName>.</title>
                     <rubric xml:lang="syr">ܠܘܬ ܡܝܫܐܝܠ ܩܘܒܘܩܠܪܐ.</rubric>
                     <quote xml:lang="syr">ܡܢ ܗܠܝܢ ܕܒܐ܏ܦܝܣܩܦܘ ܡܢ ܟܬܒܐ ܏ܕ ܗ̇ܝ
                                     ܏ܕܩ.
@@ -913,8 +879,7 @@
                 <msItem xml:id="c7" n="86" defective="true">
                   <locus>Foll. 100b-103</locus>
                   <title xml:lang="en">To fill up the remaining leaves, the scribe
-                              has added some extracts from the writings of <persName ref="http://syriaca.org/person/573">John
-                              Chrysostom</persName>.</title>
+                              has added some extracts from the writings of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName>.</title>
                   <msItem xml:id="d78" n="87">
                     <locus from="100b" to="101">Foll. 100b-101</locus>
                     <title xml:lang="en">From the eleventh homily on the epistle of

--- a/data/tei/805.xml
+++ b/data/tei/805.xml
@@ -336,8 +336,7 @@
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
                 <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">
-                  Jacob of Batnae
-              </persName>
+                  Jacob of Batnae </persName>
                 </title>
                 <msItem xml:id="p2b1" n="2" defective="true">
                   <locus from="15a" to="25"/>

--- a/data/tei/805.xml
+++ b/data/tei/805.xml
@@ -335,8 +335,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">
-                  Jacob of Batnae </persName>
+                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae </persName>
                 </title>
                 <msItem xml:id="p2b1" n="2" defective="true">
                   <locus from="15a" to="25"/>

--- a/data/tei/811.xml
+++ b/data/tei/811.xml
@@ -532,8 +532,7 @@
                     <persName xml:lang="en">Jacob of
                                         Batnae</persName>
                   </author>
-                  <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                                        Batnae</persName>
+                  <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                   </title>
                   <msItem xml:id="p2_1b3" n="5">
                     <locus from="23a"/>
@@ -583,8 +582,7 @@
                     <persName xml:lang="en">Isaac of
                                         Antioch</persName>
                   </author>
-                  <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/17">Isaac of
-                                        Antioch</persName>
+                  <title xml:lang="en">Discourses of <persName ref="http://syriaca.org/person/17">Isaac of Antioch</persName>
                   </title>
                   <msItem xml:id="p2_1b5" n="9">
                     <locus from="31b"/>

--- a/data/tei/815.xml
+++ b/data/tei/815.xml
@@ -208,8 +208,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah, Abbat of Scete</persName>
                 </author>
-                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah, abbat of
-                  Scete</persName>
+                <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah, abbat of Scete</persName>
               </title>
                 <msItem xml:id="p1b6" n="9">
                   <locus from="33a" to="36"/>

--- a/data/tei/815.xml
+++ b/data/tei/815.xml
@@ -469,8 +469,7 @@
                 <author ref="http://syriaca.org/person/22">
                   <persName xml:lang="en">Xystus, bishop of Rome</persName>
                 </author>
-                <title xml:lang="en">The discourses of <persName ref="http://syriaca.org/person/22">
-                  Xystus, bishop of Rome</persName>
+                <title xml:lang="en">The discourses of <persName ref="http://syriaca.org/person/22">Xystus, bishop of Rome</persName>
               </title>
                 <rubric xml:lang="syr">ܡܡܠܠܐ ܕܡܪܝ ܟܣܝܣܛܘܣ: ܐܦܝܣܩܘܦܐ ܕܪܗܘܡܐ</rubric>
                 <note>These have been left unfinished by the scribe, the text ending, on fol. <locus from="149a">149 a</locus>,

--- a/data/tei/819.xml
+++ b/data/tei/819.xml
@@ -232,8 +232,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Discourse on <ref>
-                    <persName>S. Matthew</persName> ch. v. 4</ref>
+                <title xml:lang="en">Discourse on <ref><persName>S. Matthew</persName> ch. v. 4</ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܥܠ ܦܬܓܡܐ ܕܐܡ̣ܪ ܡܪܢ ܕܛܘܒܝܗܘܢ ܠܐܒ̈ܝܠܐ ܕܗܢܘܢ
                   ܢܬܒܝܐܘܢ</rubric>

--- a/data/tei/819.xml
+++ b/data/tei/819.xml
@@ -125,8 +125,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Letter to <persName>Theodulus</persName> (and <persName>his
-                  disciples</persName>), who had written to him, requesting that he would write to them
+                <title xml:lang="en">Letter to <persName>Theodulus</persName> (and <persName>his disciples</persName>), who had written to him, requesting that he would write to them
                   concerning the mystery of the new life after the resurrection</title>
                 <rubric xml:lang="syr">ܕܠܘܬ ܬܐܘܕܘܠܘܣ [ܘܕܥܡܗ] ܕܟܬܒܘ ܫܠܚܘ ܠܗ ܕܢܟܬܘܒ ܠܗܘܢ ܥܠ ܐܪܙܐ
                   ܕܕܘܒܪ̈ܐ ܕܚ̈ܝܐ ܚ̈ܕܬܐ ܕܡܢ ܒܬܪ ܩܝܡܬܐ. ܘ . ܐܝܬܝܗܘܢ ܕܝܢ ܢܝ̈ܫܐ ܕܐܓܪܬܐ ܗܕܐ̣ ܗܠܝܢ. ܕܡܢܐ ܗܘ

--- a/data/tei/819.xml
+++ b/data/tei/819.xml
@@ -267,8 +267,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Letter to <placeName>a convent of <persName>Recluses</persName>
-                  </placeName>, on the rest of the
+                <title xml:lang="en">Letter to <placeName>a convent of <persName>Recluses</persName></placeName>, on the rest of the
                   world from the offences that were in it.</title>
                 <rubric xml:lang="syr">ܬܘܒ ܐܓܪܬܐ ܕܐܫܬܕܪܬ ܡܢ ܗܢܐ ܝܚܝܕܝܐ ܠܕܝܪܐ ܕܚܒܝ̈ܫܐ ܥܠ ܫܝܢܐ ܕܒܪܝܪܬܐ
                   ܡܢ ܡܟ̈ܫܘܠܐ ܕܗܘ̣ܘ ܒܗ</rubric>

--- a/data/tei/820.xml
+++ b/data/tei/820.xml
@@ -277,8 +277,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Consolatory address to <persName>those who are persecuted
-                           for the sake of the <persName ref="http://syriaca.org/person/2245">Messiah</persName>
+                <title xml:lang="en">Consolatory address to <persName>those who are persecuted for the sake of the <persName ref="http://syriaca.org/person/2245">Messiah</persName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܒܘܝܐܐ ܠܐܝܠܝܢ ܕܡܬܐܠܨܝܢ ܡܛܠ ܡܫܝܚܐ.</rubric>

--- a/data/tei/820.xml
+++ b/data/tei/820.xml
@@ -172,8 +172,7 @@
                   <author ref="http://syriaca.org/person/827">
                     <persName xml:lang="en">John the Monk</persName>
                   </author>
-                  <title xml:lang="en">On <ref>
-                      <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch.
+                  <title xml:lang="en">On <ref><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch.
                                  v. 3</ref>
                   </title>
                   <rubric xml:lang="syr">ܩܕܡܝܐ ܥܠ ܗ̇ܘ ܦܬܓܡܐ ܕܛܘܒܝܗܘܢ ܠܡܣ̈ܟܢܐ ܒܪܘܚ
@@ -186,8 +185,7 @@
                   <author ref="http://syriaca.org/person/827">
                     <persName xml:lang="en">John the Monk</persName>
                   </author>
-                  <title xml:lang="en">On <ref>
-                      <persName ref="http://syriaca.org/person/2703">S.
+                  <title xml:lang="en">On <ref><persName ref="http://syriaca.org/person/2703">S.
                                     Matthew</persName>, ch. v. 9</ref>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܦܬܓܡܐ ܕܐܡ̣ܪ ܡܪܢ ܕܛܘܒܝܗܘܢ ܠܥ̇ܒ̈ܕܝ ܫܠܡܐ
@@ -201,8 +199,7 @@
                   <author ref="http://syriaca.org/person/827">
                     <persName xml:lang="en">John the Monk</persName>
                   </author>
-                  <title xml:lang="en">On <ref>
-                      <persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch.
+                  <title xml:lang="en">On <ref><persName ref="http://syriaca.org/person/2703">S. Matthew</persName>, ch.
                                  v. 8</ref>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܗ̇ܘ ܦܬܓܡܐ ܕܛܘܒܝܗܘܢ ܠܐܝܠܝܢ ܕܕܟܝܢ ܒܠܗܘܢ <foreign xml:lang="en">(sic)</foreign> ܕܗ̣ܢܘܢ ܢܚܙܘܢܝܗܝ ܠܐܠܗܐ.</rubric>
@@ -219,8 +216,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Discourse on the <ref>Epistle to <persName>the
-                              Romans</persName>, ch. viii. 18</ref>
+                <title xml:lang="en">Discourse on the <ref>Epistle to <persName>the Romans</persName>, ch. viii. 18</ref>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܐܡ̣ܪ ܫܠܝܚܐ ܕܠܐ ܫ̇ܘܝܢ ܚܫܘܗ̈ܝ ܕܙܒܢܐ ܗܢܐ
                            ܠܬܫܒܘܚܬܐ ܐܝܕܐ ܕܥܬܝܕܐ ܕܬܬܓܠܐ</rubric>
@@ -233,8 +229,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Discourse on the <ref>Epistle to <persName>the
-                              Ephesians</persName>, ch. vi. 11 (13)</ref>
+                <title xml:lang="en">Discourse on the <ref>Epistle to <persName>the Ephesians</persName>, ch. vi. 11 (13)</ref>
                 </title>
                 <rubric xml:lang="syr">ܥܠ ܗ̇ܝ ܕܐܡ̣ܪ ܗܘ̣ܐ ܫܠܝܚܐ ܠܐ̈ܦܣܝܐ ܕܠܒ̣ܫܘ ܟܠܗ ܙܝܢܐ
                            ܕܐܠܗܐ</rubric>

--- a/data/tei/820.xml
+++ b/data/tei/820.xml
@@ -277,8 +277,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Consolatory address to <persName>those who are persecuted for the sake of the <persName ref="http://syriaca.org/person/2245">Messiah</persName>
-                  </persName>
+                <title xml:lang="en">Consolatory address to <persName>those who are persecuted for the sake of the <persName ref="http://syriaca.org/person/2245">Messiah</persName></persName>
                 </title>
                 <rubric xml:lang="syr">ܒܘܝܐܐ ܠܐܝܠܝܢ ܕܡܬܐܠܨܝܢ ܡܛܠ ܡܫܝܚܐ.</rubric>
                 <incipit xml:lang="syr">ܦܐܝܢ ܗܟܝܠ ܐܘܠܨ̈ܢܐ ܕܡܛܠ ܡܫܝܚܐ̇. ܠܐܝܠܝܢ ܕܐܚܒܘ

--- a/data/tei/821.xml
+++ b/data/tei/821.xml
@@ -331,8 +331,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title>Part of the Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/48">Batnae</placeName>
-                  </persName> on the Divine Love</title>
+                <title>Part of the Discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/48">Batnae</placeName></persName> on the Divine Love</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܚܘܒܐ ܐܠܗܝܐ<locus from="17"/>
                 </rubric>
                 <listBibl>

--- a/data/tei/824.xml
+++ b/data/tei/824.xml
@@ -254,8 +254,7 @@
                         ܕܩܕܝܫܐ ܝܘܚܢܢ ܐܝܚܝܕܝܐ̇. ܘܚ̇ܙܝܐ ܕܬܒܐܝܣ</rubric>
               <msItem xml:id="b9" n="26">
                 <locus from="164a" to="166">Foll. 164a-166</locus>
-                <title xml:lang="en">The history of <persName>John the monk</persName> by <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">The history of <persName>John the monk</persName> by <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܩܕܡܐܝܬ ܕܝܢ܆ ܬܫܥܝܬܐ ܥܠܘܗܝ ܕܛܘܒܢܐ ܝܘܚܢ̣ܢ. ܕܡܟ̣ܬܒܐ ܠܦܠܕ
                            ܐܦܝܣܩܘܦܐ ܕܐܘܪܫܠܡ.</rubric>
                 <note>See the <bibl>Paradise of <persName>Heraclides</persName>, cap. xxii.,

--- a/data/tei/824.xml
+++ b/data/tei/824.xml
@@ -217,9 +217,7 @@
               </msItem>
               <msItem xml:id="b6" n="21">
                 <locus from="122a" to="122">Foll. 122a-122</locus>
-                <title xml:lang="en">The history of <persName>Joseph the
-                              Egyptian</persName> and <persName>Eulogius the
-                           Greek</persName>.</title>
+                <title xml:lang="en">The history of <persName>Joseph the Egyptian</persName> and <persName>Eulogius the Greek</persName>.</title>
                 <rubric xml:lang="syr">[ܬܘܒ ܬܫܥܝܬܐ] ܕܐܒܐ ܝܘܣܦ ܡܨܪܝܐ̣. ܘܕܐܒܐ ܐܘܠܓܝܘܣ
                            ܝܘܢܝܐ.</rubric>
               </msItem>
@@ -256,8 +254,7 @@
                         ܕܩܕܝܫܐ ܝܘܚܢܢ ܐܝܚܝܕܝܐ̇. ܘܚ̇ܙܝܐ ܕܬܒܐܝܣ</rubric>
               <msItem xml:id="b9" n="26">
                 <locus from="164a" to="166">Foll. 164a-166</locus>
-                <title xml:lang="en">The history of <persName>John the
-                              monk</persName> by <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
+                <title xml:lang="en">The history of <persName>John the monk</persName> by <persName ref="http://syriaca.org/person/668">Palladius, bishop of <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܩܕܡܐܝܬ ܕܝܢ܆ ܬܫܥܝܬܐ ܥܠܘܗܝ ܕܛܘܒܢܐ ܝܘܚܢ̣ܢ. ܕܡܟ̣ܬܒܐ ܠܦܠܕ
                            ܐܦܝܣܩܘܦܐ ܕܐܘܪܫܠܡ.</rubric>

--- a/data/tei/825.xml
+++ b/data/tei/825.xml
@@ -164,8 +164,7 @@
               <msItem xml:id="b7" n="10">
                 <locus from="43a" to="46">Foll. 43a-46</locus>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName>
-                  </persName>.</title>
+                  <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName></persName>.</title>
               </msItem>
               <msItem xml:id="b8" n="11">
                 <locus from="46b" to="47">Foll. 46b-47</locus>
@@ -212,8 +211,7 @@
             </msItem>
             <msItem xml:id="a5" n="18">
               <locus from="80a" to="81">Foll. 80a-81</locus>
-              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                </persName>.</title>
+              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName>.</title>
               <rubric xml:lang="syr">ܕܛܘܒܢܐ ܡܪܝ ܐܟܣܢܝܐ</rubric>
               <incipit xml:lang="syr"> ܦܐܝܐ ܢܟܦܘܬܐ ܠܢܟ̈ܦܐ̇ ܘܟܢ̣ܝܟܘܬܐ ܠܝܩܝܪ̈ܐ. ܘܡܛܟ̣ܣܘܬܐ
                         ܠܬܠܡ̈ܝܕܘܗܝ ܕܡܫܝܚܐ. ܏ܘܫ.</incipit>
@@ -236,14 +234,12 @@
               </msItem>
               <msItem xml:id="b16" n="22">
                 <locus from="115a"/>
-                <title xml:lang="en">A passage relating to <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">A passage relating to <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName></persName>.</title>
               </msItem>
             </msItem>
             <msItem xml:id="a7" n="23">
               <locus from="117a" to="122">Foll. 117a-122</locus>
-              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                </persName>.</title>
+              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>.</title>
               <rubric xml:lang="syr">ܣܗܕܘܬܐ ܕܩܕܝܫܐ ܦܛܪܘܣ ܪܝܫ ܐܦܣ̈ܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ</rubric>
               <incipit xml:lang="syr">ܒܝܘ̈ܡܝ ܕܘܩܠܛܝܢܘܣ ܡܠܟܐ. ܗܘ̣ܐ ܟܕ ܐܬܠܒܟ ܛܘܒܢܐ ܦܛܪܘܣ ܡܢ
                         ܛܪ̈ܝܒܘܢܐ ܐܝܠܝܢ ܕܐܫܬܕܪܘ ܒܗ̇ܘ ܙܒܢܐ ܡܢ ܡܠܟܐ ܏ܘܫ.</incipit>
@@ -251,8 +247,7 @@
             </msItem>
             <msItem xml:id="a8" n="24">
               <locus from="123a" to="124">Foll. 123a-124</locus>
-              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName> taken from the tract "on the
+              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName> taken from the tract "on the
                         Passions which war against Ascetics."</title>
               <note>See <bibl>Add. 14,575, no. 16</bibl>.</note>
             </msItem>
@@ -279,8 +274,7 @@
             </msItem>
             <msItem xml:id="a12" n="28">
               <locus from="126a" to="127">Foll. 126a-127</locus>
-              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName>.</title>
               <msItem xml:id="b17" n="29">
                 <locus from="126a" to="127">Foll. 126a-127</locus>
                 <rubric xml:lang="syr">ܡܡܠܠܐ ܕܛܘܒܢܐ ܡܪ (sic) ܐܟܣܢܝܐ ܐܦܣܩܦܐ ܕܡܒܘܓ</rubric>
@@ -305,8 +299,7 @@
             </msItem>
             <msItem xml:id="a14" n="32">
               <locus from="128a" to="128">Foll. 128a-128</locus>
-              <title xml:lang="en">Extracts from the homily of <persName ref="http://syriaca.org/person/376">Basil of <placeName ref="http://syriaca.org/place/60">Caesarea</placeName>
-                </persName> on Anger and Wrath.</title>
+              <title xml:lang="en">Extracts from the homily of <persName ref="http://syriaca.org/person/376">Basil of <placeName ref="http://syriaca.org/place/60">Caesarea</placeName></persName> on Anger and Wrath.</title>
               <rubric xml:lang="syr">ܡܢ ܕܛܘܒܢܐ ܡܪܝ ܒܣܝܠܝܣ ܥܠ ܚܡܬܐ ܘܪܘܓܙܐ</rubric>
               <incipit xml:lang="syr">ܗܠܝܢ ܗܟܝܠ ܬܪܬܝܢ ܣܒ ܡܢ ܢܦܫܟ: ܕܠܐ ܬܚܫ̣ܘܒ ܢܦܫܟ ܪܒܐ ܘܡܝܩܪܐ.
                         ܘܠܐ ܐܢܫ ܕܒ̣ܨܝܪ ܡܢܟ ܡܢ ܒܢܝ̈ܢܫܐ ܬܣ̣ܒܪ ܕܐܝܬ ܒܥܠܡܐ</incipit>

--- a/data/tei/825.xml
+++ b/data/tei/825.xml
@@ -164,8 +164,7 @@
               <msItem xml:id="b7" n="10">
                 <locus from="43a" to="46">Foll. 43a-46</locus>
                 <title xml:lang="en">
-                  <persName ref="http://syriaca.org/person/1816">John of
-                                 <placeName>Lycopolis</placeName>
+                  <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName>
                   </persName>.</title>
               </msItem>
               <msItem xml:id="b8" n="11">
@@ -213,8 +212,7 @@
             </msItem>
             <msItem xml:id="a5" n="18">
               <locus from="80a" to="81">Foll. 80a-81</locus>
-              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                        <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
+              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr">ܕܛܘܒܢܐ ܡܪܝ ܐܟܣܢܝܐ</rubric>
               <incipit xml:lang="syr"> ܦܐܝܐ ܢܟܦܘܬܐ ܠܢܟ̈ܦܐ̇ ܘܟܢ̣ܝܟܘܬܐ ܠܝܩܝܪ̈ܐ. ܘܡܛܟ̣ܣܘܬܐ
@@ -238,15 +236,13 @@
               </msItem>
               <msItem xml:id="b16" n="22">
                 <locus from="115a"/>
-                <title xml:lang="en">A passage relating to <persName ref="http://syriaca.org/person/1816">John of
-                                 <placeName>Lycopolis</placeName>
+                <title xml:lang="en">A passage relating to <persName ref="http://syriaca.org/person/1816">John of <placeName>Lycopolis</placeName>
                   </persName>.</title>
               </msItem>
             </msItem>
             <msItem xml:id="a7" n="23">
               <locus from="117a" to="122">Foll. 117a-122</locus>
-              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of
-                        <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+              <title xml:lang="en">The martyrdom of <persName ref="http://syriaca.org/person/1413">Peter of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr">ܣܗܕܘܬܐ ܕܩܕܝܫܐ ܦܛܪܘܣ ܪܝܫ ܐܦܣ̈ܩܘܦܐ ܕܐܠܟܣܢܕܪܝܐ</rubric>
               <incipit xml:lang="syr">ܒܝܘ̈ܡܝ ܕܘܩܠܛܝܢܘܣ ܡܠܟܐ. ܗܘ̣ܐ ܟܕ ܐܬܠܒܟ ܛܘܒܢܐ ܦܛܪܘܣ ܡܢ
@@ -255,8 +251,7 @@
             </msItem>
             <msItem xml:id="a8" n="24">
               <locus from="123a" to="124">Foll. 123a-124</locus>
-              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of
-                        <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                 </persName> taken from the tract "on the
                         Passions which war against Ascetics."</title>
               <note>See <bibl>Add. 14,575, no. 16</bibl>.</note>
@@ -284,8 +279,7 @@
             </msItem>
             <msItem xml:id="a12" n="28">
               <locus from="126a" to="127">Foll. 126a-127</locus>
-              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                        <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
+              <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
                 </persName>.</title>
               <msItem xml:id="b17" n="29">
                 <locus from="126a" to="127">Foll. 126a-127</locus>
@@ -311,8 +305,7 @@
             </msItem>
             <msItem xml:id="a14" n="32">
               <locus from="128a" to="128">Foll. 128a-128</locus>
-              <title xml:lang="en">Extracts from the homily of <persName ref="http://syriaca.org/person/376">Basil of
-                        <placeName ref="http://syriaca.org/place/60">Caesarea</placeName>
+              <title xml:lang="en">Extracts from the homily of <persName ref="http://syriaca.org/person/376">Basil of <placeName ref="http://syriaca.org/place/60">Caesarea</placeName>
                 </persName> on Anger and Wrath.</title>
               <rubric xml:lang="syr">ܡܢ ܕܛܘܒܢܐ ܡܪܝ ܒܣܝܠܝܣ ܥܠ ܚܡܬܐ ܘܪܘܓܙܐ</rubric>
               <incipit xml:lang="syr">ܗܠܝܢ ܗܟܝܠ ܬܪܬܝܢ ܣܒ ܡܢ ܢܦܫܟ: ܕܠܐ ܬܚܫ̣ܘܒ ܢܦܫܟ ܪܒܐ ܘܡܝܩܪܐ.

--- a/data/tei/825.xml
+++ b/data/tei/825.xml
@@ -317,8 +317,7 @@
             </msItem>
             <msItem xml:id="a16" n="34">
               <locus from="140a" to="144">Foll. 140a-144</locus>
-              <title xml:lang="en">Paraenetic hymns by <placeName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</placeName>.</title>
+              <title xml:lang="en">Paraenetic hymns by <placeName ref="http://syriaca.org/person/42">Jacob of Batnae</placeName>.</title>
               <rubric xml:lang="syr">ܒ̈ܬܐ ܕܡܪܬܝܢܘܬܐ ܕܣܝ̣̈ܡܝܢ ܠܛܘܒܢܐ ܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ ܐܦܣܩܦܐ
                         ܕܒܛܢܢ.</rubric>
               <msItem xml:id="b19" n="35">

--- a/data/tei/826.xml
+++ b/data/tei/826.xml
@@ -243,8 +243,7 @@
                 <msItem xml:id="c16" n="19">
                   <locus from="166a" to="169">Foll. 166a-169</locus>
                   <title xml:lang="en">Chap. 5. An encomium on the monks of
-                              <placeName ref="http://syriaca.org/place/715">Egypt</placeName>, from the commentary of <persName ref="http://syriaca.org/person/573">John
-                                 Chrysostom</persName> on the <bibl>Gospel of <persName ref="http://syriaca.org/person/2703">S.
+                              <placeName ref="http://syriaca.org/place/715">Egypt</placeName>, from the commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on the <bibl>Gospel of <persName ref="http://syriaca.org/person/2703">S.
                                     Matthew</persName>, hom. viii</bibl>.</title>
                   <rubric xml:lang="syr">ܩܘܠܣܐ ܕܕܝܪ̈ܝܐ ܕܡܨܪܝܢ ܡܢ ܡܐܡܪܐ ܕܬܡ̈ܢܝܐ ܕܦܘܫܩܐ ܕܡܬܝ
                               ܐܘܢܓܠܝܣܛܐ: ܕܥܒܝ̣ܕ ܠܡܪܝ ܝܘܐܢܝ݊ܣ ܐܦܝܣ݊ܩܘܦܐ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ</rubric>

--- a/data/tei/829.xml
+++ b/data/tei/829.xml
@@ -143,8 +143,7 @@
               <title xml:lang="en">The first part of the history of the Man of God
                            (<persName ref="http://syriaca.org/person/607">Alexius</persName>) from
                            <placeName ref="http://syriaca.org/place/641">Rome</placeName>, in the
-                        time of <persName>Rabulas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                </persName>.</title>
+                        time of <persName>Rabulas, bishop of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>.</title>
               <finalRubric xml:lang="syr">ܫܠܡܬ ܬܫܥܝܬܐ ܕܥܠ ܓܒܪܐ ܕܐܠܗܐ<locus from="125a"/>
               </finalRubric>
               <note>See <bibl>Add. 14,649, no. 3</bibl>.</note>

--- a/data/tei/830.xml
+++ b/data/tei/830.xml
@@ -124,8 +124,7 @@
               </persName>
               </author>
               <title xml:lang="en">Short extracts from the writings of
-                        <persName ref="http://syriaca.org/person/548">Isaiah, abbat of
-                           <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+                        <persName ref="http://syriaca.org/person/548">Isaiah, abbat of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr">ܬܘܒ ܡܡܠܐ ܕܐܒܐ ܐܫܥܝܐ</rubric>
             </msItem>
@@ -172,8 +171,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the monk</persName>
               </author>
-              <title xml:lang="en">An extract from <persName>John the
-                        monk</persName>.</title>
+              <title xml:lang="en">An extract from <persName>John the monk</persName>.</title>
               <rubric xml:lang="syr">ܕܝܘܚܢܢ ܐܝܚܝܕܝܐ.</rubric>
               <incipit xml:lang="syr">ܫܘܦܪܐ ܕܢܦܫܐ̣ ܪܢܝܐ ܗܘܼ ܕܐܠܗܐ</incipit>
             </msItem>
@@ -193,8 +191,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the monk</persName>
               </author>
-              <title xml:lang="en">Another extract from <persName>John the
-                           monk</persName>.</title>
+              <title xml:lang="en">Another extract from <persName>John the monk</persName>.</title>
               <rubric xml:lang="syr">ܕܝܘܚܢܢ ܐܝܚܝܕܝܐ</rubric>
               <incipit xml:lang="syr">ܐܬܡܐܢ (sic) ܒܩܪܝܢܐ ܕܢܒ̈ܝܐ ܕܡܢܗܘܢ ܬܐܠܦ ܪܒܘܬܗ ܕܐܠܗܐ܇
                         ܘܒܣܝܡܘܬܗ ܘܟ̇ܐܢܘܬܗ ܘܛܝܒܘܬܗ.</incipit>
@@ -205,8 +202,7 @@
                 <persName xml:lang="en">Philoxenus of Mabūg
               </persName>
               </author>
-              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                        <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr"> ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
               <incipit xml:lang="syr">ܠܐ ܢܗܘܐ ܥܢܝܢܟ ܥܡ ܐܚ̈ܐ ܪ̈ܦܝܐ̣. ܕܠܐ ܢܝܒܠܘܢ ܠܘܬܟ ܥܝ̈ܕܐ
@@ -219,8 +215,7 @@
                 <persName xml:lang="en">Isaac of Antioch
               </persName>
               </author>
-              <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/33">Isaac of
-                        <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+              <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr"> ܕܡܪܝ ܐܝܣܚܩ</rubric>
               <incipit xml:lang="syr">ܚܪܬܐ ܘܢܘܓܪܐ ܕܫ̈ܢܝܐ. ܒܕܪܢ ܕܝܠܢ ܐܫ̇ܬܠܡ</incipit>
@@ -282,16 +277,14 @@
             </msItem>
             <msItem xml:id="a15" n="20">
               <locus from="90a" to="90">Foll. 90a-90</locus>
-              <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                        <placeName ref="http://syriaca.org/place/122 ">Mabūg</placeName>
+              <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122 ">Mabūg</placeName>
                 </persName>, of a sage
                         (<foreign xml:lang="syr">ܚܟܝܡܐ</foreign>), of <persName ref="http://syriaca.org/person/22">Xystus</persName>, and of
                         <persName ref="http://syriaca.org/person/483">Evagrius</persName>. </title>
             </msItem>
             <msItem xml:id="a16" n="21" defective="true">
               <locus from="90b" to="146">Foll. 90b-146</locus>
-              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of
-                        <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                 </persName>.</title>
               <msItem xml:id="b6" n="22">
                 <locus from="90b" to="103">Foll. 90b-103</locus>

--- a/data/tei/830.xml
+++ b/data/tei/830.xml
@@ -124,8 +124,7 @@
               </persName>
               </author>
               <title xml:lang="en">Short extracts from the writings of
-                        <persName ref="http://syriaca.org/person/548">Isaiah, abbat of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>.</title>
+                        <persName ref="http://syriaca.org/person/548">Isaiah, abbat of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
               <rubric xml:lang="syr">ܬܘܒ ܡܡܠܐ ܕܐܒܐ ܐܫܥܝܐ</rubric>
             </msItem>
             <msItem xml:id="a3" n="3" defective="true">
@@ -202,8 +201,7 @@
                 <persName xml:lang="en">Philoxenus of Mabūg
               </persName>
               </author>
-              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                </persName>.</title>
+              <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
               <rubric xml:lang="syr"> ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
               <incipit xml:lang="syr">ܠܐ ܢܗܘܐ ܥܢܝܢܟ ܥܡ ܐܚ̈ܐ ܪ̈ܦܝܐ̣. ܕܠܐ ܢܝܒܠܘܢ ܠܘܬܟ ܥܝ̈ܕܐ
                         ܡ̈ܥܝܣܐ ܕܚ̈ܫܝܗܘܢ̇ ܒܦܪܨܘܦ ܚܠܝܛܘܬܐ. ܐܝܟܐ ܕܣܝܡܬܟ ܬܗܘܐ̣ ܗܟܢܐ ܓܒܝ ܠܟ ܒ̈ܢܝ
@@ -215,8 +213,7 @@
                 <persName xml:lang="en">Isaac of Antioch
               </persName>
               </author>
-              <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>.</title>
+              <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
               <rubric xml:lang="syr"> ܕܡܪܝ ܐܝܣܚܩ</rubric>
               <incipit xml:lang="syr">ܚܪܬܐ ܘܢܘܓܪܐ ܕܫ̈ܢܝܐ. ܒܕܪܢ ܕܝܠܢ ܐܫ̇ܬܠܡ</incipit>
             </msItem>
@@ -277,15 +274,13 @@
             </msItem>
             <msItem xml:id="a15" n="20">
               <locus from="90a" to="90">Foll. 90a-90</locus>
-              <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122 ">Mabūg</placeName>
-                </persName>, of a sage
+              <title xml:lang="en">Sayings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122 ">Mabūg</placeName></persName>, of a sage
                         (<foreign xml:lang="syr">ܚܟܝܡܐ</foreign>), of <persName ref="http://syriaca.org/person/22">Xystus</persName>, and of
                         <persName ref="http://syriaca.org/person/483">Evagrius</persName>. </title>
             </msItem>
             <msItem xml:id="a16" n="21" defective="true">
               <locus from="90b" to="146">Foll. 90b-146</locus>
-              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
               <msItem xml:id="b6" n="22">
                 <locus from="90b" to="103">Foll. 90b-103</locus>
                 <title xml:lang="en">Part a</title>

--- a/data/tei/831.xml
+++ b/data/tei/831.xml
@@ -121,8 +121,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the monk</persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName>John the
-                  monk</persName>.</title>
+              <title xml:lang="en">Selections from the writings of <persName>John the monk</persName>.</title>
               <rubric xml:lang="syr">ܕܝܘܚܢܢ ܝܚܝܕܝܐ</rubric>
               <msItem xml:id="b1" n="2">
                 <locus from="1a" to="1">Foll. 1a-1</locus>
@@ -207,8 +206,7 @@
                 <persName xml:lang="en">Isaiah of Scete
               </persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of
-                        <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                 </persName>.</title>
               <msItem xml:id="b11" n="17" defective="true">
                 <locus from="31a" to="32">Foll. 31a-32</locus>

--- a/data/tei/831.xml
+++ b/data/tei/831.xml
@@ -206,8 +206,7 @@
                 <persName xml:lang="en">Isaiah of Scete
               </persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Selections from the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
               <msItem xml:id="b11" n="17" defective="true">
                 <locus from="31a" to="32">Foll. 31a-32</locus>
                 <rubric xml:lang="syr">ܡܛܠ ܐܝܠܝܢ ܕܐܬܟܬܫܘ ܘܫܡܠܝܘ</rubric>

--- a/data/tei/832.xml
+++ b/data/tei/832.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/321">
                 <persName xml:lang="en">Abraham Nephtarenus</persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName>Abraham
-                           Nephtarenus</persName>.</title>
+              <title xml:lang="en">Selections from the writings of <persName>Abraham Nephtarenus</persName>.</title>
               <rubric xml:lang="syr">ܕܡܪܝ ܐܒܪܗܡ [ܢܦܬܪܝܐ]</rubric>
               <msItem xml:id="b1" n="2">
                 <locus from="1a" to="2">Foll. 1a-2</locus>
@@ -162,8 +161,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the monk</persName>
               </author>
-              <title xml:lang="en">Selections from the writings of <persName>John the
-                           monk</persName>.</title>
+              <title xml:lang="en">Selections from the writings of <persName>John the monk</persName>.</title>
               <rubric xml:lang="syr">ܡܪܝ ܝܘܚܢܢ ܢܩܪ</rubric>
               <msItem xml:id="b6" n="9">
                 <locus from="10a" to="10">Foll. 10a-10</locus>
@@ -185,8 +183,7 @@
               <author ref="http://syriaca.org/person/21">
                 <persName xml:lang="en">Gregory the monk</persName>
               </author>
-              <title xml:lang="en">Selections from <persName>Gregory the
-                           monk</persName>. </title>
+              <title xml:lang="en">Selections from <persName>Gregory the monk</persName>. </title>
               <note>See <bibl>Add. 17,201<ptr target="https://bl.syriac.uk/ms/863"/>, <citedRange unit="fol">foll. 26—32</citedRange>
                 </bibl>, and <bibl>Add. 12,103, foll:
                            240 b</bibl>.</note>
@@ -244,8 +241,7 @@
                 <persName xml:lang="en">Philoxenus of Mabug
               </persName>
               </author>
-              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus
-                        of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
+              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
                 </persName>.</title>
               <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
               <note>See <bibl>Add. 14,582<ptr target="https://bl.syriac.uk/ms/318"/>, no. 10</bibl>.</note>
@@ -305,8 +301,7 @@
               <author ref="http://syriaca.org/person/573">
                 <persName xml:lang="en">John Chrysostom</persName>
               </author>
-              <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/573">John
-                  Chrysostom</persName> on <title> Ps. 1. (li.) </title>1.</title>
+              <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <title> Ps. 1. (li.) </title>1.</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܣܝܡ ܠܩܕܝܫܐ ܘܠܒܝܫ ܠܐܠܗܐ ܡܪܝ ܝܘܐܢܝܣ ܥܠ ܗ̇ܝ ܕܪܚܡ ܥܠܝ
                         ܐܠܗܐ ܐܝܟ ܛܝܒܘܬܟ</rubric>
             </msItem>

--- a/data/tei/832.xml
+++ b/data/tei/832.xml
@@ -241,8 +241,7 @@
                 <persName xml:lang="en">Philoxenus of Mabug
               </persName>
               </author>
-              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Extracts from the writings of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabug</placeName></persName>.</title>
               <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ</rubric>
               <note>See <bibl>Add. 14,582<ptr target="https://bl.syriac.uk/ms/318"/>, no. 10</bibl>.</note>
               <msItem xml:id="b13" n="19">

--- a/data/tei/837.xml
+++ b/data/tei/837.xml
@@ -770,10 +770,7 @@
                 </author>
                 <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on 
                   <title ref="http://syriaca.org/work/9672">Ps. 
-                    <choice>
-                      <sic>l.</sic>
-                      <corr resp="#wwright">li.</corr>
-                    </choice>. 1</title>
+                    <choice><sic>l.</sic><corr resp="#wwright">li.</corr></choice>. 1</title>
                 </title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܡܪܝ ܝܘܗܢܝܣ ܥܠ ܗ̇ܝ ܕܪܚܡ ܥܠܝ ܐܠܗܐ ܐܝܟ ܛܝܒܘܬܟ.</rubric>
                 <note>See <bibl>Opera, t. v., p. 708</bibl>.</note>

--- a/data/tei/837.xml
+++ b/data/tei/837.xml
@@ -197,8 +197,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName>
+                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
                 </title>
                 <msItem xml:id="p1b5" n="7">
                   <locus from="43a" to="43">Fol. 43</locus>
@@ -261,8 +260,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName>
+                <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
                 </title>
                 <msItem xml:id="p1b8" n="13">
                   <locus from="51a" to="54">Foll. 51a-54</locus>
@@ -617,8 +615,7 @@
                 <author ref="http://syriaca.org/person/548">
                   <persName xml:lang="en">Isaiah of Scete</persName>
                 </author>
-                <title xml:lang="en">Part of the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName>
-                  </persName>
+                <title xml:lang="en">Part of the writings of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName>Scete</placeName></persName>
                 </title>
                 <note>See <bibl>Add. 14,575, nos. 1—11<ptr target="https://bl.syriac.uk/ms/311"/>
                   </bibl>.</note>
@@ -786,8 +783,7 @@
                 <author ref="http://syriaca.org/person/2163">
                   <persName xml:lang="en">Julius of Rome</persName>
                 </author>
-                <title xml:lang="en">Letters of <persName ref="http://syriaca.org/person/2163">Julius of <placeName>Rome</placeName>
-                  </persName> on the Incarnation of <persName>our Lord</persName>
+                <title xml:lang="en">Letters of <persName ref="http://syriaca.org/person/2163">Julius of <placeName>Rome</placeName></persName> on the Incarnation of <persName>our Lord</persName>
                 </title>
                 <rubric xml:lang="syr">ܐܓܪ̈ܬܐ ܕܝܘܠܝܣ ܐܦܝܣܩܘܦܐ ܕܪܘܡܐ ܥܠ ܡܬܒܣܪܢܘܬܗ ܕܡܪܢ</rubric>
                 <msItem xml:id="p1b49" n="70">
@@ -838,15 +834,13 @@
                 </msItem>
                 <msItem xml:id="p1b54" n="76">
                   <locus from="186b" to="187">Foll. 186b-187</locus>
-                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1702">Valens of <placeName>Palestine</placeName>
-                    </persName>
+                  <title xml:lang="en">Of <persName ref="http://syriaca.org/person/1702">Valens of <placeName>Palestine</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܘܠܝܣ ܦܠܝܣܛܝܢܝܐ</rubric>
                 </msItem>
                 <msItem xml:id="p1b55" n="77">
                   <locus from="187a" to="187">Foll. 187a-187</locus>
-                  <title xml:lang="en">Of <persName>Hero of <placeName>Alexandria</placeName>
-                    </persName>
+                  <title xml:lang="en">Of <persName>Hero of <placeName>Alexandria</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܥܠ ܗܪܘܢ ܕܐܠܟܣܢܕܪܝܐ</rubric>
                 </msItem>

--- a/data/tei/838.xml
+++ b/data/tei/838.xml
@@ -112,8 +112,7 @@
               <author ref="http://syriaca.org/person/42">
                 <persName xml:lang="en">Jacob of Batnae</persName>
               </author>
-              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</persName>
+              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
               </title>
               <msItem xml:id="b1" n="2" defective="true">
                 <locus from="1a" to="20">Foll. 1a-20</locus>
@@ -182,8 +181,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">The second discourse, on
-                                 <persName>Elisha</persName> and the <persName>king of
-                                 <placeName>Moab</placeName>
+                                 <persName>Elisha</persName> and the <persName>king of <placeName>Moab</placeName>
                     </persName> (<ref>2 Kings, ch. iii. 26, 27</ref>)</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܪ̈ܝܢ ܕܥܠ ܐܠܝܫܥ: ܘܥܠ ܡ̇ܠܟܐ ܕܡܘܐܒ ܕܕܒܚ̣ ܒܪܗ
                               ܥܠ ܫܘܪܐ </rubric>

--- a/data/tei/838.xml
+++ b/data/tei/838.xml
@@ -169,8 +169,7 @@
                   <author ref="http://syriaca.org/person/42">
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
-                  <title xml:lang="en">The first discourse, on <persName>Elisha</persName> making the bitter waters sweet (<ref>2
-                                 Kings, ch. ii. 19 — 22</ref>), and multiplying <persName>the Widow</persName>'s oil
+                  <title xml:lang="en">The first discourse, on <persName>Elisha</persName> making the bitter waters sweet (<ref>2 Kings, ch. ii. 19 — 22</ref>), and multiplying <persName>the Widow</persName>'s oil
                                  (<ref>ch. iv. 1—7</ref>)</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܩܕܡܝܐ ܕܥܠ ܐܠܝܫܥ</rubric>
                   <note>Imperfect at the beginning.</note>

--- a/data/tei/838.xml
+++ b/data/tei/838.xml
@@ -181,8 +181,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">The second discourse, on
-                                 <persName>Elisha</persName> and the <persName>king of <placeName>Moab</placeName>
-                    </persName> (<ref>2 Kings, ch. iii. 26, 27</ref>)</title>
+                                 <persName>Elisha</persName> and the <persName>king of <placeName>Moab</placeName></persName> (<ref>2 Kings, ch. iii. 26, 27</ref>)</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܪ̈ܝܢ ܕܥܠ ܐܠܝܫܥ: ܘܥܠ ܡ̇ܠܟܐ ܕܡܘܐܒ ܕܕܒܚ̣ ܒܪܗ
                               ܥܠ ܫܘܪܐ </rubric>
                   <incipit xml:lang="syr">ܟܬܒܐ ܡܢ̣ܗܪ ܥ̈ܝܢܐ ܕܢܦܫܐ ܡܢ ܩܪ̈ܝܢܐ. ܏ܘܫ</incipit>

--- a/data/tei/839.xml
+++ b/data/tei/839.xml
@@ -375,8 +375,7 @@
                 <persName xml:lang="en">Ephraim</persName>
               </author>
               <title xml:lang="en">A metrical discourse of
-                        <persName ref="http://syriaca.org/person/13">Ephraim</persName>, on the <placeName ref="http://syriaca.org/place/502">city of
-                           Nicomedia</placeName>, and on the Resurrection and Free-will.</title>
+                        <persName ref="http://syriaca.org/person/13">Ephraim</persName>, on the <placeName ref="http://syriaca.org/place/502">city of Nicomedia</placeName>, and on the Resurrection and Free-will.</title>
               <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܦܪܡ: ܕܣܝܡ ܠܗ ܥܠ ܢܝܩܘܡܕܝܐ. ܘܥܠ ܢܘܚܡܐ
                         ܘܚܐܪܘܬܐ</rubric>
               <incipit xml:lang="syr">ܠܐ ܬܬܟܠܘܢ ܥܠ ܗܕܐ. ܕܦܣܝܩ ܩܨܐ ܠܒܪܢܫܐ. ܡܢ ܗܕܐ ܓܝܪ ܡܪܢܝܬܐ.

--- a/data/tei/839.xml
+++ b/data/tei/839.xml
@@ -114,8 +114,7 @@
                 <persName xml:lang="en">Philoxenus of Mabūg
               </persName>
               </author>
-              <title xml:lang="en">Copious extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                        <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+              <title xml:lang="en">Copious extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                 </persName>.</title>
               <msItem xml:id="b1" n="2">
                 <locus from="1b" to="32">Foll. 1b-32</locus>
@@ -149,8 +148,7 @@
               </msItem>
               <msItem xml:id="b2" n="6">
                 <locus from="33a" to="44">Foll. 33a-44</locus>
-                <title xml:lang="en">From the letter to <persName>Patricius the
-                              monk</persName>.</title>
+                <title xml:lang="en">From the letter to <persName>Patricius the monk</persName>.</title>
                 <rubric xml:lang="syr">ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܩܕܝܫܐ ܦܝܠܦܣܘܢܣ. ܐܝܓܪܬܐ ܕܠܘܬ ܦܛܪܝܩ
                            ܕܝܪܝܐ</rubric>
               </msItem>
@@ -185,8 +183,7 @@
               <author ref="http://syriaca.org/person/827">
                 <persName xml:lang="en">John the Monk</persName>
               </author>
-              <title xml:lang="en">Extracts from <persName>John the
-                        monk</persName>.</title>
+              <title xml:lang="en">Extracts from <persName>John the monk</persName>.</title>
               <msItem xml:id="b5" n="11">
                 <locus from="49b" to="53">Foll. 49b-53</locus>
                 <title xml:lang="en">Extracts from the three discourses on the
@@ -247,8 +244,7 @@
                 <persName xml:lang="en">Jacob of
                         Batnae</persName>
               </author>
-              <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of
-                        Batnae</persName>.</title>
+              <title xml:lang="en">A letter of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
               <rubric xml:lang="syr">ܐܝܓܪܬܐ ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ ܐܦܝܣܩܘܦܐ ܕܒܢܛܢ (sic) ܕܡ̇ܘܕܥܐ ܥܠ
                         ܕܘܒܪ̈ܐ ܡܝܬܪ̈ܐ ܕܟܬܝ̇ܒܐ ܠܚܕ ܡܣ̇ܟܢܐ ܡܛܠ ܦܘܪܩܢܐ ܕܚ̈ܝܘܗܝ.</rubric>
               <incipit xml:lang="syr">ܐܝ̈ܠܝܢ ܕܒܕܘܒܪ̈ܐ ܡ̈ܥܠܝܐ ܘܪ̈ܘܚܢܐ ܕܬܠܡܝܕܘܬܗ ܕܡܫܝܚܐ ܢܦܫܗܘܢ
@@ -289,8 +285,7 @@
                 <persName xml:lang="en">Jacob of
                         Batnae</persName>
               </author>
-              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</persName>.</title>
+              <title xml:lang="en">Metrical discourses of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
               <msItem xml:id="b8" n="23">
                 <locus from="63a" to="66">Foll. 63a-66</locus>
                 <title xml:lang="en">On the Divine Love.</title>
@@ -318,8 +313,7 @@
                 <persName xml:lang="en">Isaiah of Scete
               </persName>
               </author>
-              <title xml:lang="en">Selections from <persName ref="http://syriaca.org/person/548">Isaiah of
-                        <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+              <title xml:lang="en">Selections from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                 </persName>.</title>
               <note>See <bibl>Add. 14,575, nos. 7—11</bibl>.</note>
               <msItem xml:id="b10" n="27">
@@ -372,8 +366,7 @@
                 <persName xml:lang="en">Jacob of
                         Batnae</persName>
               </author>
-              <title xml:lang="en">A funeral sermon of <persName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</persName> on Strangers.</title>
+              <title xml:lang="en">A funeral sermon of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on Strangers.</title>
               <rubric xml:lang="syr">ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ. ܐܟܣܢܝܐ </rubric>
               <note>See <bibl>Assemani, Bibl. Or., t. i., p. 313, no. 44, serm.
                         vii</bibl>.</note>

--- a/data/tei/839.xml
+++ b/data/tei/839.xml
@@ -114,8 +114,7 @@
                 <persName xml:lang="en">Philoxenus of Mabūg
               </persName>
               </author>
-              <title xml:lang="en">Copious extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Copious extracts from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
               <msItem xml:id="b1" n="2">
                 <locus from="1b" to="32">Foll. 1b-32</locus>
                 <title xml:lang="en">From the discourses on Christian life and
@@ -313,8 +312,7 @@
                 <persName xml:lang="en">Isaiah of Scete
               </persName>
               </author>
-              <title xml:lang="en">Selections from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>.</title>
+              <title xml:lang="en">Selections from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
               <note>See <bibl>Add. 14,575, nos. 7—11</bibl>.</note>
               <msItem xml:id="b10" n="27">
                 <locus from="73a" to="83">Foll. 73a-83</locus>

--- a/data/tei/842.xml
+++ b/data/tei/842.xml
@@ -103,8 +103,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="1a" to="94">Foll. 1a-94</locus>
-              <title xml:lang="en">The Homilies or Dissertations of <persName ref="http://syriaca.org/person/173">Moses
-                           bar Kipha</persName>, on the principal Festivals of the Church, with some
+              <title xml:lang="en">The Homilies or Dissertations of <persName ref="http://syriaca.org/person/173">Moses bar Kipha</persName>, on the principal Festivals of the Church, with some
                         other discourses by the same writer.</title>
               <rubric xml:lang="syr">ܥܠ ܚܝܠܗ ܕܡܪܢ ܝܫܘܥ ܡܫܝܚܐ̣. ܡ̇ܫܪܝܢܢ ܠܡܟܬܒ ܟܬܒܐ ܕܥ̈ܠܬܐ
                         ܕܥ̈ܐܕܐ. ܕܥܒܝܕ ܠܡܘܫܐ ܒܪ ܟܐܦܐ̣. ܐܦܝܣܩܘܦܐ ܕܒܝܬ ܪܡܢ ܘܕܒܝܬ ܥܪ̈ܒܝܐ̣܀ ܀ ܀</rubric>

--- a/data/tei/846.xml
+++ b/data/tei/846.xml
@@ -117,8 +117,7 @@
                 <title xml:lang="en">Palm Sunday.</title>
                 <msItem xml:id="c1" n="3" defective="true">
                   <locus from="1b" to="3">Foll. 1b-3</locus>
-                  <title xml:lang="en">The twentieth homily of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>.</title>
+                  <title xml:lang="en">The twentieth homily of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܣܪܝܢ ܕܐܦܝܬܪ̈ܘܢܝܘ. ܥܠ ܐܘܪܥܐ ܕܦܪܘܩܢ: ܐܘܟܝܬ
                               ܥܐܕܐ ܕܐܘ̈ܫܥܢܐ: ܘܕܗ̇ܝ ܕܒܪܝܟ ܗܘ. ܕܩܕܝܫܐ ܣܐܘܪܝܣ. ܪܝܫ ܐܦܝܣ̈ܩܘܦܐ ܕܐܢܛܝܘܟܝܐ.
                               ܦܛܪܝܪܟܐ</rubric>

--- a/data/tei/846.xml
+++ b/data/tei/846.xml
@@ -117,8 +117,7 @@
                 <title xml:lang="en">Palm Sunday.</title>
                 <msItem xml:id="c1" n="3" defective="true">
                   <locus from="1b" to="3">Foll. 1b-3</locus>
-                  <title xml:lang="en">The twentieth homily of <persName ref="http://syriaca.org/person/51">Severus of
-                              <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                  <title xml:lang="en">The twentieth homily of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                     </persName>.</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܥܣܪܝܢ ܕܐܦܝܬܪ̈ܘܢܝܘ. ܥܠ ܐܘܪܥܐ ܕܦܪܘܩܢ: ܐܘܟܝܬ
                               ܥܐܕܐ ܕܐܘ̈ܫܥܢܐ: ܘܕܗ̇ܝ ܕܒܪܝܟ ܗܘ. ܕܩܕܝܫܐ ܣܐܘܪܝܣ. ܪܝܫ ܐܦܝܣ̈ܩܘܦܐ ܕܐܢܛܝܘܟܝܐ.
@@ -153,8 +152,7 @@
                 </msItem>
                 <msItem xml:id="c7" n="9">
                   <locus from="40a" to="42">Foll. 40a-42</locus>
-                  <title xml:lang="en">Sūgyāthā of <persName ref="http://syriaca.org/person/42">Jacob of
-                                 Batnae</persName>
+                  <title xml:lang="en">Sūgyāthā of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>
                   </title>
                   <rubric xml:lang="syr">ܣܘ̈ܓܝܬܐ</rubric>
                   <msItem xml:id="d1" n="10">
@@ -208,8 +206,7 @@
                   <title xml:lang="en">Monday.</title>
                   <msItem xml:id="d6" n="18">
                     <locus from="53b" to="59">Foll. 53b-59</locus>
-                    <title xml:lang="en">Sūgīthā (of <persName ref="http://syriaca.org/person/42">Jacob of
-                                 Batnae</persName>) on <persName ref="http://syriaca.org/person/1635">Cain</persName> and
+                    <title xml:lang="en">Sūgīthā (of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>) on <persName ref="http://syriaca.org/person/1635">Cain</persName> and
                                  <persName ref="http://syriaca.org/person/1540">Abel</persName>.</title>
                     <incipit xml:lang="syr">ܫܪܒܗ ܕܗܒܝܠ ܬܗܪܐ ܡ̣ܠܢܝ ܘܠܕܘܡܪܐ ܪܥܝܢܝ
                                  ܫ̣ܪܟ</incipit>
@@ -232,8 +229,7 @@
                   <title xml:lang="en">Thursday.</title>
                   <msItem xml:id="d8" n="23">
                     <locus from="81b" to="86">Foll. 81b-86</locus>
-                    <title xml:lang="en">Sūgīthā (of <persName ref="http://syriaca.org/person/42">Jacob of
-                                    Batnae</persName>) on the Female Sinner and
+                    <title xml:lang="en">Sūgīthā (of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>) on the Female Sinner and
                                  <persName ref="http://syriaca.org/person/3651">Satan</persName>.</title>
                     <rubric xml:lang="syr">ܣܘܓܝܬܐ ܕܥܠ ܚܛܝܬܐ ܘܣܛܢܐ </rubric>
                     <incipit xml:lang="syr">ܫܒ̇ܩ ܚܘ̈ܒܐ ܠܐܪܥܐ ܢܚ̣ܬ. ܘܡܢ ܒܪܬ ܕܘܝܕ ܦܓܪܐ ܠܒ̣ܫ. </incipit>
@@ -249,8 +245,7 @@
                   <title xml:lang="en">Friday.</title>
                   <msItem xml:id="d10" n="26">
                     <locus from="95b" to="109">Foll. 95b-109</locus>
-                    <title xml:lang="en">Sūgyāthā of <persName ref="http://syriaca.org/person/42">Jacob of
-                                    Batnae</persName>.</title>
+                    <title xml:lang="en">Sūgyāthā of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName>.</title>
                     <msItem xml:id="e1" n="27">
                       <locus from="95b" to="97">Foll. 95b-97</locus>
                       <title xml:lang="en">First, on the Apostasy of

--- a/data/tei/847.xml
+++ b/data/tei/847.xml
@@ -156,8 +156,7 @@
                   <author ref="http://syriaca.org/person/452">
                     <persName xml:lang="en">Dionysius the Areopagite</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the letters of <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName>
+                  <title xml:lang="en">Extracts from the letters of <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>
                 </title>
                   <note>See <bibl>Opera, t. i., pp. 589, seqq.</bibl>
                   </note>
@@ -227,8 +226,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <msItem xml:id="p1c6" n="11">
                     <locus from="2b"/>
@@ -268,8 +266,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/511">Gregory
-                    Nazianzen</persName>
+                  <title xml:lang="en">A short extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܓܪܝܘܣ</rubric>
                 </msItem>
@@ -330,8 +327,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܓܪܓܪܝܘܣ ܕܢܙܝܢܙܘ</rubric>
                   <msItem xml:id="p1c11" n="22">
@@ -373,8 +369,7 @@
                   <author ref="http://syriaca.org/person/548">
                     <persName xml:lang="en">Isaiah of Scete</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of
-                  <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܕܐܒܐ ܐܫܥܝܐ ܝܚܝܕܝܐ</rubric>
@@ -433,8 +428,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/33">Isaac of
-                    <placeName>Antioch</placeName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܐܝܣܚܩ</rubric>
@@ -453,8 +447,7 @@
                   <author ref="http://syriaca.org/person/619">
                     <persName xml:lang="en">Marcus the monk</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/1869">Marcus the
-                  monk</persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/1869">Marcus the monk</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܡܪܩܘܣ ܝܚܝܕܝܐ</rubric>
                 </msItem>
@@ -463,8 +456,7 @@
                   <author ref="http://syriaca.org/person/452">
                     <persName xml:lang="en">Dionysius the Areopagite</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܕܝܢܣܝܘܣ ܡܛܠ ܗܠܝܢ ܕܐܬܝܢ ܠܬܘܠܡܕܐ</rubric>
                 </msItem>
@@ -482,8 +474,7 @@
                   <author ref="http://syriaca.org/person/794">
                     <persName xml:lang="en">Titus of Bostra</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/794">Titus of
-                    <placeName>Bostra</placeName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/794">Titus of <placeName>Bostra</placeName>
                   </persName> on <ref target="http://syriaca.org/work/9648">S. Luke, chapp. i. and ii</ref>.</title>
                   <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܦܬܓ̈ܡܐ ܡܢ ܐܘܢܓܠܝܘܢ: ܕܩܕܝܫܐ ܛܛܘܣ ܐܦܣܩܘܦܐ
                   ܕܒܘܨܪܐ.</rubric>
@@ -538,8 +529,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of
-                    <placeName>Antioch</placeName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
                   </persName>
                 </title>
                   <msItem xml:id="p1c16" n="44">
@@ -851,8 +841,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܓܪܝܘܣ ܡܡܠܠ ܐܠܗ̈ܝܬܐ ܡܢ ܡܐܡܪܐ ܕܥܠ ܥܡܕܐ</rubric>
                 </msItem>
@@ -888,8 +877,7 @@
                   <author ref="http://syriaca.org/person/2163">
                     <persName xml:lang="en">Julius of Rome</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/2163">Julius of
-                  <placeName>Rome</placeName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/2163">Julius of <placeName>Rome</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܝܘܠܝܘܣ ܕܪܘܡܐ</rubric>
@@ -911,8 +899,7 @@
                   <author ref="http://syriaca.org/person/452">
                     <persName xml:lang="en">Dionysius the Areopagite</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the letter of <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName> to <persName>Timothy</persName>
+                  <title xml:lang="en">Extracts from the letter of <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName> to <persName>Timothy</persName>
                 </title>
                   <rubric xml:lang="syr">ܡܛܠ ܕܗܢ̣ܘܢ ܟܕ ܗܢ̣ܘܢ ܦܓܪ̈ܐ ܕܒܗܘܢ ܐܬܕܒܪܘ ܐܘܟܝܬ ܐܬܗܦܟ ܢ̈ܦܫܬܐ
                   ܒܥܠܡܐ ܗܢܐ: ܗܢ̣ܘܢ ܩܝܡܝܢ ܕܠܐ ܚܒܠܐ ܒܢܘܚܡܐ. ܘܠܘ ܐܚܪ̈ܢܐ ܚܠܦܝܗܘܢ ܡܬܚܝܕܝܢ ܠܢܦܫ̈ܬܐ܇ ܘܒܗܘܢ
@@ -956,8 +943,7 @@
                   <author>
                     <persName xml:lang="en">Peter of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of
-                  <placeName>Alexandria</placeName>
+                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of <placeName>Alexandria</placeName>
                   </persName> <title xml:lang="grc">
                     περὶ τοῦ μηδὲ προυπάρχειν τὴν ψυχήν,
                                     μηδὲ ἁμαρτήσασαν τοῦτο εἰς τὸ σῶμα βληθῆναι
@@ -991,8 +977,7 @@
                     <persName xml:lang="en">Basil</persName>
                   </author>
                   <title xml:lang="en">Extract from the letter of <persName ref="http://syriaca.org/person/376">Basil</persName> to
-                  <persName ref="http://syriaca.org/person/963">Ambrose of
-                    <placeName>Milan</placeName>
+                  <persName ref="http://syriaca.org/person/963">Ambrose of <placeName>Milan</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܒܣܝܠܝܘܣ ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܡܒܪܘܣܝܘܣ ܐܦܝܣܩܘܦܐ
@@ -1004,8 +989,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܓܪܓܘܪܝܘܣ ܡܡܠܠ ܐܠܗ̈ܝܬܐ ܡܢ ܡܐܡܪܐ ܕܥܠ ܩܒܘܪܬܐ ܕܩܣܪܝܘܣ
                   ܐܚܘܗܝ.</rubric>
@@ -1015,8 +999,7 @@
                   <author>
                     <persName xml:lang="en">John of Jerusalem</persName>
                   </author>
-                  <title xml:lang="en">Extract from the Apology of <persName>John of
-                    <placeName>Jerusalem</placeName>
+                  <title xml:lang="en">Extract from the Apology of <persName>John of <placeName>Jerusalem</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܕܝܘܚܢܢ ܐܦܝܣܩܘܦܐ ܕܐܘܪܫܠܡ ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܥܒܕ ܠܘܬ ܗܠܝܢ ܕܒܗ̇ܘ
@@ -1027,8 +1010,7 @@
                   <author ref="http://syriaca.org/person/2507">
                     <persName xml:lang="en">Theophilus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/2507">Theophilus of
-                    <placeName>Alexandria</placeName>
+                  <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName>Alexandria</placeName>
                   </persName> to the monks at <placeName xml:lang="syr">ܐܦܝܠܛܘܣ</placeName>
                   </title>
                 </msItem>
@@ -1045,8 +1027,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extract from a discourse of <persName ref="http://syriaca.org/person/33">Isaac of
-                  <placeName>Antioch</placeName>
+                  <title xml:lang="en">Extract from a discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
                   </persName> on the Resurrection</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ ܡܠܦܢܐ ܕܥܠ ܢܘܚܡܐ.</rubric>
                 </msItem>
@@ -1055,8 +1036,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the Commentaries of <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName> on <ref target="http://syriaca.org/work/9643">the Pauline Epistles</ref>
+                  <title xml:lang="en">Extracts from the Commentaries of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9643">the Pauline Epistles</ref>
                   </title>
                   <msItem xml:id="p1c30" n="93">
                     <locus from="63a"/>
@@ -1130,8 +1110,7 @@
                   <author ref="http://syriaca.org/person/44">
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
-                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                   </persName>, entitled "<title xml:lang="en">
                     the Book of Sentences or
                     Maxims
@@ -1143,8 +1122,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܓܘܪܝܘܣ ܡܡܠܠ ܐܠܗ̈ܝܬܐ. ܡܢ ܡܐܡܪܐ ܕܡܛܠ ܒܬܘܠܘܬܐ</rubric>
                 </msItem>
@@ -1162,8 +1140,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܓܪܓܘܪܝܘܣ ܬܐܘܠܓܘܣ. ܡܢ ܡܐܡܪܐ ܕܡܛܠ ܒܪܐ.</rubric>
                 </msItem>
@@ -1172,8 +1149,7 @@
                   <author ref="http://syriaca.org/person/511">
                     <persName xml:lang="en">Gregory Nazianzen</persName>
                   </author>
-                  <title xml:lang="en">Extract from the first epistle of <persName ref="http://syriaca.org/person/511">Gregory
-                    Nazianzen</persName> to <persName>Cledonius</persName>
+                  <title xml:lang="en">Extract from the first epistle of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> to <persName>Cledonius</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܡܘܕܝܢ ܐܒ̈ܗܬܐ ܩ̈ܕܝܫܐ ܘܡܟܪ̈ܙܝܢ ܕܗܘܼ ܒܣܪܐ ܡܢ ܝܡܝܢܐ ܝܬܒ. ܘܗܫܐ
                   ܒܒܣܪܐ ܐܝܬܘܗܝ ܡܪܢ. ܘܥܡܗ ܐܬ݂ܐ. ܟܕ ܐܝܬܘܗܝ ܡܫܒܚܐ ܘܠܐ ܡܬܚܒܠܢܐ ܘܠܐ ܡܝܘܬܐ ܕܢܕܘܢ ܚ̈ܝܐ
@@ -1186,8 +1162,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Extract from the Commentary of <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName> on <ref target="http://syriaca.org/work/9596">2nd Corinthians</ref>, hom. xi.</title>
+                  <title xml:lang="en">Extract from the Commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9596">2nd Corinthians</ref>, hom. xi.</title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܝܘܗܢܝܣ. ܡܢ ܡܐܡܪܐ ܕܚܕܥܣܪ ܕܦܘܫܩܐ ܕܐܓܪܬܐ ܕܬܪ̈ܬܝܢ ܕܠܘܬ
                   ܩܘܪ̈ܢܬܝܐ.</rubric>
                 </msItem>
@@ -1236,8 +1211,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">Extract from the Commentary of <persName ref="http://syriaca.org/person/573">John
-                    Chrysostom</persName> on <ref target="http://syriaca.org/work/9594">the Epistle to the Romans</ref>, hom. xix.</title>
+                  <title xml:lang="en">Extract from the Commentary of <persName ref="http://syriaca.org/person/573">John Chrysostom</persName> on <ref target="http://syriaca.org/work/9594">the Epistle to the Romans</ref>, hom. xix.</title>
                   <rubric xml:lang="syr">ܕܬܫܬܥܣܪ ܕܦܘܫܩܐ ܕܐܓܪܬܐ ܕܠܘܬ ܪ̈ܗܘܡܝܐ.</rubric>
                 </msItem>
                 <msItem xml:id="p1b76" n="111">
@@ -1258,8 +1232,7 @@
                     <persName xml:lang="en">Severus</persName>
                   </author>
                   <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/51">Severus</persName> to
-                    <persName ref="http://syriaca.org/person/2417">Solon, bishop of
-                      <placeName>Isauria</placeName>
+                    <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName>Isauria</placeName>
                   </persName>
                 </title>
                   <rubric xml:lang="syr">ܡܛܠ ܕܠܘ ܡܬܪܓܫܢܐ ܗܘ ܒܘܣܡܐ ܕܛܒ̈ܬܐ ܗܠܝܢ ܕܢܛܝܪ̈ܢ ܠܢ ܘܡܛܠ ܕܦܓܪ̈ܐ

--- a/data/tei/847.xml
+++ b/data/tei/847.xml
@@ -369,8 +369,7 @@
                   <author ref="http://syriaca.org/person/548">
                     <persName xml:lang="en">Isaiah of Scete</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                  </persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܕܐܒܐ ܐܫܥܝܐ ܝܚܝܕܝܐ</rubric>
                 </msItem>
@@ -428,8 +427,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
-                  </persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܕܡܪܝ ܐܝܣܚܩ</rubric>
                 </msItem>
@@ -474,8 +472,7 @@
                   <author ref="http://syriaca.org/person/794">
                     <persName xml:lang="en">Titus of Bostra</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/794">Titus of <placeName>Bostra</placeName>
-                  </persName> on <ref target="http://syriaca.org/work/9648">S. Luke, chapp. i. and ii</ref>.</title>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/794">Titus of <placeName>Bostra</placeName></persName> on <ref target="http://syriaca.org/work/9648">S. Luke, chapp. i. and ii</ref>.</title>
                   <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܦܬܓ̈ܡܐ ܡܢ ܐܘܢܓܠܝܘܢ: ܕܩܕܝܫܐ ܛܛܘܣ ܐܦܣܩܘܦܐ
                   ܕܒܘܨܪܐ.</rubric>
                 </msItem>
@@ -529,8 +526,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                  </persName>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName>
                 </title>
                   <msItem xml:id="p1c16" n="44">
                     <locus from="37a"/>
@@ -877,8 +873,7 @@
                   <author ref="http://syriaca.org/person/2163">
                     <persName xml:lang="en">Julius of Rome</persName>
                   </author>
-                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/2163">Julius of <placeName>Rome</placeName>
-                  </persName>
+                  <title xml:lang="en">Extract from <persName ref="http://syriaca.org/person/2163">Julius of <placeName>Rome</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܝܘܠܝܘܣ ܕܪܘܡܐ</rubric>
                 </msItem>
@@ -943,8 +938,7 @@
                   <author>
                     <persName xml:lang="en">Peter of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of <placeName>Alexandria</placeName>
-                  </persName> <title xml:lang="grc">
+                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of <placeName>Alexandria</placeName></persName> <title xml:lang="grc">
                     περὶ τοῦ μηδὲ προυπάρχειν τὴν ψυχήν,
                                     μηδὲ ἁμαρτήσασαν τοῦτο εἰς τὸ σῶμα βληθῆναι
                   </title>
@@ -977,8 +971,7 @@
                     <persName xml:lang="en">Basil</persName>
                   </author>
                   <title xml:lang="en">Extract from the letter of <persName ref="http://syriaca.org/person/376">Basil</persName> to
-                  <persName ref="http://syriaca.org/person/963">Ambrose of <placeName>Milan</placeName>
-                  </persName>
+                  <persName ref="http://syriaca.org/person/963">Ambrose of <placeName>Milan</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܒܣܝܠܝܘܣ ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܡܒܪܘܣܝܘܣ ܐܦܝܣܩܘܦܐ
                   ܕܡܕܘܠܝܐ.</rubric>
@@ -999,8 +992,7 @@
                   <author>
                     <persName xml:lang="en">John of Jerusalem</persName>
                   </author>
-                  <title xml:lang="en">Extract from the Apology of <persName>John of <placeName>Jerusalem</placeName>
-                  </persName>
+                  <title xml:lang="en">Extract from the Apology of <persName>John of <placeName>Jerusalem</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܕܝܘܚܢܢ ܐܦܝܣܩܘܦܐ ܕܐܘܪܫܠܡ ܡܢ ܡܦܩ ܒܪܘܚܐ ܕܥܒܕ ܠܘܬ ܗܠܝܢ ܕܒܗ̇ܘ
                   ܙܒܢܐ.</rubric>
@@ -1010,8 +1002,7 @@
                   <author ref="http://syriaca.org/person/2507">
                     <persName xml:lang="en">Theophilus of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName>Alexandria</placeName>
-                  </persName> to the monks at <placeName xml:lang="syr">ܐܦܝܠܛܘܣ</placeName>
+                  <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName>Alexandria</placeName></persName> to the monks at <placeName xml:lang="syr">ܐܦܝܠܛܘܣ</placeName>
                   </title>
                 </msItem>
                 <msItem xml:id="p1b60" n="90">
@@ -1027,8 +1018,7 @@
                   <author ref="http://syriaca.org/person/33">
                     <persName xml:lang="en">Isaac of Antioch</persName>
                   </author>
-                  <title xml:lang="en">Extract from a discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName>
-                  </persName> on the Resurrection</title>
+                  <title xml:lang="en">Extract from a discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName>Antioch</placeName></persName> on the Resurrection</title>
                   <rubric xml:lang="syr">ܡܐܡܪܐ ܕܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ ܡܠܦܢܐ ܕܥܠ ܢܘܚܡܐ.</rubric>
                 </msItem>
                 <msItem xml:id="p1b62" n="92">
@@ -1110,8 +1100,7 @@
                   <author ref="http://syriaca.org/person/44">
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
-                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName>, entitled "<title xml:lang="en">
+                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>, entitled "<title xml:lang="en">
                     the Book of Sentences or
                     Maxims
                   </title>"</title>
@@ -1232,8 +1221,7 @@
                     <persName xml:lang="en">Severus</persName>
                   </author>
                   <title xml:lang="en">Extract from a letter of <persName ref="http://syriaca.org/person/51">Severus</persName> to
-                    <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName>Isauria</placeName>
-                  </persName>
+                    <persName ref="http://syriaca.org/person/2417">Solon, bishop of <placeName>Isauria</placeName></persName>
                 </title>
                   <rubric xml:lang="syr">ܡܛܠ ܕܠܘ ܡܬܪܓܫܢܐ ܗܘ ܒܘܣܡܐ ܕܛܒ̈ܬܐ ܗܠܝܢ ܕܢܛܝܪ̈ܢ ܠܢ ܘܡܛܠ ܕܦܓܪ̈ܐ
                   ܡܢ ܒܬܪ ܩܝܡܬܐ̣. ܠܐ ܡ̈ܬܓܠܙܝܢ ܡܢ ܗ̈ܕܡܐ ܡ̈ܘܠܕܢܐ. ܐܠܐ ܒܫܘܒܚܐ ܡ̈ܬܒܠܥܝܢ ܐܣ̈ܟܡܐ ܕܦܘܪܣܝܐ ..

--- a/data/tei/847.xml
+++ b/data/tei/847.xml
@@ -545,10 +545,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus of Antioch</persName>
                     </author>
-                    <title xml:lang="en">From <title xml:lang="en" ref="http://syriaca.org/work/3145">
-                    a letter to the priest
-                        <persName>Leontius</persName>
-                  </title>
+                    <title xml:lang="en">From <title xml:lang="en" ref="http://syriaca.org/work/3145">a letter to the priest <persName>Leontius</persName></title>
                   </title>
                     <rubric xml:lang="syr">ܡܛܠ ܗ̇ܝ ܕܐܡܪ ܡܪܢ ܕܠܐ ܐܫܬܐ ܥܡܟܘܢ ܡܢ ܗܫܐ ܡܢ ܗܢܐ ܝܠܕܐ ܕܟܦܬܐ
                     ܥܕܡܐ ܠܝܘܡܐ ܗ̇ܘ ܕܒܗ ܐܫܬܝܘܗܝ ܚܬܝܬ ܥܡܟܘܢ ܒܡܠܟܘܬܗ ܕܐܒܝ. ܡܢ ܐܓܪܬܐ ܕܫܬܝܢ. ܕܐܬܟܬܒܬ ܠܘܬ
@@ -670,10 +667,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus</persName>
                     </author>
-                    <title xml:lang="en">From <title xml:lang="en" ref="http://syriaca.org/work/3003">
-                    a letter to <persName>Phocas</persName> and
-                        <persName>Eupraxius</persName>
-                  </title>
+                    <title xml:lang="en">From <title xml:lang="en" ref="http://syriaca.org/work/3003">a letter to <persName>Phocas</persName> and <persName>Eupraxius</persName></title>
                   </title>
                     <rubric xml:lang="syr">ܡܛܠ ܗ̇ܝ ܕܗܐ ܡܫܕܪ ܐܢܐ ܨ̈ܝܕܐ ܣ̈ܓܝܐܐ ܐܡܪ ܡܪܝܐ ܘܗܠܝܢ ܕܫܪܟܐ ܬܘܒ
                     ܕܝܠܗ ܡܢ ܐܓܪܬܐ ܕܥܣܪ ܕܐܬܟܬܒܬ ܠܘܬ ܦܘܩܐ ܘܐܘܦܪܟܣܝܣ <sic>ܩܒ̈ܘܠܩܪܐ</sic>
@@ -938,8 +932,7 @@
                   <author>
                     <persName xml:lang="en">Peter of Alexandria</persName>
                   </author>
-                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of <placeName>Alexandria</placeName></persName> <title xml:lang="grc">
-                    περὶ τοῦ μηδὲ προυπάρχειν τὴν ψυχήν,
+                  <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/1413">Peter of <placeName>Alexandria</placeName></persName> <title xml:lang="grc">περὶ τοῦ μηδὲ προυπάρχειν τὴν ψυχήν,
                                     μηδὲ ἁμαρτήσασαν τοῦτο εἰς τὸ σῶμα βληθῆναι
                   </title>
                   </title>
@@ -1100,10 +1093,7 @@
                   <author ref="http://syriaca.org/person/44">
                     <persName xml:lang="en">Philoxenus of Mabūg</persName>
                   </author>
-                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>, entitled "<title xml:lang="en">
-                    the Book of Sentences or
-                    Maxims
-                  </title>"</title>
+                  <title xml:lang="en">Extract from the fifth chapter of a work of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>, entitled "<title xml:lang="en">the Book of Sentences or Maxims </title>"</title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܝܠܝܟܣܝܢܘܣ. ܡܢ ܟܬܒܐ ܕܪ̈ܥܝܢܐ. ܡܢ ܪܥܝܢܐ ܕܚܡܫܐ.</rubric>
                 </msItem>
                 <msItem xml:id="p1b66" n="101">

--- a/data/tei/848.xml
+++ b/data/tei/848.xml
@@ -288,16 +288,14 @@
               <msItem xml:id="b8" n="24">
                 <locus from="192b" to="227">Foll. 192b-227</locus>
                 <title xml:lang="en">The seventeenth book of the treatise of
-                           <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> on
+                           <persName ref="http://syriaca.org/person/430">Cyril of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on
                            Worship in Spirit and in Truth.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܫܒܬܥܣܪ ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܕܥܠ ܥܐܕ̈ܐ ܕܩ̈ܕܝܫܐ </rubric>
                 <note>See <bibl>Opera, ed. Aubert, t. i., p. 590</bibl>.</note>
               </msItem>
               <msItem xml:id="b9" n="25">
                 <locus from="228a" to="230">Foll. 228a-230</locus>
-                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName> on Spiritual
+                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName> on Spiritual
                            Beings.</title>
                 <rubric xml:lang="syr"> ܡܐܡܪܐ ܕܣܝܡ ܠܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ ܡܠܦܢܐ ܕܥܠ
                            ܪ̈ܘܚܢܐ.</rubric>
@@ -319,8 +317,7 @@
               </msItem>
               <msItem xml:id="b11" n="27">
                 <locus from="231b" to="254">Foll. 231b-254</locus>
-                <title xml:lang="en">The Life of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName ref="http://syriaca.org/place/714">Cyprus</placeName>
-                  </persName>, written by his disciple
+                <title xml:lang="en">The Life of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName ref="http://syriaca.org/place/714">Cyprus</placeName></persName>, written by his disciple
                            <persName ref="http://syriaca.org/person/2794">John</persName>.</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܛܘܒܢܐ ܡܪܝ ܐܦܝܦܢ ܐܦܝܣܩܘܦܐ ܕܗܘ̣ܐ ܒܩܘܣܛܢܛܝܢܐ
                            ܕܒܩܘܦܪܘܣ ܓܙܪܬܐ</rubric>
@@ -340,8 +337,7 @@
               </msItem>
               <msItem xml:id="b13" n="29">
                 <locus from="260a" to="268">Foll. 260a-268</locus>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName ref="http://syriaca.org/place/641">Rome</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName ref="http://syriaca.org/place/641">Rome</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܛܘܒܢܐ ܝܘܚܢܢ ܕܡܢ ܪܗܘܡܐ</rubric>
                 <note>See <bibl>Add. 14,649, no. 23</bibl>.</note>
               </msItem>
@@ -358,8 +354,7 @@
               </msItem>
               <msItem xml:id="b15" n="31">
                 <locus from="278a" to="282">Foll. 278-282</locus>
-                <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2485">Alexander of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                  </persName> on the Incarnation of
+                <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2485">Alexander of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName> on the Incarnation of
                            <persName ref="http://syriaca.org/person/2245">our Lord</persName>, and on the Soul and the Body.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܛܘܒܬܢܐ ܐܠܟܣܢܕܪܘܣ. ܥܠ ܡܬܓܫܡܢܘܬܗ ܕܡܪܢ̇ ܘܥܠ ܢܦܫܐ
                            ܘܥܠ ܦܓܪܐ</rubric>

--- a/data/tei/848.xml
+++ b/data/tei/848.xml
@@ -177,8 +177,7 @@
               </msItem>
               <msItem xml:id="b3" n="14">
                 <locus from="78a" to="81a">Foll. 78a-81a</locus>
-                <title xml:lang="en">Two letters of <persName>John the
-                              monk</persName> on Love.</title>
+                <title xml:lang="en">Two letters of <persName>John the monk</persName> on Love.</title>
                 <rubric xml:lang="syr">ܐܓܪ̈ܬܐ ܕܚܘܒܐ</rubric>
                 <finalRubric xml:lang="syr">ܫܠܡ ܕܐܓܢܛܝܣ<locus from="81a"/>
                 </finalRubric>
@@ -199,8 +198,7 @@
               </msItem>
               <msItem xml:id="b5" n="16">
                 <locus from="82b" to="160">Foll. 82b-160</locus>
-                <title xml:lang="en">Writings of <persName>Marcus the
-                           monk</persName>.</title>
+                <title xml:lang="en">Writings of <persName>Marcus the monk</persName>.</title>
                 <msItem xml:id="c11" n="17">
                   <locus from="82b" to="106b">Foll. 82b-106b</locus>
                   <title xml:lang="en">On Baptism.</title>
@@ -255,11 +253,8 @@
               </msItem>
               <msItem xml:id="b6" n="22">
                 <locus from="160b"/>
-                <title xml:lang="en">The eighth discourse of <persName>Gregory the
-                              monk</persName>, on the exercise of the virtues, in the form of a
-                           dialogue, addressed to his friends, the <persName>bishop
-                              Theodore</persName> and the <persName>abbat
-                           Epiphanius</persName>.</title>
+                <title xml:lang="en">The eighth discourse of <persName>Gregory the monk</persName>, on the exercise of the virtues, in the form of a
+                           dialogue, addressed to his friends, the <persName>bishop Theodore</persName> and the <persName>abbat Epiphanius</persName>.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܡܢܝܐ ܕܓܪܝܓܪܝܘܣ ܝܚܝܕܝܐ ܕܥܠ ܦܘܠܚܢܐ ܕܡܝܬܪ̈ܬܐ.
                            ܒܫܐܘܠܐ ܘܒܦܘܢܝ ܦܓܬܡܐ. ܕܟܬܒ ܠܘܬ ܬܐܘܕܘܪܘܣ ܐܦܝܣܩܘܦܐ. ܘܠܘܬ ܐܒܐ ܐܦܝܦܢܝܘܣ
                            ܪ̈ܚܡܘܗܝ. ܕܒܥܘ ܡܢܗ</rubric>
@@ -301,8 +296,7 @@
               </msItem>
               <msItem xml:id="b9" n="25">
                 <locus from="228a" to="230">Foll. 228a-230</locus>
-                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of
-                           <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Metrical discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName> on Spiritual
                            Beings.</title>
                 <rubric xml:lang="syr"> ܡܐܡܪܐ ܕܣܝܡ ܠܩܕܝܫܐ ܡܪܝ ܐܝܣܚܩ ܡܠܦܢܐ ܕܥܠ
@@ -325,8 +319,7 @@
               </msItem>
               <msItem xml:id="b11" n="27">
                 <locus from="231b" to="254">Foll. 231b-254</locus>
-                <title xml:lang="en">The Life of <persName ref="http://syriaca.org/person/477">Epiphanius of
-                           <placeName ref="http://syriaca.org/place/714">Cyprus</placeName>
+                <title xml:lang="en">The Life of <persName ref="http://syriaca.org/person/477">Epiphanius of <placeName ref="http://syriaca.org/place/714">Cyprus</placeName>
                   </persName>, written by his disciple
                            <persName ref="http://syriaca.org/person/2794">John</persName>.</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܛܘܒܢܐ ܡܪܝ ܐܦܝܦܢ ܐܦܝܣܩܘܦܐ ܕܗܘ̣ܐ ܒܩܘܣܛܢܛܝܢܐ
@@ -347,8 +340,7 @@
               </msItem>
               <msItem xml:id="b13" n="29">
                 <locus from="260a" to="268">Foll. 260a-268</locus>
-                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of
-                           <placeName ref="http://syriaca.org/place/641">Rome</placeName>
+                <title xml:lang="en">The history of <persName ref="http://syriaca.org/person/1818">John of <placeName ref="http://syriaca.org/place/641">Rome</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܛܘܒܢܐ ܝܘܚܢܢ ܕܡܢ ܪܗܘܡܐ</rubric>
                 <note>See <bibl>Add. 14,649, no. 23</bibl>.</note>
@@ -366,8 +358,7 @@
               </msItem>
               <msItem xml:id="b15" n="31">
                 <locus from="278a" to="282">Foll. 278-282</locus>
-                <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2485">Alexander of
-                           <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
+                <title xml:lang="en">Homily of <persName ref="http://syriaca.org/person/2485">Alexander of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
                   </persName> on the Incarnation of
                            <persName ref="http://syriaca.org/person/2245">our Lord</persName>, and on the Soul and the Body.</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܛܘܒܬܢܐ ܐܠܟܣܢܕܪܘܣ. ܥܠ ܡܬܓܫܡܢܘܬܗ ܕܡܪܢ̇ ܘܥܠ ܢܦܫܐ
@@ -380,8 +371,7 @@
               </msItem>
               <msItem xml:id="b16" n="32">
                 <locus from="282b" to="310">Foll. 282b-310</locus>
-                <title xml:lang="en">The History or Doctrine of <persName ref="http://syriaca.org/person/1826">S. John the
-                           Evangelist</persName> at <placeName ref="http://syriaca.org/place/623">Ephesus</placeName>.</title>
+                <title xml:lang="en">The History or Doctrine of <persName ref="http://syriaca.org/person/1826">S. John the Evangelist</persName> at <placeName ref="http://syriaca.org/place/623">Ephesus</placeName>.</title>
                 <rubric xml:lang="syr">ܬܫܥܝܬܐ ܕܩܕܝܫܐ ܘܪܚܝܡܐ ܡܪܝ ܝܘܚܢܢ ܐܘܢܓܠܣܛܐ: ܕܡ̇ܠܠ ܘܬܠܡܕ
                            ܘܐܥܡܕ ܒܡܥܕܪܢܘܬܐ ܕܡܪܢ ܝܫܘܥ ܡܫܝܚܐ: ܒܐܦܣܘܣ ܡܕܝܢܬܐ</rubric>
               </msItem>

--- a/data/tei/848.xml
+++ b/data/tei/848.xml
@@ -304,9 +304,7 @@
               </msItem>
               <msItem xml:id="b10" n="26">
                 <locus from="231a" to="231">Foll. 231a-231</locus>
-                <title xml:lang="en">An extract from a homily of <placeName ref="http://syriaca.org/person/688">Proclus
-                           of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                  </placeName> on the
+                <title xml:lang="en">An extract from a homily of <placeName ref="http://syriaca.org/person/688">Proclus of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></placeName> on the
                            Nativity.</title>
                 <rubric xml:lang="syr">ܕܛܘܒܢܐ ܦܪܘܩܠܘܣ ܐܦܣܩܦܐ (sic)  ܕܩܘܣܛܢܛܝܢܐܦܘܠܝܣ ܡܢ
                            ܬܘܪܓܡܐ ܕܥܠ ܝܠܕܗ ܕܡܫܝܚܐ.</rubric>

--- a/data/tei/849.xml
+++ b/data/tei/849.xml
@@ -149,8 +149,7 @@
                 <author ref="http://syriaca.org/person/1826">
                   <persName xml:lang="en">S. John</persName>
                 </author>
-                <title xml:lang="en">The passage from <ref target="http://syriaca.org/work/9641">the
-                    Gospel of S. John, regarding the woman taken in adultery, ch. viii.
+                <title xml:lang="en">The passage from <ref target="http://syriaca.org/work/9641">the Gospel of S. John, regarding the woman taken in adultery, ch. viii.
                   3—11</ref>.</title>
                 <incipit xml:lang="syr">ܬܘܒ ܏ܫܪܒܐ ܏ܐܚܪܢܐ. ܐܝܬ ܗܘܐ ܒܗ ܒܐܘܢܓܠܝܘܢ ܕܝܠܗ ܕܩܕܝܫܐ ܡܪܐ
                   ܐܦܝܣܩܘܦܐ ܘܒܩܢܘܢܐ ܕ܏ܦܛ ܪܝܫܐ ܕܚܕܢܐܝܬ ܐܡܝܪ ܠܝܘܚܢܢ ܒܐܘܢܓܠܝܘܢ ܕܝܠܗ̣. ܘܠܐ ܫܟܝܚ ܒܨ̈ܚܚܐ
@@ -614,8 +613,7 @@
               </msItem>
               <msItem xml:id="b39" n="50">
                 <locus from="16b"/>
-                <title xml:lang="en">Select sentences from the <ref target="http://syriaca.org/work/9623">Proverbs of <persName ref="http://syriaca.org/person/3571">Solomon</persName>
-                  </ref>
+                <title xml:lang="en">Select sentences from the <ref target="http://syriaca.org/work/9623">Proverbs of <persName ref="http://syriaca.org/person/3571">Solomon</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡ̈ܠܐ ܡܢ ܚܟܝ̈ܡܐ ܠܘܩܒܠ ܐܝܠܝܢ ܕܠܐ ܡ̇ܩܒܠܝܢ
                   ܡܪܕܘܬܐ.</rubric>
@@ -837,9 +835,7 @@
                 <author ref="http://syriaca.org/person/1118">
                   <persName xml:lang="en">Addai the Apostle</persName>
                 </author>
-                <title xml:lang="en">Two extracts from the <ref target="http://syriaca.org/work/922">Doctrine of <persName ref="http://syriaca.org/person/1118">Addai
-                      the Apostle</persName>
-                  </ref>
+                <title xml:lang="en">Two extracts from the <ref target="http://syriaca.org/work/922">Doctrine of <persName ref="http://syriaca.org/person/1118">Addai the Apostle</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܢ ܐܓܪܬܐ ܕܐܕܝ ܫܠܝܚܐ ܕܡܠܠ ܒܐܘܪܗܝ ܡܕܝܢܬܐ</rubric>
                 <note>See <bibl>Cureton's Ancient Syriac Documents, p. <foreign xml:lang="syr">ܩܛ</foreign>, nos. <foreign xml:lang="syr">ܓ</foreign> and
@@ -849,8 +845,7 @@
               <msItem xml:id="b54" n="74">
                 <locus from="37a"/>
                 <title xml:lang="en">Extracts from the Canons of <persName ref="http://syriaca.org/person/1605">the Apostles</persName>, as contained in
-                  the <ref target="http://syriaca.org/work/1559">Doctrine of <persName ref="http://syriaca.org/person/1605">the Apostles</persName>
-                  </ref>
+                  the <ref target="http://syriaca.org/work/1559">Doctrine of <persName ref="http://syriaca.org/person/1605">the Apostles</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܡܢ ܩ̈ܢܘܢܐ ܕܫ̈ܠܝܚܐ</rubric>
                 <note>See <bibl>Cureton's Ancicnt Syriac Documents, pp. <foreign xml:lang="syr">ܟܗ</foreign> — <foreign xml:lang="syr">ܟܙ</foreign>.</bibl>
@@ -1051,9 +1046,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus</persName>
                   </author>
-                  <title xml:lang="en">On <ref target="http://syriaca.org/work/9648">
-                      <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                    , ch. xi.
+                  <title xml:lang="en">On <ref target="http://syriaca.org/work/9648"><persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. xi.
                     5—8</ref>
                   </title>
                   <rubric xml:lang="syr">ܕܝܠܗ ܡܢ ܐܓܪܬܐ ܟܕ ܡ̇ܦܫܩ ܠܗܠܝܢ ܕܐܡܪ ܡܪܢ
@@ -1183,9 +1176,7 @@
               </msItem>
               <msItem xml:id="b71" n="112">
                 <locus from="47a"/>
-                <title xml:lang="en">On <ref target="http://syriaca.org/work/9648">
-                    <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  , ch. ii.
+                <title xml:lang="en">On <ref target="http://syriaca.org/work/9648"><persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. ii.
                   23</ref>
                 </title>
                 <rubric xml:lang="syr">ܕܡܢܐ ܗܝ ܗ̇ܝ ܕܐܡ̇ܪ ܕܟܠ ܒܘܟܪܐ ܦܬ̇ܚ ܪ̈ܚ̣ܡܐ ܕܐܡܗ ܩܘܕܫܐ ܠܡܪܝܐ
@@ -1233,8 +1224,7 @@
                 <author ref="http://syriaca.org/person/827">
                   <persName xml:lang="en">John the Monk</persName>
                 </author>
-                <title xml:lang="en">Extracts from a Commentary on <ref target="http://syriaca.org/work/9538">the book of
-                    Ecclesiastes</ref> by <persName>John the Monk</persName>
+                <title xml:lang="en">Extracts from a Commentary on <ref target="http://syriaca.org/work/9538">the book of Ecclesiastes</ref> by <persName>John the Monk</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܦܘܫܩܐ ܕܡ̈ܠܐ ܡܢ ܟܬܒܐ ܕܩܘܗܠܬ ܚܟܝܡܐ. ܕܥܒܝܕ ܠܩܕܝܫܐ ܝܘܚܢܢ
                   ܝܚܝܕܝܐ.</rubric>
@@ -1293,8 +1283,7 @@
                   Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> on the <ref>Old
-                  Testament</ref>
+                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> on the <ref>Old Testament</ref>
                 </title>
                 <finalRubric xml:lang="syr">ܫܠܡ ܣܟܘܠܝܐ ܕܝܥܩܘܒ ܐܦܝܣܩܦܐ ܕܐܘܪܗܝ<locus from="69b"/>
                 </finalRubric>
@@ -1572,8 +1561,7 @@
               </msItem>
               <msItem xml:id="b102" n="148">
                 <locus from="88b"/>
-                <title xml:lang="en">Passages from the <ref target="http://syriaca.org/work/9586">Old</ref> and <ref target="http://syriaca.org/work/9587">New
-                  Testaments</ref>, to prove that <persName ref="http://syriaca.org/person/2245">He who was crucified</persName> is
+                <title xml:lang="en">Passages from the <ref target="http://syriaca.org/work/9586">Old</ref> and <ref target="http://syriaca.org/work/9587">New Testaments</ref>, to prove that <persName ref="http://syriaca.org/person/2245">He who was crucified</persName> is
                   God</title>
                 <rubric xml:lang="syr">ܬܘܒ ܦ̈ܬܓܡܐ ܕܡ̇ܚܘܝ̣ܢ ܕܐܠܗܐ ܐܝܬܘܗܝ ܗ̇ܘ ܕܐܙܕܩܦ</rubric>
               </msItem>
@@ -1599,8 +1587,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">From hom. xxv. on the <ref target="http://syriaca.org/work/9594">Epistle to the
-                    Romans</ref>
+                  <title xml:lang="en">From hom. xxv. on the <ref target="http://syriaca.org/work/9594">Epistle to the Romans</ref>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܦܘܫܩܐ ܕܐܓܪܬܐ ܕܠܘܬ ܪ̈ܗܘܡܝܐ ܡܢ ܏ܡ ܏ܕܟܗ.</rubric>
                 </msItem>
@@ -1627,8 +1614,7 @@
                   <author ref="http://syriaca.org/person/573">
                     <persName xml:lang="en">John Chrysostom</persName>
                   </author>
-                  <title xml:lang="en">From hom. vii. on the <ref target="http://syriaca.org/work/9594">Epistle to the
-                    Romans</ref>
+                  <title xml:lang="en">From hom. vii. on the <ref target="http://syriaca.org/work/9594">Epistle to the Romans</ref>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܏ܡ ܏ܕܙ ܕܦܘܫܩܐ ܕܐܓܪܬܐ ܕܠܘܬ ܪ̈ܗܘܡܝܐ ܟܕ ܐܡ̇ܪ ܥܠ ܗ̇ܘ
                     ܕܚ̇ܣܡ ܕܟܡܐ ܩܫܝܐ ܒܝܫ̣ܬܗ</rubric>
@@ -1800,9 +1786,7 @@
                   <persName xml:lang="en">Cyril</persName>
                 </author>
                 <title xml:lang="en">An extract from the Commentary of
-                  <persName ref="http://syriaca.org/person/430">Cyril</persName> on <ref target="http://syriaca.org/work/9648">
-                    <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  </ref>
+                  <persName ref="http://syriaca.org/person/430">Cyril</persName> on <ref target="http://syriaca.org/work/9648"><persName ref="http://syriaca.org/person/1855">S. Luke</persName></ref>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘ݊ܪܝܠܘܣ. ܡܢ ܬܘܪܓܡܐ ܕܦܘܫܩܐ ܕܠܘܩܐ.</rubric>
               </msItem>
@@ -1834,9 +1818,7 @@
                   <persName xml:lang="en">Severus</persName>
                 </author>
                 <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/51">Severus</persName>, on
-                  <ref target="http://syriaca.org/work/9648">
-                    <persName ref="http://syriaca.org/person/1855">S. Luke</persName>
-                  , ch. xv. 8</ref>
+                  <ref target="http://syriaca.org/work/9648"><persName ref="http://syriaca.org/person/1855">S. Luke</persName>, ch. xv. 8</ref>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܣܐܘܪܐ̣. ܡܛܠ ܗ̇ܘ ܙܘܙܐ ܕܐܝܬ ܒܐܘܢܓܠܝܘܢ</rubric>
               </msItem>

--- a/data/tei/849.xml
+++ b/data/tei/849.xml
@@ -189,8 +189,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  Mabūg</persName>, on the quotations in the <ref target="http://syriaca.org/work/9643">Pauline Epistles</ref> from profane
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of Mabūg</persName>, on the quotations in the <ref target="http://syriaca.org/work/9643">Pauline Epistles</ref> from profane
                   writers and from unknown books</title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܦܝܠܟܣܢܘܣ. ܡ̈ܠܐ ܕܐܡ̣ܪ ܦܘܠܘܣ ܡܢ ܚܟܝ̈ܡܐ ܒܪ̈ܝܐ ܘܡܢ
                   ܟܬ̈ܒܐ ܕܠܐ ܝܕܝܥܝܢ.</rubric>
@@ -206,8 +205,7 @@
                 <author ref="http://syriaca.org/person/480">
                   <persName xml:lang="en">Eusebius of Caesarea</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/480">Eusebius of
-                    Caesarea</persName> regarding <persName>Moses</persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/480">Eusebius of Caesarea</persName> regarding <persName>Moses</persName>
                 </title>
                 <rubric xml:lang="syr">ܫܪܒܐ ܐܚܪܢܐ ܕܐܘܣܒܝܣ ܩܣܪܝܐ ܡܛܠ ܡܘܫܐ</rubric>
                 <incipit xml:lang="syr">ܟܕ ܗܘ̣ܘ ܕܝܢ ܡ̈ܠܟܐ ܣܓܝ̈ܐܐ ܒܐܓܒܛܘܣ̣. ܐܡܠܟ ܗܘܐ ܐܡܢܘܦܘܬܝܣ
@@ -252,9 +250,7 @@
                   </author>
                   <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril</persName>, "<title xml:lang="la">
                     contra <persName xml:lang="la" ref="http://syriaca.org/person/2283">
-                      Julianum
-                        Apostatam
-                    </persName>
+                      Julianum Apostatam </persName>
                   </title>"</title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܝܘܠܝܢܘܣ ܡܢ ܫܘܐܠܐ ܕܬܠܬܝܢ
                     ܘܬܠܬܐ</rubric>
@@ -486,8 +482,7 @@
                 <author ref="http://syriaca.org/person/452">
                   <persName xml:lang="en">Dionysius the Areopagite</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܕܝܢܘܣܝܘܣ. ܫܪܒܐ ܕܡ̇ܚܘܐ̣. ܕܐܝܢܐ ܗܘ ܫܘܡܠܝܐ ܕܡܫܡܠܐ
                   ܠܟܠܗܘܢ ܪ̈ܐܙܐ ܕܥܕܬܐ.</rubric>
@@ -645,8 +640,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/33">Isaac of
-                      <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName> on
                   Prayer, regarding the prayer of <persName>Hezekiah</persName> (<ref target="http://syriaca.org/work/9529">2 Kings, ch. xx. 3</ref>)</title>
                 <rubric xml:lang="syr">ܫܪܒܐ ܕܡ̇ܚܘܐ ܕܥܠ ܡܢܐ ܨ̇ܠܝ ܚܙܩܝܐ̣. ܡܢ ܡܕܪ̈ܫܐ ܕܣܝ̣ܡܝܢ
@@ -801,8 +795,7 @@
                 <author ref="http://syriaca.org/person/71">
                   <persName xml:lang="en">Sergius bar Karyā</persName>
                 </author>
-                <title xml:lang="en">An extract from a letter of the bishop <persName ref="http://syriaca.org/person/71">Sergius bar
-                  Karyā</persName>
+                <title xml:lang="en">An extract from a letter of the bishop <persName ref="http://syriaca.org/person/71">Sergius bar Karyā</persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܢ ܐܓܪܐ ܕܣܪܓܝܣ ܐܦܝܣܩܘܦܐ ܒܪ ܟܪܝܐ.</rubric>
               </msItem>
@@ -915,19 +908,16 @@
               </msItem>
               <msItem xml:id="b56" n="84">
                 <locus from="37b"/>
-                <title xml:lang="en">Extracts from the Canons of <persName ref="http://syriaca.org/person/1605">the
-                    Apostles</persName>
+                <title xml:lang="en">Extracts from the Canons of <persName ref="http://syriaca.org/person/1605">the Apostles</persName>
                 </title>
                 <rubric xml:lang="syr">ܡܢ ܕܫܠܝ̈ܚܐ</rubric>
                 <msItem xml:id="c28" n="85">
                   <locus from="37b"/>
-                  <title xml:lang="en">The Canons of <persName ref="http://syriaca.org/person/1605">the
-                    Apostles</persName>, no. 23</title>
+                  <title xml:lang="en">The Canons of <persName ref="http://syriaca.org/person/1605">the Apostles</persName>, no. 23</title>
                 </msItem>
                 <msItem xml:id="c29" n="86">
                   <locus from="37b"/>
-                  <title xml:lang="en">The Canons of <persName ref="http://syriaca.org/person/1605">the
-                    Apostles</persName>, no. 50</title>
+                  <title xml:lang="en">The Canons of <persName ref="http://syriaca.org/person/1605">the Apostles</persName>, no. 50</title>
                 </msItem>
               </msItem>
               <msItem xml:id="b57" n="87">
@@ -1105,8 +1095,7 @@
                   <persName xml:lang="en">Jacob of Batnae
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from the discourse of <persName ref="http://syriaca.org/person/42">Jacob of
-                  <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
+                <title xml:lang="en">An extract from the discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
                   </persName> on
                     <persName>Nebuchadnezzar</persName>
                 </title>
@@ -1166,8 +1155,7 @@
                 <author ref="http://syriaca.org/person/512">
                   <persName xml:lang="en">Gregory Nyssen</persName>
                 </author>
-                <title xml:lang="en">An extract from the xith discourse of <persName ref="http://syriaca.org/person/512">Gregory
-                  Nyssen</persName> against <persName>Eunomius</persName>, on <ref target="http://syriaca.org/work/9628">Genesis,
+                <title xml:lang="en">An extract from the xith discourse of <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName> against <persName>Eunomius</persName>, on <ref target="http://syriaca.org/work/9628">Genesis,
                   ch. ii. 17</ref>
                 </title>
                 <rubric xml:lang="syr">ܕܓܪܝܓܘܪܝܘܣ ܕܢܘܣܐ̣. ܡܢ ܏ܡ ܕ܏ܝܐ ܕܠܘܩܒܠ ܐܘܢܡܝܘܣ̣. ܡܛܠ ܗ̇ܝ
@@ -1246,8 +1234,7 @@
                 <author ref="http://syriaca.org/person/452">
                   <persName xml:lang="en">Dionysius the Areopagite</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the
-                    Areopagite</persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܛܠ ܡܘܢ ܦܩ̇ܕ ܕܢܬܒ ܓܪܒܢܐ ܠܒܪ ܡܢ ܡܫܪܝܬܐ ܫܒܥܐ ܝܘܡ̈ܝܢ̇.
                   ܘܒܝܘܡܐ: ܏ܕܚ̣. ܢܣܒ ܕܘܟܝܐ. ܕܩܕܝܫܐ ܕܝܘܢܣܝܘܣ.</rubric>
@@ -1275,8 +1262,7 @@
                   Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from the Scholia of <persName>Jacob of
-                      <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <title xml:lang="en">Extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </persName> on
                   <ref target="http://syriaca.org/work/9586">the Old Testament</ref>
                 </title>
@@ -1290,8 +1276,7 @@
                   <persName xml:lang="en">Jacob of Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from a discourse of <persName>Jacob of
-                  <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <title xml:lang="en">Extracts from a discourse of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </persName> against impious men and transgressors
                   of the law of God, chap, xii., in which he shows what Christianity is, and that it
                   is anterior to all other religions</title>
@@ -1321,8 +1306,7 @@
                   Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob
-                  of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </persName> on the <ref>Old
                   Testament</ref>
                 </title>
@@ -1436,8 +1420,7 @@
                 <author>
                   <persName xml:lang="en">John the patriarch</persName>
                 </author>
-                <title xml:lang="en">A letter concerning an interview which <persName>John
-                    the patriarch</persName> had with an Arab amir</title>
+                <title xml:lang="en">A letter concerning an interview which <persName>John the patriarch</persName> had with an Arab amir</title>
                 <rubric xml:lang="syr">ܬܘܒ ܐܓܪܬܐ ܕܡܪܝ ܝܘܚܢܢ ܦܛܪܝܪܟܐ̣. ܡܛܠ ܡܡܠܠܐ ܕܡܠܠ ܥܡ ܐܡܝܪܐ
                   ܕܡܗܓܪ̈ܝܐ.</rubric>
                 <incipit xml:lang="syr">ܡܛܠ ܕܝܕܥ̇ܝܢܢ ܕܒܪܢܝܐ ܘܩܢܛܐ ܕܡܛܠܬܢ ܐܝܬܝܟܘܢ: ܡܛܠ ܣܘܥܪܢܐ
@@ -1508,8 +1491,7 @@
               </msItem>
               <msItem xml:id="b96" n="139">
                 <locus from="82b"/>
-                <title xml:lang="en">Of the date of the Nativity of <persName ref="http://syriaca.org/person/2245">our
-                    Lord</persName>, and the dates of the different Councils</title>
+                <title xml:lang="en">Of the date of the Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>, and the dates of the different Councils</title>
                 <rubric xml:lang="syr">ܚܘܫܒܢܐ ܚܬܝܬܐ ܕܡܛܠ ܝܠܝܕܘܬܗ ܕܡܪܢ ܘܕܒܫܢܬ ܟܡܐ ܐܬܟ̣ܢܫܬ̇ ܟܠ
                   ܚܕܐ ܡܢ ܣܘܢܗ̈ܕܘܣ</rubric>
               </msItem>
@@ -1520,8 +1502,7 @@
                   Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from a letter of <persName ref="http://syriaca.org/person/44">Philoxenus of
-                  <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">An extract from a letter of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                   </persName> to the <foreign xml:lang="grc">Στρατηλάτης</foreign> of <placeName ref="http://syriaca.org/place/219">al-Hīra</placeName>,
                   regarding the dates of the Councils</title>
                 <rubric xml:lang="syr">ܡܢ ܟܬܒܐ ܕܡܪܝ ܐܟܣܢܝܐ ܕܠܘܬ ܐܣܛܪܛܠܛܝܣ ܕܚܝܪܬܐ ܕܒܝܬ ܢܥܡ̣ܢ.
@@ -1534,8 +1515,7 @@
                   Antioch
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of
-                  <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                   </persName>
                 </title>
                 <msItem xml:id="c43" n="142">
@@ -1576,8 +1556,7 @@
                 <author ref="http://syriaca.org/person/452">
                   <persName xml:lang="en">Dionysius the Areopagite</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the
-                  Areopagite</persName>, explanatory of the 153 fishes (<ref target="http://syriaca.org/work/9641">S. John</ref>, ch.
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/452">Dionysius the Areopagite</persName>, explanatory of the 153 fishes (<ref target="http://syriaca.org/work/9641">S. John</ref>, ch.
                   xxi. 11)</title>
                 <rubric xml:lang="syr">ܦܘܫܩܐ ܕܗ̇ܢܘܢ ܡܐܐ ܘܚܡܫܝܢ ܘܬܠܬܐ ܢܘ̈ܢܐ ܕܐܣܩ̣ܬ̇ ܗ̇ܝ ܡܨܝܕܬܐ
                   ܕܦܛܪܘܣ ܪܝܫܐ ܕܫܠܝ̈ܚܐ ܡܢ ܝܡܐ</rubric>
@@ -1851,8 +1830,7 @@
                   Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from <persName>Philoxenus of
-                  <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">An extract from <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                   </persName> on <ref target="http://syriaca.org/work/9704">1 John</ref>, ch. v. 6</title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ̣. ܟܕ ܡ̇ܦܫܩ. ܗ̇ܝ ܕܐܡ̣ܪ ܝܘܚܢܢ̇. ܕܗ̇ܢܘ ܕܐ̇ܬܐ.
                   ܒܝܕ ܡ̈ܝܐ ܘܕܡܐ̣. ܘܪܘܚܐ.</rubric>
@@ -1885,8 +1863,7 @@
                 <author ref="http://syriaca.org/person/511">
                   <persName xml:lang="en">Gregory Nazianzen</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/511">Gregory
-                  Nazianzen</persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܡܛܠ ܟܗ̈ܢܐ</rubric>
               </msItem>
@@ -1912,8 +1889,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus</persName>
                   </author>
-                  <title xml:lang="en">From the treatise against <persName ref="http://syriaca.org/person/579">Julian of
-                    <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
+                  <title xml:lang="en">From the treatise against <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܗ̇ܘ ܟܬܒܐ ܕܠܘܩܒܠ ܝܘܠܝܢܐ</rubric>
@@ -1983,8 +1959,7 @@
                   <persName xml:lang="en">Philoxenus of Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from the Commentary of <persName>Philoxenus of
-                  <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">Extracts from the Commentary of <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                   </persName> on <ref target="http://syriaca.org/work/9646">S. Matthew</ref>
                 </title>
               </msItem>
@@ -1994,10 +1969,8 @@
                   <persName xml:lang="en">John of Tellā
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/50">John of
-                  <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                  </persName>, in which he cites <persName>Rabūlas
-                    of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/50">John of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
+                  </persName>, in which he cites <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
                   </persName>
                 </title>
                 <rubric xml:lang="syr">ܬܚܘܝܬܐ̣. ܏ܡܛܠ ܏ܡܪ̈ܓܢܝܬܐ ܏ܕܝܗ̇ܒ ܏ܩܫܝܫܐ ܏ܐ̇ܘ ܏ܫ̇ܡܫܐ̇.
@@ -2031,8 +2004,7 @@
                   <persName xml:lang="en">Cyril</persName>
                 </author>
                 <title xml:lang="en">Extracts from the Thesaurus of
-                  <persName ref="http://syriaca.org/person/430">Cyril</persName>, regarding <persName ref="http://syriaca.org/person/1808">S. John the
-                  Baptist</persName>
+                  <persName ref="http://syriaca.org/person/430">Cyril</persName>, regarding <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ܇ ܡܢ ܟܬܒܐ ܕܣܝ̈ܡܬܐ̣. ܕܡ̇ܦܫܩ̣ ܡܛܠ ܝܘܚܢܢ
                   ܡܥܡܕܢܐ.</rubric>
@@ -2044,10 +2016,8 @@
                   Batnae
                 </persName>
                 </author>
-                <title xml:lang="en">From the letter of <persName ref="http://syriaca.org/person/42">Jacob of
-                  <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName> to <persName ref="http://syriaca.org/person/36">Stephen bar
-                    Sūdailī</persName>
+                <title xml:lang="en">From the letter of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
+                  </persName> to <persName ref="http://syriaca.org/person/36">Stephen bar Sūdailī</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ̣. ܡܢ ܐܓܪܬܐ ܕܡܪܝܬܝܢܘܬܐ</rubric>
                 <note>In the margin of the rubric are the following words: <quote xml:lang="syr">ܕܠܘܬ ܐܣܛܦܲܢܸܐ ܒܪ ܨܽܘܕܰܝܠܻܝ</quote>.</note>

--- a/data/tei/849.xml
+++ b/data/tei/849.xml
@@ -248,9 +248,7 @@
                   <author ref="http://syriaca.org/person/430">
                     <persName xml:lang="en">Cyril</persName>
                   </author>
-                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril</persName>, "<title xml:lang="la">
-                    contra <persName xml:lang="la" ref="http://syriaca.org/person/2283">Julianum Apostatam </persName>
-                  </title>"</title>
+                  <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril</persName>, "<title xml:lang="la">contra <persName xml:lang="la" ref="http://syriaca.org/person/2283">Julianum Apostatam </persName></title>"</title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܝܘܠܝܢܘܣ ܡܢ ܫܘܐܠܐ ܕܬܠܬܝܢ
                     ܘܬܠܬܐ</rubric>
                 </msItem>

--- a/data/tei/849.xml
+++ b/data/tei/849.xml
@@ -249,8 +249,7 @@
                     <persName xml:lang="en">Cyril</persName>
                   </author>
                   <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/430">Cyril</persName>, "<title xml:lang="la">
-                    contra <persName xml:lang="la" ref="http://syriaca.org/person/2283">
-                      Julianum Apostatam </persName>
+                    contra <persName xml:lang="la" ref="http://syriaca.org/person/2283">Julianum Apostatam </persName>
                   </title>"</title>
                   <rubric xml:lang="syr">ܕܩܕܝܫܐ ܩܘܪܝܠܘܣ ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܝܘܠܝܢܘܣ ܡܢ ܫܘܐܠܐ ܕܬܠܬܝܢ
                     ܘܬܠܬܐ</rubric>
@@ -576,8 +575,7 @@
                   <persName xml:lang="en">Jacob of Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName> on the term
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/113">Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> on the term
                   <foreign xml:lang="syr">ܫܘܫܒܝܢܘܬܐ</foreign> (<foreign xml:lang="syr">ܫܘܫܒܝܢܐ</foreign>,
                   <foreign xml:lang="grc">σύντεκνος</foreign>, fellow-sponsor—in old English gossip—and
                   groomsman)</title>
@@ -640,8 +638,7 @@
                 <author ref="http://syriaca.org/person/33">
                   <persName xml:lang="en">Isaac of Antioch</persName>
                 </author>
-                <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName> on
+                <title xml:lang="en">Extracts from the discourse of <persName ref="http://syriaca.org/person/33">Isaac of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName> on
                   Prayer, regarding the prayer of <persName>Hezekiah</persName> (<ref target="http://syriaca.org/work/9529">2 Kings, ch. xx. 3</ref>)</title>
                 <rubric xml:lang="syr">ܫܪܒܐ ܕܡ̇ܚܘܐ ܕܥܠ ܡܢܐ ܨ̇ܠܝ ܚܙܩܝܐ̣. ܡܢ ܡܕܪ̈ܫܐ ܕܣܝ̣ܡܝܢ
                   ܠܛܘܒܢܐ ܡܪܝ ܐܝܣܚܩ. ܥܠ ܨܠܘܬܐ.</rubric>
@@ -651,8 +648,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName>, addressed to
+                <title xml:lang="en">A discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>, addressed to
                   one who asked him, whether the Holy Spirit departs from a man when he sins, or
                   returns to him when he repents</title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܥܒܝܕ ܠܛܘܒܢܐ ܡܪܝ ܐܟܣܢܝܐ̣ ܥܠ ܕܫܐܠܗ ܐܢܫ ܕܐܢ
@@ -714,9 +710,7 @@
                   </author>
                   <title xml:lang="en">From a letter to 
                     <persName ref="http://syriaca.org/person/2705">Menas</persName> and 
-                    <persName ref="http://syriaca.org/person/2642">
-                      <foreign xml:lang="syr">ܐܦܓܕܬܘܣ</foreign>, Epagathus, <foreign xml:lang="grc">'Επαγαθός</foreign>
-                    </persName> 
+                    <persName ref="http://syriaca.org/person/2642"><foreign xml:lang="syr">ܐܦܓܕܬܘܣ</foreign>, Epagathus, <foreign xml:lang="grc">'Επαγαθός</foreign></persName> 
                     </title>
                   <rubric xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܡܝܢܐ ܘܐܦܓܕܬܘܣ. ܥܠ ܕܠܐ ܙܕܩ̇ ܢܒ̇ܣܐ ܐܢܫ ܥܠ
                     ܟܗܢܐ̇. ܒܗ̇ܝ ܠܡ ܕܐܝܬܘܗܝ ܫܝܛܐ̇. ܐܘ ܢܬ̇ܩܪܒ ܠܘܬ ܗ̇ܘ ܕܡܝܩܪ̈. ܐܢ ܒܗܝܡܢܘܬܐ ܫܪܝܪܬܐ
@@ -1095,8 +1089,7 @@
                   <persName xml:lang="en">Jacob of Batnae
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from the discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName> on
+                <title xml:lang="en">An extract from the discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName> on
                     <persName>Nebuchadnezzar</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ ܡܢ ܏ܡ ܕܥܠ ܢܒܘܟܕܢܨ̇ܪ</rubric>
@@ -1108,8 +1101,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">On <ref target="http://syriaca.org/work/9628">Genesis</ref>, ch. iii. 14, from the discourse
-                  of <persName>Severianus of <placeName ref="http://syriaca.org/place/85">Gabala</placeName>
-                  </persName> on the
+                  of <persName>Severianus of <placeName ref="http://syriaca.org/place/85">Gabala</placeName></persName> on the
                   Hexaemeron</title>
                 <rubric xml:lang="syr">ܕܡܛܠ ܡܢܐ ܥܠ ܚܕܝܗ ܘܥܠ ܟܪܣܗ ܡܬ݂ܦܩܕ ܠܗ ܠܚܘܝܐ ܠܡܗܠܟܘܼ ܘܡܛܠ
                   ܡܢܐ ܥܦܪܐ ܗܘ̣ܬ ܡܟܘܠܬܗ. ܕܚܣܝܐ <sic>ܣܐܘܪܐ</sic> ܐܦܝܣܩܘܦܐ ܕܓܒܠܐ. ܏ܒܡ. ܕܥܠ ܐܫ̣ܬܬ̇ ܝܘܡ̈ܐ
@@ -1122,8 +1114,7 @@
                 </author>
                 <title xml:lang="en">An extract from the treatise of
                     <persName>Severus</persName> against the Additions, or Appendices, of
-                  <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
-                  </persName>
+                  <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܕܠܘ ܐ ܝܟ ܡ̇ܢ ܕܛܡ̣ܐ ܙܘܘܓܐ ܐܫ̣ܬܐܠ ܡܫܝܚܐ ܕܡܢ ܓܒܪܐ ܘܐܢܬܬܐ
                   ܢܗܘܐ̣. ܕܩܕܝܫܐ ܣܐܘܪܐ ܡܢ ܟܬܒܐ ܕܠܘܩܒܠ ܬܘ̈ܣܦܬܐ ܕܝܘܠܝܢܐ</rubric>
@@ -1262,8 +1253,7 @@
                   Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName> on
+                <title xml:lang="en">Extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> on
                   <ref target="http://syriaca.org/work/9586">the Old Testament</ref>
                 </title>
                 <rubric xml:lang="syr">ܣܟܘ̈ܠܝܐ</rubric>
@@ -1276,8 +1266,7 @@
                   <persName xml:lang="en">Jacob of Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from a discourse of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName> against impious men and transgressors
+                <title xml:lang="en">Extracts from a discourse of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> against impious men and transgressors
                   of the law of God, chap, xii., in which he shows what Christianity is, and that it
                   is anterior to all other religions</title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܢ ܡܐܡܪܐ ܕܡܟܣܢܘܬܐ ܕܠܘܩܒܠ ܐ̈ܢܫܝܢ ܡܪ̈ܚܐ ܘܥ̇ܒܪ̈ܝ ܥܠ
@@ -1306,8 +1295,7 @@
                   Edessa
                 </persName>
                 </author>
-                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName> on the <ref>Old
+                <title xml:lang="en">Additional extracts from the Scholia of <persName>Jacob of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName> on the <ref>Old
                   Testament</ref>
                 </title>
                 <finalRubric xml:lang="syr">ܫܠܡ ܣܟܘܠܝܐ ܕܝܥܩܘܒ ܐܦܝܣܩܦܐ ܕܐܘܪܗܝ<locus from="69b"/>
@@ -1452,8 +1440,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Short extracts from various discourses of
-                  <persName>Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName>
+                  <persName>Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܘܒ ܫܘܐ̈ܠܐ ܐܘ ܟܝܬ ܬܚ̈ܘܝܬܐ ܕܡ̈ܟܢܫܢ ܡܢ ܡܪܝ ܝܥܩܘܒ
                   ܡܠܦܢܐ.</rubric>
@@ -1502,8 +1489,7 @@
                   Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from a letter of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName> to the <foreign xml:lang="grc">Στρατηλάτης</foreign> of <placeName ref="http://syriaca.org/place/219">al-Hīra</placeName>,
+                <title xml:lang="en">An extract from a letter of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName> to the <foreign xml:lang="grc">Στρατηλάτης</foreign> of <placeName ref="http://syriaca.org/place/219">al-Hīra</placeName>,
                   regarding the dates of the Councils</title>
                 <rubric xml:lang="syr">ܡܢ ܟܬܒܐ ܕܡܪܝ ܐܟܣܢܝܐ ܕܠܘܬ ܐܣܛܪܛܠܛܝܣ ܕܚܝܪܬܐ ܕܒܝܬ ܢܥܡ̣ܢ.
                   ܕܡ̇ܘܕܥ̣ ܥܠ ܟܠ ܚܕܐ ܡܢ ܣܘܢܗ̈ܕܘܣ ܕܒܝ̈ܘܡܝ ܡ̇ܢ ܐܬܟ̣ܢܫܬ̇ ܘܠܡ̇ܢ ܐܚ̣ܪܡܬ̇.</rubric>
@@ -1515,8 +1501,7 @@
                   Antioch
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                  </persName>
+                <title xml:lang="en">Extracts from <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>
                 </title>
                 <msItem xml:id="c43" n="142">
                   <locus from="83b"/>
@@ -1830,8 +1815,7 @@
                   Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName> on <ref target="http://syriaca.org/work/9704">1 John</ref>, ch. v. 6</title>
+                <title xml:lang="en">An extract from <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName> on <ref target="http://syriaca.org/work/9704">1 John</ref>, ch. v. 6</title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܐܟܣܢܝܐ̣. ܟܕ ܡ̇ܦܫܩ. ܗ̇ܝ ܕܐܡ̣ܪ ܝܘܚܢܢ̇. ܕܗ̇ܢܘ ܕܐ̇ܬܐ.
                   ܒܝܕ ܡ̈ܝܐ ܘܕܡܐ̣. ܘܪܘܚܐ.</rubric>
               </msItem>
@@ -1889,8 +1873,7 @@
                   <author ref="http://syriaca.org/person/51">
                     <persName xml:lang="en">Severus</persName>
                   </author>
-                  <title xml:lang="en">From the treatise against <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
-                    </persName>
+                  <title xml:lang="en">From the treatise against <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܡܢ ܗ̇ܘ ܟܬܒܐ ܕܠܘܩܒܠ ܝܘܠܝܢܐ</rubric>
                 </msItem>
@@ -1959,8 +1942,7 @@
                   <persName xml:lang="en">Philoxenus of Mabūg
                 </persName>
                 </author>
-                <title xml:lang="en">Extracts from the Commentary of <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName> on <ref target="http://syriaca.org/work/9646">S. Matthew</ref>
+                <title xml:lang="en">Extracts from the Commentary of <persName>Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName> on <ref target="http://syriaca.org/work/9646">S. Matthew</ref>
                 </title>
               </msItem>
               <msItem xml:id="b120" n="188">
@@ -1969,9 +1951,7 @@
                   <persName xml:lang="en">John of Tellā
                 </persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/50">John of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName>
-                  </persName>, in which he cites <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName>
-                  </persName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/50">John of <placeName ref="http://syriaca.org/place/1889">Tellā</placeName></persName>, in which he cites <persName>Rabūlas of <placeName ref="http://syriaca.org/place/78">Edessa</placeName></persName>
                 </title>
                 <rubric xml:lang="syr">ܬܚܘܝܬܐ̣. ܏ܡܛܠ ܏ܡܪ̈ܓܢܝܬܐ ܏ܕܝܗ̇ܒ ܏ܩܫܝܫܐ ܏ܐ̇ܘ ܏ܫ̇ܡܫܐ̇.
                   ܏ܕܝܘܚܢܢ ܏ܕܬ̇ܠܐ: ܐܬ̣ܚܙܝܬ̇ ܠܢ ܡܛܠ ܕܡ̇ܢܟܪܝܐ ܗܕܐ ܠܕܚܠ̣ܬ̇ ܐܠܗܐ̣. ܕܠܐ ܬܗ̣ܘܐ. ܐܠܐ ܣ̇ܦܩܐ
@@ -2016,8 +1996,7 @@
                   Batnae
                 </persName>
                 </author>
-                <title xml:lang="en">From the letter of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName>
-                  </persName> to <persName ref="http://syriaca.org/person/36">Stephen bar Sūdailī</persName>
+                <title xml:lang="en">From the letter of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/45">Batnae</placeName></persName> to <persName ref="http://syriaca.org/person/36">Stephen bar Sūdailī</persName>
                 </title>
                 <rubric xml:lang="syr">ܕܡܪܝ ܝܥܩܘܒ̣. ܡܢ ܐܓܪܬܐ ܕܡܪܝܬܝܢܘܬܐ</rubric>
                 <note>In the margin of the rubric are the following words: <quote xml:lang="syr">ܕܠܘܬ ܐܣܛܦܲܢܸܐ ܒܪ ܨܽܘܕܰܝܠܻܝ</quote>.</note>

--- a/data/tei/85.xml
+++ b/data/tei/85.xml
@@ -111,8 +111,7 @@
               </msItem>
               <msItem xml:id="b2" n="3" defective="true">
                 <locus from="3" to="161">Foll. 3-161</locus>
-                <title ref="http://syriaca.org/work/151">The two books of Samuel and a portion of the first book of Kings according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                  </persName>
+                <title ref="http://syriaca.org/work/151">The two books of Samuel and a portion of the first book of Kings according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
                 </title>
                 <note>See <bibl>Assemani, Bibl. Or., t. ii. p. 335-36</bibl>;<bibl>Ceriani, Monumenta Sacra et Profana, t. ii. fasc. i., pp. x., xi.</bibl>; and his memoir, <bibl>Le Edizioni e i Manoscritti etc., p. 27.</bibl>
                 </note>
@@ -123,8 +122,7 @@
                 </msItem>
                 <msItem xml:id="c2" n="5" defective="true">
                   <locus from="5a" to="90">Foll. 5-90</locus>
-                  <title ref="http://syriaca.org/work/152">The first book of Samuel, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                    </persName>
+                  <title ref="http://syriaca.org/work/152">The first book of Samuel, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܟܬܒܐ ܩܕܡܝܐ ܕܡܠܟܘ̈ܬܐ<locus from="5a" to="5a"/>
                   </rubric>
@@ -141,14 +139,12 @@
                 </msItem>
                 <msItem xml:id="c4" n="7" defective="true">
                   <locus from="91" to="161">Foll. 91-161</locus>
-                  <title ref="http://syriaca.org/work/153">The second book of Samuel, including the first book of Kings, ch. 1:1—49, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                    </persName>
+                  <title ref="http://syriaca.org/work/153">The second book of Samuel, including the first book of Kings, ch. 1:1—49, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
                   </title>
                   <note>It is likewise divided into 15 chapters.</note>
                   <msItem xml:id="d1" n="8" defective="unknown">
                     <locus from="91" to="161">Foll. 91-161</locus>
-                    <title ref="http://syriaca.org/work/154">The second book of Samuel, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                      </persName>
+                    <title ref="http://syriaca.org/work/154">The second book of Samuel, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܟܬܒܐ ܕܬܪ̈ܝܢ ܕܡ̈ܠܟܘܬܐ<locus from="91b" to="91b"/>
                     </rubric>
@@ -158,8 +154,7 @@
                   </msItem>
                   <msItem xml:id="d2" n="9" defective="true">
                     <locus from="162a" to="166">Foll. 162-166</locus>
-                    <title ref="http://syriaca.org/work/155">The first book of Kings, ch. 1:1-49, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName>
-                      </persName>
+                    <title ref="http://syriaca.org/work/155">The first book of Kings, ch. 1:1-49, according to the recension of <persName ref="http://syriaca.org/person/113">Jacob of <placeName>Edessa</placeName></persName>
                     </title>
                     <note>The fifteenth chapter extended as far as 1 Kings, ch. 2:11:<foreign xml:lang="syr">܏ܝܗ ܥܠ ܗ̇ܝ ܕܟܕ ܣܐ̣ܒ ܕܘܝܕ ܠܐ ܫܚ̇ܢ ܗܘܐ ܒܠܒܘ̈ܫܐ܆ ܘܐܝܬ̣ܝܘ ܠܗ ܥܠܝܡܬܐ ܒܬܘܠܬܐ ܕܬܫܟ݂ܒ ܥܡܗ: ܘܥܠ ܪܘܪܒܗ ܕܐܘܪܢܝܐ ܒܪ ܚܐܓܝܬ ܠܘܬ ܗ̇ܝ ܕܢܡܠܟ̇ ܘܥܠ ܦܘܕܗ ܕܡܢ ܪܓܬܗ: ܘܥܠ ܡܠܟܘܬܗ ܕܫܠܘܡܘܢ ܘܥܠ ܗܠܝܢ ܕܦܩܕܗ ܐܒܘܗܝ ܩܕܡ ܕܢܡܘܬ܀</foreign>
                     </note>

--- a/data/tei/851.xml
+++ b/data/tei/851.xml
@@ -133,8 +133,7 @@
               <textLang mainLang="syr" otherLangs="grc">Syriac</textLang>
               <msItem xml:id="p1a1" n="1">
                 <locus from="1b"/>
-                <title xml:lang="en">Demonstrations from the Scriptures of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the
-                                    Old and New Testaments</ref>, as well as from the Apocrypha, on various
+                <title xml:lang="en">Demonstrations from the Scriptures of <ref target="http://syriaca.org/work/9586 http://syriaca.org/work/9587">the Old and New Testaments</ref>, as well as from the Apocrypha, on various
                                     points of religion, morals, and Christian duty</title>
                 <quote xml:lang="syr">ܪܝܫܐ ܕܦ̈ܬܓܡܐ ܕܚ̈ܫܚܝܢ ܠܓܘܐ ܒܪ̈ܢܝܐ ܡܫܚ̈ܠܦܐ<locus from="1b"/>
                 </quote>

--- a/data/tei/852.xml
+++ b/data/tei/852.xml
@@ -192,9 +192,7 @@
                 <msItem xml:id="p1b5" n="6">
                   <locus from="11" to="14">Foll. 11-14</locus>
                   <title xml:lang="en">Notes and glosses on difficult words and
-                                    phrases in the works of <persName ref="http://syriaca.org/person/512">Gregory
-                                        Nyssen</persName> and <persName ref="http://syriaca.org/person/511">Gregory
-                                        Nazianzen</persName>.</title>
+                                    phrases in the works of <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName> and <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>.</title>
                   <rubric xml:lang="syr">ܫܠ̣ܡܘ ܢܘܗܪ̈ܐ ܕܩܕܝܫܐ ܓܪܝܓܪܝܘܣ ܕܢܘܣܐ܀ ܠܘܩܒܠ
                                     ܐܘܢܡܝܘܣ<locus from="11a"/>
                   </rubric>

--- a/data/tei/853.xml
+++ b/data/tei/853.xml
@@ -143,10 +143,8 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p1a1" n="1" defective="true">
                 <locus from="1a" to="25">Foll. 1a-25</locus>
-                <title xml:lang="en">A Commentary on <title xml:lang="en">the first volume of the Works of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName>
-                  </title>, as translated by the abbat <persName>Paul</persName>, compiled by an anonymous author, who
-                followed <title>the exposition of <persName ref="http://syriaca.org/person/152">Benjamin, metropolitan of Edessa</persName>
-                  </title>
+                <title xml:lang="en">A Commentary on <title xml:lang="en">the first volume of the Works of <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName></title>, as translated by the abbat <persName>Paul</persName>, compiled by an anonymous author, who
+                followed <title>the exposition of <persName ref="http://syriaca.org/person/152">Benjamin, metropolitan of Edessa</persName></title>
                 </title>
                 <rubric xml:lang="syr">ܒܫܡ ܝܫܘܥ ܢܘܼܗܪܐ ܕܢܘܼܗܪ̈ܐ ܡ̇ܫܪܝܢܢ ܕܢܟܬܘܒ ܦܘܫ̇ܩܐ ܐܝܟ ܕܒܙܥܘܪ̈ܝܬܐ
                 ܕܡ̈ܠܐ ܥܣ̈ܩܬܐ ܕܡܬܬܝ̈ܬܝܢ ܒܟܬܒܐ ܩܕܡܝܐ ܕܩܕܝܫܐ ܓܪܝܓܘܪܝܘܣ ܬܐܘܠܘܓܘܣ ܐܦܝܣܩܘܦܐ ܕܢܐܙܝܐܢܙܘ܀

--- a/data/tei/856.xml
+++ b/data/tei/856.xml
@@ -200,8 +200,7 @@
                     <persName xml:lang="en">Jacob of Batnae</persName>
                   </author>
                   <title xml:lang="en">The metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the
-                        Crucifixion of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                        Crucifixion of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 </msItem>
               </msContents>
               <physDesc>
@@ -450,8 +449,7 @@
                 <locus from="7" to="22"/>
                 <locus from="33" to="88"/>
                 <title xml:lang="en">The metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the
-                        Crucifixion of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                        Crucifixion of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <note>Of the subdivisions, there are marked on the margin the following:</note>
                 <msItem xml:id="p2b1" n="2">
                   <locus from="13a"/>

--- a/data/tei/858.xml
+++ b/data/tei/858.xml
@@ -115,12 +115,9 @@
               <author ref="http://syriaca.org/person/579">
                 <persName xml:lang="en">Julian of Halicarnassus</persName>
               </author>
-              <title xml:lang="en">The correspondence of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName> and
-                           <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
-                </persName> on the Corruptibility or
-                        Incorruptibility of the Body of Christ, translated by <persName>Paul of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
-                </persName>
+              <title xml:lang="en">The correspondence of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName> and
+                           <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName></persName> on the Corruptibility or
+                        Incorruptibility of the Body of Christ, translated by <persName>Paul of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName></persName>
               </title>
               <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 46</bibl>.</note>
               <msItem xml:id="b1" n="2">

--- a/data/tei/858.xml
+++ b/data/tei/858.xml
@@ -119,8 +119,7 @@
                 </persName> and
                            <persName ref="http://syriaca.org/person/579">Julian of <placeName ref="http://syriaca.org/place/1468">Halicarnassus</placeName>
                 </persName> on the Corruptibility or
-                        Incorruptibility of the Body of Christ, translated by <persName>Paul of
-                              <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
+                        Incorruptibility of the Body of Christ, translated by <persName>Paul of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
                 </persName>
               </title>
               <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 46</bibl>.</note>

--- a/data/tei/864.xml
+++ b/data/tei/864.xml
@@ -241,10 +241,8 @@
                   </msItem>
                   <msItem xml:id="d9" n="12">
                     <locus from="43a"/>
-                    <title xml:lang="en">The revelation of <placeName>the repository of the bones of
-                      <persName ref="http://syriaca.org/person/1711">S. Stephen the protomartyr</persName>, <persName>Nicodemus</persName>,
-                  <persName ref="http://syriaca.org/person/1245">Gamaliel</persName>, and his son <persName ref="http://syriaca.org/person/3019">Ḥabib</persName>
-                      </placeName>, from <ref>the
+                    <title xml:lang="en">The revelation of <placeName>the repository of the bones of <persName ref="http://syriaca.org/person/1711">S. Stephen the protomartyr</persName>, <persName>Nicodemus</persName>,
+                  <persName ref="http://syriaca.org/person/1245">Gamaliel</persName>, and his son <persName ref="http://syriaca.org/person/3019">Ḥabib</persName></placeName>, from <ref>the
                   letters of <persName>Lucian, the priest, of
                     <placeName>Kĕphar-Gamlā</placeName>
                         </persName>
@@ -1038,8 +1036,7 @@
                   </msItem>
                   <msItem xml:id="d89" n="100">
                     <locus from="138b"/>
-                    <title xml:lang="en">Of the flood at <placeName ref="http://syriaca.org/place/78">Edessa</placeName>, the stoppage of <placeName>the spring of Siloam (<foreign xml:lang="syr">ܫܝܠܘܚܐ</foreign>)</placeName> at <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>, the destruction of <placeName ref="http://syriaca.org/place/10">Antioch</placeName> by an earthquake, and the burning of <placeName>the temple of <persName>Solomon</persName> at <placeName>Ba'albek</placeName>
-                      </placeName>
+                    <title xml:lang="en">Of the flood at <placeName ref="http://syriaca.org/place/78">Edessa</placeName>, the stoppage of <placeName>the spring of Siloam (<foreign xml:lang="syr">ܫܝܠܘܚܐ</foreign>)</placeName> at <placeName ref="http://syriaca.org/place/104">Jerusalem</placeName>, the destruction of <placeName ref="http://syriaca.org/place/10">Antioch</placeName> by an earthquake, and the burning of <placeName>the temple of <persName>Solomon</persName> at <placeName>Ba'albek</placeName></placeName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܐܪ̈ܒܥܐ ܕܝܠܗ ܕܠܐܓܘܣ ܕܬܡܢܝܐ. ܡܘܕܥ ܥܠ ܡ̈ܝܐ ܕܥܠܘ ܠܐܘܪܗܝ. ܘܕܐܬܟܠܝ ܪܕܝܐ ܕܡ̈ܝܐ ܕܫܝܠܘܚܐ ܕܐܘܪܫܠܡ. ܘܕܐܬܗܦܟܬ ܐܢܛܝܘܟ. ܘܝܩܕ ܗܝܟܠܐ ܗ̇ܘ ܕܫܠܝܡܘܢ ܕܒܥܠܒܟ ܡܕܝܢܬܐ</rubric>
                     <note>See <bibl>Land, p. 243</bibl>.</note>
@@ -1083,16 +1080,14 @@
                   </msItem>
                   <msItem xml:id="d94" n="106">
                     <locus from="146b"/>
-                    <title xml:lang="en">Of the accession of <persName ref="http://syriaca.org/person/2284">Justinian I.</persName>, and of the expedition against <placeName ref="http://syriaca.org/place/142">Nisibis</placeName> and <placeName>the fort of <foreign xml:lang="syr">ܬܒܬ</foreign>
-                      </placeName>
+                    <title xml:lang="en">Of the accession of <persName ref="http://syriaca.org/person/2284">Justinian I.</persName>, and of the expedition against <placeName ref="http://syriaca.org/place/142">Nisibis</placeName> and <placeName>the fort of <foreign xml:lang="syr">ܬܒܬ</foreign></placeName>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܩܕܡܝܐ ܕܡܐܡܪܐ ܕܬܫܥܐ: ܬܒܬ ܕܡܘܕܥ ܥܠ ܪܝܫ ܡܠܟܘܬܗ ܕܝܘܣܛܝܢܝܢܘܣ. ܘܥܠ ܩܪܒܐ ܕܗܘܐ ܥܠ ܢܨܝܒܝܢ ܘܬܒܬ ܚܣܢܐ</rubric>
                     <note>See <bibl>Land, p. 255</bibl>.</note>
                   </msItem>
                   <msItem xml:id="d95" n="107">
                     <locus from="147a"/>
-                    <title xml:lang="en">Of the expedition to <placeName>the desert of <foreign xml:lang="syr">ܬܢܘܪܝܢ</foreign>
-                      </placeName>, against <persName>the Persians</persName>
+                    <title xml:lang="en">Of the expedition to <placeName>the desert of <foreign xml:lang="syr">ܬܢܘܪܝܢ</foreign></placeName>, against <persName>the Persians</persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬ̈ܪܝܢ ܕܝܠܗ ܕܫܪܒܐ ܕܬܫܥܐ ܥܠ ܩܪܒܐ ܕܗܘܐ ܒܡܕܒܪܐ ܕܬܢܘ̈ܪܝܢ</rubric>
                     <note>See <bibl>Land, p. 256</bibl>.</note>
@@ -1347,8 +1342,7 @@
                   </msItem>
                   <msItem xml:id="d125" n="138" defective="true">
                     <locus from="185a"/>
-                    <title xml:lang="en">Of the Dedication of <placeName>the Church at <placeName>Antioch</placeName>
-                      </placeName>, celebrated by <persName>Ephraim</persName>, and of the synod of <persName>bishops of <placeName>the diocese</placeName></persName>
+                    <title xml:lang="en">Of the Dedication of <placeName>the Church at <placeName>Antioch</placeName></placeName>, celebrated by <persName>Ephraim</persName>, and of the synod of <persName>bishops of <placeName>the diocese</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܡܫܐ ܥܠ ܐܢܩܢܝܐ ܕܥܒܕ ܐܦܪܝܡ ܕܐܢܛܝܘܟ ܕܥܕܬܐ ܘܣܘܢܗܕܘܣ ܕܐܦܣܩܦܐ ܕܫܘܠܛܢܗ</rubric>
                     <note>See <bibl>Land, p. 322</bibl>.</note>

--- a/data/tei/864.xml
+++ b/data/tei/864.xml
@@ -304,8 +304,7 @@
                   </msItem>
                   <msItem xml:id="d13" n="17">
                     <locus from="50b"/>
-                    <title xml:lang="en">The history of <persName>the Seven Youths of <placeName>Ephesus</placeName>
-                      </persName>
+                    <title xml:lang="en">The history of <persName>the Seven Youths of <placeName>Ephesus</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܬܘܒ ܪܝܫܐ ܩܕܡܝܐ ܗܘܦܡܢܝܡܐ ܕܫ̈ܒܥܐ ܣܗ̈ܕܐ ܕܐܬܢ̇ܚܡܘ. ܡܠܦ̣ ܒܡܥܪܬܐ ܕܐܢܟܠܣ ܛܘܪܐ ܐܫܬܟܚܘ. ܕܒܐܦܣܘܣ ܐܬܪܐ</rubric>
                     <note>See <bibl>Land, p. 87</bibl>, and <bibl>Add. 14,641, no. 4, e</bibl>.</note>
@@ -400,8 +399,7 @@
                   </msItem>
                   <msItem xml:id="d21" n="26">
                     <locus from="71b"/>
-                    <title xml:lang="en">Of the exile of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName>Alexandria</placeName>
-                      </persName>, and the ordination of <persName ref="http://syriaca.org/person/2471">Proterius</persName>
+                    <title xml:lang="en">Of the exile of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName>Alexandria</placeName></persName>, and the ordination of <persName ref="http://syriaca.org/person/2471">Proterius</persName>
                       in his stead</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬ̈ܪܝܢ ܡܘܕܥ ܥܠ ܐܟܣܘܪܝܐ ܕܕܝܣܩܪܣ ܘܟܪܛܘܢܝܐ ܕܦܪܛܘܪܝܣ
                       ܕܚܠܦܘܗܝ. ܘܩ̈ܛܠܐ ܕܗ̈ܘܘ ܒܡܥܠܬܗ. ܘܢܦܩ̈ܬܐ ܕܥܒܕ ܗܘܐ ܥܠ ܪ̈ܗܘܡܝܐ. ܕܡܥܕܪܝܢ ܗܘܘ ܠܗ ܡܢ
@@ -410,8 +408,7 @@
                   </msItem>
                   <msItem xml:id="d22" n="27">
                     <locus from="72a"/>
-                    <title xml:lang="en">Of <persName>Juvenalis of <placeName>Jerusalem</placeName>
-                      </persName>, and
+                    <title xml:lang="en">Of <persName>Juvenalis of <placeName>Jerusalem</placeName></persName>, and
                       how the monk <persName>Theodosius</persName> was substituted for him as
                       bishop</title>
                     <rubric xml:lang="syr"> ܪܫܐ ܕܬܠܬܐ ܕܡܠܦ ܗܠܝܢ ܕܗ̈ܘܝ ܒܦܠܣܛܝܢܐ. ܡܛܘܠ ܝܘܒܢܠܝܣ
@@ -474,8 +471,7 @@
                   </msItem>
                   <msItem xml:id="d29" n="34">
                     <locus from="75a"/>
-                    <title xml:lang="en">Of the heresy of <persName>Joannes Rhetor of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Of the heresy of <persName>Joannes Rhetor of <placeName>Alexandria</placeName></persName>
                       </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܥܣ̈ܪܐ ܡܥܗܕ ܥܠ ܗܪܣܝܣ ܕܝܘܚܢܢ ܪܗܛܪܐ ܕܒܐܠܟܣܢܕܝܐ <foreign xml:lang="en">(sic)</foreign>
                         ܕܐܝܟܢܐ ܓܪܫܬ <foreign xml:lang="en">(sic)</foreign> ܘܐܬܚܪܡܬܝ <foreign xml:lang="en">(sic)</foreign>
@@ -494,8 +490,7 @@
                   <msItem xml:id="d31" n="36">
                     <locus from="76b"/>
                     <title xml:lang="en">Of <persName>Anthemius</persName> (who was slain by
-                        <persName>Ricimer, <foreign xml:lang="syr">ܪܝܩܝܡܪ</foreign>
-                      </persName>),
+                        <persName>Ricimer, <foreign xml:lang="syr">ܪܝܩܝܡܪ</foreign></persName>),
                         <persName>Severus</persName>, <persName>Olybrius</persName>, and
                         <persName>Leo</persName>
                       </title>
@@ -553,8 +548,7 @@
                   </msItem>
                   <msItem xml:id="d36" n="42">
                     <locus from="79a"/>
-                    <title xml:lang="en">How many of <persName>the clergy, who had taken the side of <persName ref="http://syriaca.org/person/2471">Proterius</persName>
-                      </persName>, wished to be reconciled to
+                    <title xml:lang="en">How many of <persName>the clergy, who had taken the side of <persName ref="http://syriaca.org/person/2471">Proterius</persName></persName>, wished to be reconciled to
                         <persName>Timotheus</persName>, but were hindered by <persName>the common people</persName> and
                       <persName>the more bigoted priests</persName>
                     </title>
@@ -593,10 +587,8 @@
                   </msItem>
                   <msItem xml:id="d40" n="46">
                     <locus from="82a"/>
-                    <title xml:lang="en">How <persName>the bishops who had been at <placeName ref="http://syriaca.org/place/622">Chalcedon</placeName>
-                      </persName>, with the exception of
-                        <persName>Amphilochius of <placeName>Side</placeName>
-                      </persName>, wrote to the emperor
+                    <title xml:lang="en">How <persName>the bishops who had been at <placeName ref="http://syriaca.org/place/622">Chalcedon</placeName></persName>, with the exception of
+                        <persName>Amphilochius of <placeName>Side</placeName></persName>, wrote to the emperor
                       <persName ref="http://syriaca.org/person/2270">Leo</persName>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܫܒܥܐ ܕܡܘܕܥ܆ ܐܦ ܗܠܝܢ ܕܟܬܒܘ ܫܪܟܐ ܕܐ̈ܦܣܩܦܐ ܠܒܪ ܡܢ
@@ -627,8 +619,7 @@
                     <locus from="83b"/>
                     <title xml:lang="en">Of the other <persName>Timotheus</persName>,
                         surnamed <foreign xml:lang="syr">ܡܬܪܘܛ ܦܩܝܠܐ</foreign> (or <foreign xml:lang="syr">ܪܥܘܠܦܩܝܠܐ</foreign>, or
-                        <persName>Salofaciolus</persName>), whom the <persName>partizans of <persName>Proterius</persName>
-                      </persName> elected bishop</title>
+                        <persName>Salofaciolus</persName>), whom the <persName>partizans of <persName>Proterius</persName></persName> elected bishop</title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܥ̈ܣܪܐ ܥܠ ܛܝܡܬܐܣ ܐܚܪܝܢܐ ܡܚܘܐ̣. ܗ̣ܘ ܕܗܘܐ ܐܦܣܩܘܦܐ ܡܢ
                       ܒ̈ܢܝ ܓܒܗ ܕܦܪܛܘܪܝܣ ܕܡܬܩܪܐ ܗܘܐ ܡܬܪܘܛ ܦܩܝܠܐ</rubric>
                     <note>See <bibl>Land, p. 145</bibl>.</note>
@@ -637,18 +628,15 @@
                     <locus from="84b"/>
                     <title xml:lang="en">How <persName>Timotheus Ælurus</persName> was
                       conveyed from <placeName ref="http://syriaca.org/place/624">Gangra</placeName> to <placeName>Cherson</placeName>
-                        (<foreign xml:lang="grc">Χερσών</foreign>), through the machinations of <persName>Gennadius of <placeName>Constantinople</placeName>
-                      </persName> and his party</title>
+                        (<foreign xml:lang="grc">Χερσών</foreign>), through the machinations of <persName>Gennadius of <placeName>Constantinople</placeName></persName> and his party</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚ̈ܕܥܣܪ݂. ܕܐܝܟܢ ܡܢ ܓܢܓܪܐ ܠܟܪܣܘܢܐ ܐܬ݂ܕܒܪ ܛܝܡܬܐܘܣ.
                       ܒܣܢܐܬܐ ܕܥܠܘܗܝ ܕܟܠܩܝܕܘܢܐ</rubric>
                     <note>See <bibl>Land, p. 146</bibl>.</note>
                   </msItem>
                   <msItem xml:id="d45" n="51">
                     <locus from="85a"/>
-                    <title xml:lang="en">Of <persName>Isaiah, bishop of <placeName>Hermopolis</placeName>
-                      </persName>, and the priest
-                        <persName>Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                      </persName>, <persName>the Eutychianists</persName>, and how <persName>Timotheus</persName> wrote against them and
+                    <title xml:lang="en">Of <persName>Isaiah, bishop of <placeName>Hermopolis</placeName></persName>, and the priest
+                        <persName>Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName></persName>, <persName>the Eutychianists</persName>, and how <persName>Timotheus</persName> wrote against them and
                       excommunicated them</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬܪ̈ܥܣܪ܆ ܥܠ ܐܫܥܝܐ ܐܦܣܩܘܦܐ ܕܗܪܡܦܘܠܝܣ. ܘܥܠ ܬܐܦܝܠܐ
                       ܩܫܝܫܐ ܕܐܠܟܣܢܕܪܝܐ ܐܘܛܟܝܢܣܛܐ. ܘܐܓܪܬܐ ܕܥܒ̣ܕ ܡܛܠܬܗܘܢ ܛܝܡܬܐܣ ܘܦܪܣܝ ܐܢܘܢ</rubric>
@@ -756,8 +744,7 @@
                   </msItem>
                   <msItem xml:id="d50" n="57">
                     <locus from="96a"/>
-                    <title xml:lang="en">The letter of <persName>the bishops of <placeName>the diocese of Asia</placeName>
-                      </persName>,
+                    <title xml:lang="en">The letter of <persName>the bishops of <placeName>the diocese of Asia</placeName></persName>,
                     assembled at <placeName ref="http://syriaca.org/place/623">Ephesus</placeName>, to <persName>Basiliscus</persName>
                     and <persName>Marcus</persName>
                   </title>
@@ -777,12 +764,9 @@
                   </msItem>
                   <msItem xml:id="d52" n="59">
                     <locus from="98b"/>
-                    <title xml:lang="en">Of <persName>Acacius of <placeName>Constantinople</placeName>
-                      </persName> and
-                    <ref>his anti-encyclical letter</ref>, and of <persName ref="http://syriaca.org/person/1414">Peter of <placeName>Antioch</placeName>
-                      </persName> and
-                    <persName ref="http://syriaca.org/person/2470">Paul of <placeName>Ephesus</placeName>
-                      </persName>
+                    <title xml:lang="en">Of <persName>Acacius of <placeName>Constantinople</placeName></persName> and
+                    <ref>his anti-encyclical letter</ref>, and of <persName ref="http://syriaca.org/person/1414">Peter of <placeName>Antioch</placeName></persName> and
+                    <persName ref="http://syriaca.org/person/2470">Paul of <placeName>Ephesus</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܡܫܐ ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܫܪܒܐ ܕܚܡܫܐ. ܡܘܕܥ̣. ܥܠ ܗ̈ܠܝܢ ܕܥܬܕ
                     ܐܩܩ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ. ܘܥܠ ܐܢܛܐܢܩܘܩܠܝܐ. ܘܥܠ ܦܛܪܘܣ ܘܦܘܠܘܣ ܕܐܢܛܝܘܟ݂ ܘܕܐܦܣܘܣ. ܘܕܐܫܬܪܝܘ
@@ -791,8 +775,7 @@
                   </msItem>
                   <msItem xml:id="d53" n="60">
                     <locus from="99b"/>
-                    <title xml:lang="en">Of <persName>Martyrius of <placeName>Jerusalem</placeName>
-                      </persName>
+                    <title xml:lang="en">Of <persName>Martyrius of <placeName>Jerusalem</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܫܬܐ ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܡܐܡܪܐ ܥܠ ܡܪܛܘܪ ܡܘܕܥ܇ ܗ̇ܘ ܕܗ̣ܘܐ
                     ܒܐܘܪܫܠܡ ܒܬܪ ܐܢܣܛܣ. ܕܐܦ ܗ̣ܘ ܡܟܪܙ ܗܘܐ ܠܥܡܐ ܗܝܡܢܘܬܐ ܕܫܪܪܐ. ܘܡܚܪܡ ܗܘܐ ܠܢܣܛܪܝܣ̣
@@ -823,26 +806,21 @@
                   </msItem>
                   <msItem xml:id="d57" n="64">
                     <locus from="105a"/>
-                    <title xml:lang="en">Synodical letter of the Council of <placeName ref="http://syriaca.org/place/10">Antioch</placeName> under <persName>Peter</persName> to <persName>Peter of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Synodical letter of the Council of <placeName ref="http://syriaca.org/place/10">Antioch</placeName> under <persName>Peter</persName> to <persName>Peter of <placeName>Alexandria</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܥ̈ܣܪܐ ܕܝܠܗ ܕܠܐܓܘܣ ܕܚܡܫܐ ܡ̇ܠܦ̣. ܡܢ ܐܓܪܬܐ ܣܘܢܗܕܝܩܐ ܕܗܘܬ ܡܢ ܟܢܘܫܝܐ̇. ܕܐܢܛܝܘܟ ܕܒܝܘ̈ܡܝ ܦܛܪܘܣ܇ ܕܬܡܢ ܠܘܬ ܦܛܪܣ ܕܐܠܟܣܢܕܪܝܐ</rubric>
                     <note>See <bibl>Land, p. 184.</bibl>.</note>
                   </msItem>
                   <msItem xml:id="d58" n="65">
                     <locus from="106a"/>
-                    <title xml:lang="en">Letter of <persName>Acacius of <placeName>Constantinople</placeName>
-                      </persName> to <persName>Peter of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName>Acacius of <placeName>Constantinople</placeName></persName> to <persName>Peter of <placeName>Alexandria</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܕ̈ܥܣܪ݂. ܐܓܪܬܐ ܬܘܒ ܕܐܩܩ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ. ܕܠܘܬ ܦܛܪܘܣ ܕܐܠܟܣܢܕܪܝܐ</rubric>
                     <note>See <bibl>Land, p. 186</bibl>.</note>
                   </msItem>
                   <msItem xml:id="d59" n="66">
                     <locus from="107a"/>
-                    <title xml:lang="en">Letter of <persName>Martyrius of <placeName>Jerusalem</placeName>
-                      </persName> to <persName>Peter of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName>Martyrius of <placeName>Jerusalem</placeName></persName> to <persName>Peter of <placeName>Alexandria</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܬܪ̈ܥܣܪ ܥܠ ܐܓܪܬܗ ܕܝܠܗ ܕܡܪܛܘܪ ܕܐܘܪܫܠܡ ܡ̇ܠܦ̣. ܕܟܬ̣ܒ ܠܦܛܪܘܣ ܕܗܘܐ ܗܘܐ ܒܐܠܟܣܢܕܪܝܐ ܗܟܘܬ</rubric>
                     <note>See <bibl>Land, p. 187</bibl>.</note>
@@ -868,9 +846,7 @@
                   </msItem>
                   <msItem xml:id="d62" n="71">
                     <locus from="108b"/>
-                    <title xml:lang="syr">Of <persName>those who separated themselves from communion with <persName>Peter of <placeName>Alexandria</placeName>
-                        </persName>
-                      </persName>
+                    <title xml:lang="syr">Of <persName>those who separated themselves from communion with <persName>Peter of <placeName>Alexandria</placeName></persName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܩܕܡܝܐ ܕܝܠܗ ܕܡܐܡܪܐ ܕܫܬܐ ܡܘܕܥ̣. ܥܠ ܗܠܝܢ ܕܦܪܫܘ ܡܢ ܚܘܠܛܢܗ ܕܦܛܪܘܣ. ܥܠ ܕܠܐ ܝܕܝܥܐܝܬ ܐܝܬ ܗܘܐ ܒܗܢܛܝܩܘܢ̇ ܘܒܟ̈ܬܝܒܬܐ ܬܘܒ ܕܪ̈ܝܫܝ ܟܗ̈ܢܐ ܕܠܘܬܗ ܚܪ̈ܡܐ. ܕܣܘܢܗܕܣ ܕܝܠܗ ܕܟܠܩܝܕܘܢܐ. ܘܕܛܘܡܣܐ ܕܠܐܘܢ</rubric>
                     <note>See <bibl>Land, p. 188</bibl>.</note>
@@ -897,8 +873,7 @@
                   </msItem>
                   <msItem xml:id="d66" n="75">
                     <locus from="111b"/>
-                    <title xml:lang="en">Letter of <persName>Fravitas</persName> of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName> to <persName>Peter of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName>Fravitas</persName> of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName> to <persName>Peter of <placeName>Alexandria</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܚܡܫܐ ܕܝܠܗ ܕܫܪܒܐ ܕܐܫܬܐ ܡܫܘܕܥ ܐܓܪܬܗ ܕܦܪܘܝܛܣ ܕܝܠܗ̇ ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ. ܕܠܘܬ ܦܛܪܘܣ ܕܐܠܟܣܢܕܪܝܐ ܕܐܝܬܝܗ̇ ܗܟܘܬ</rubric>
                     <note>See <bibl>Land, p. 194</bibl>.</note>
@@ -928,8 +903,7 @@
                   </msItem>
                   <msItem xml:id="d70" n="80">
                     <locus from="115a"/>
-                    <title xml:lang="en">Of the succession of <persName>Anastasius</persName> to the throne, and the expulsion of <persName ref="http://syriaca.org/person/2277">Euphemius, bishop of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                      </persName>
+                    <title xml:lang="en">Of the succession of <persName>Anastasius</persName> to the throne, and the expulsion of <persName ref="http://syriaca.org/person/2277">Euphemius, bishop of <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܩܕܡܝܐ ܕܝܠܗ ܕܫܪܒܐ ܕܫܒ̈ܥܐ. ܡܘܕܥ ܥܠ ܡܠܟܘܬܗ ܕܐܢܣܛܘܣ ܐܘܛܩܪܛܘܪ ܗ̇ܘ ܕܐܡܠܟ ܒܬܪ ܙܝܢܘܢ̇ ܘܥܠ ܐܘܦܡܝܣ ܐܦܣܩܘܦܐ ܕܬܡܢ ܕܐܬܕܚܝ</rubric>
                     <note>See <bibl>Land, p. 201</bibl>.</note>
@@ -999,17 +973,14 @@
                   </msItem>
                   <msItem xml:id="d80" n="90">
                     <locus from="129b"/>
-                    <title xml:lang="en">The <foreign xml:lang="grc">δέησις</foreign> of <persName>the Oriental monks</persName> and of <persName>Cosmas of <placeName>Ḳinnesrῑn</placeName>
-                      </persName>, laid before the above mentioned council of <placeName ref="http://syriaca.org/place/187">Sidon</placeName>
+                    <title xml:lang="en">The <foreign xml:lang="grc">δέησις</foreign> of <persName>the Oriental monks</persName> and of <persName>Cosmas of <placeName>Ḳinnesrῑn</placeName></persName>, laid before the above mentioned council of <placeName ref="http://syriaca.org/place/187">Sidon</placeName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܕ̈ܥܣܪ ܕܝܠܗ ܕܠܐܓܘܣ ܕܫܒܥܐ. ܡܘܕܥ ܥܠ ܕܝܣܝܣ ܕܗܘܬ ܡܢ ܕܝܪ̈ܝܐ ܡܕ̈ܢܚܝܐ. ܘܩܘܙܡܐ ܕܩܢܫܪܝܢ. ܘܐܬܩܪܒܬ ܠܟܢܘܫܝܐ ܕܒ̈ܝܘܡܝ ܦܠܘܝܢܣ ܘܐܟܣܢܝܐ ܐܦܣ̈ܩܘܦܐ ܕܐܬܡܢܥܘ ܠܨܝܕܢ ܒܫܢܬ ܚܡܫܡܐܐ ܘܐܫܬܝܢ ܒܡܢܝܢܐ ܕܐܢ̈ܛܝܘܟܝܐ</rubric>
                     <note>See <bibl>Land, p. 226</bibl>.</note>
                   </msItem>
                   <msItem xml:id="d81" n="91">
                     <locus from="130b"/>
-                    <title xml:lang="en">Of the Council of <placeName ref="http://syriaca.org/place/195">Tyre</placeName>, in the days of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                      </persName> and <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName>
-                      </persName>
+                    <title xml:lang="en">Of the Council of <placeName ref="http://syriaca.org/place/195">Tyre</placeName>, in the days of <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName> and <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName>Mabūg</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬܪ̈ܥܣܪ ܕܥܠ ܣܘܢܗܕܣ ܕܗܘܬ ܒܨܘܪ ܡܘܕܥ ܒܝ̈ܘܡܝ ܣܐܘܪܣ ܘܐܟܣܢܝܐ̇. ܡ̈ܠܦܢܐ ܘܐܦܣ̈ܩܘܦܐ ܕܥܡܗܘܢ ܕܩܪܝܚܐܝܬ ܘܓܠܝܐܝܬ ܐܚܪܡܘܗ̇ ܠܣܘܢܗܕܣ ܘܠܛܘܡܣܐ</rubric>
                     <note>See <bibl>Land, p. 228</bibl>.</note>
@@ -1060,10 +1031,7 @@
                   </msItem>
                   <msItem xml:id="d88" n="99">
                     <locus from="134a"/>
-                    <title xml:lang="en">Of <persName>the martyrs of <placeName ref="http://syriaca.org/place/464">Najrān (<foreign xml:lang="ar">نَجْران</foreign>)</placeName>
-                      </persName>; being the epistle of <persName ref="http://syriaca.org/person/53">Simeon, bishop of <persName>the Persians</persName>
-                      </persName>, to <persName>Simeon of <placeName>Gabūla</placeName>
-                      </persName>
+                    <title xml:lang="en">Of <persName>the martyrs of <placeName ref="http://syriaca.org/place/464">Najrān (<foreign xml:lang="ar">نَجْران</foreign>)</placeName></persName>; being the epistle of <persName ref="http://syriaca.org/person/53">Simeon, bishop of <persName>the Persians</persName></persName>, to <persName>Simeon of <placeName>Gabūla</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬܠܬܐ ܕܝܠܗ ܕܫܪܒܐ. ܡܘܕܥ ܥܠ ܣܗ̈ܕܐ ܕܐܬܩܛܠܘ ܒܢ̈ܓܪܝܢ ܡܕܝܢܬ ܡܠܟܘܬܐ. ܕܒܝܬ ܚܡ̈ܝܪܐ ܒܫܢܬ ܬܡܢܡܐܐ ܘܬܠܬܝܢ ܘܚܡܫ ܕܝܘ̈ܢܝܐ. <foreign xml:lang="en">[<date when="0524">A.D. 524</date>]</foreign> ܫܢܬ ܫܬ ܕܡܠܟܘܬܗ ܕܝܘܣܛܝܢܣ. ܐܝܟ ܕܟܬܒ ܫܡܥܘܢ ܐܦܣܩܘܦܐ ܘܐܦܩܪܝܣܪܐ ܕܡܗ̈ܝܡܢܐ ܡܢ ܒܝܬ ܦܪ̈ܣܝܐ. ܠܫܡܥܘܢ ܪܝܫܕܝܪܐ ܕܓܒܘܠܐ ܗܟܘܬ</rubric>
                     <note>See <bibl>Land, p. 235</bibl>.</note>
@@ -1093,8 +1061,7 @@
                   </msItem>
                   <msItem xml:id="d92" n="103">
                     <locus from="142b"/>
-                    <title xml:lang="en">A short introduction to <ref>the four Gospels</ref>, written in Greek by <persName ref="http://syriaca.org/person/48">Mārā (Maras), bishop of <placeName ref="http://syriaca.org/place/8">Amid</placeName>
-                      </persName>
+                    <title xml:lang="en">A short introduction to <ref>the four Gospels</ref>, written in Greek by <persName ref="http://syriaca.org/person/48">Mārā (Maras), bishop of <placeName ref="http://syriaca.org/place/8">Amid</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܫܒ̈ܥܐ ܦܪܠܓܘܣ ܐܝܬ ܒܗ ܡܢ ܠܬܚܬ ܕܐܡܝܪ ܠܡܪܐ ܐܦܣܩܦܐ ܕܐܡܕ ܒܠܫܢܐ ܝܘܢܝܐ ܒܛܛܪܐ ܐܘܢܓܠܝܘܢ.</rubric>
                     <explicit xml:lang="syr">
@@ -1184,8 +1151,7 @@
                     <author ref="http://syriaca.org/person/579">
                       <persName xml:lang="en">Julian</persName>
                     </author>
-                    <title xml:lang="en">The first letter of <persName ref="http://syriaca.org/person/579">Julian</persName> to <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName>
-                      </persName>
+                    <title xml:lang="en">The first letter of <persName ref="http://syriaca.org/person/579">Julian</persName> to <persName ref="http://syriaca.org/person/51">Severus of <placeName>Antioch</placeName></persName>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܥ̈ܣܪܐ ܥܠ ܐܓܪܬܐ ܕܝܘܠܝܢܐ ܩܕܡܝܬܐ ܕܠܘܬ ܣܘܪܐ. ܒܫܘܐܠܐ ܡܛܠ ܦܓܪܗ ܕܡܫܝܚܐ</rubric>
                     <note>See <persName>Land, p. 263</persName>.</note>
@@ -1232,8 +1198,7 @@
                   </msItem>
                   <msItem xml:id="d108" n="120">
                     <locus from="157a"/>
-                    <title xml:lang="en">Of <persName>the bishops who were recalled from exile to <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                      </persName>, and <ref>their confession of faith</ref>
+                    <title xml:lang="en">Of <persName>the bishops who were recalled from exile to <placeName ref="http://syriaca.org/place/586">Constantinople</placeName></persName>, and <ref>their confession of faith</ref>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܡܫ̈ܬܥܣܪ ܥܠ ܐܦ̈ܣܩܦܐ ܗܠܝܢ ܡܗ̈ܝܡܢܐ. ܕܡܢ ܐܟܣܘܪܝܐ ܬܘܒ ܐܬܩܪܝܘ ܠܡܕܝܢܬ ܡܠܟܘܬܐ. ܘܝܗܒܘ ܦܣܐ <foreign xml:lang="en">(sic)</foreign> ܕܥܠ ܗܝܡܢܘܬܗܘܢ̇ ܠܡܠܟܐ ܕܐܝܬܘܗܝ ܗܟܘܬ</rubric>
                     <note>See <bibl>Land, p. 272</bibl>.</note>
@@ -1285,8 +1250,7 @@
                     <author ref="http://syriaca.org/person/1592">
                       <persName xml:lang="en">Anthimus of Constantinople</persName>
                     </author>
-                    <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/1592">Anthimus of <placeName>Constantinople</placeName>
-                      </persName> to <persName ref="http://syriaca.org/person/51">Severus</persName>
+                    <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/1592">Anthimus of <placeName>Constantinople</placeName></persName> to <persName ref="http://syriaca.org/person/51">Severus</persName>
                       </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܥ̈ܣܪܝܢ ܘܚܕ ܐܓܪܬܐ ܕܐܢܬܝܡܘܣ ܠܘܬ ܣܐܘܪܣ ܕܝܠܗ̇ ܕܐܢܛܝܘܟ</rubric>
                     <note>See <bibl>Land, p. 292</bibl>.</note>
@@ -1306,8 +1270,7 @@
                     <author ref="http://syriaca.org/person/51">
                       <persName xml:lang="en">Severus</persName>
                     </author>
-                    <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/51">Severus</persName> to <persName ref="http://syriaca.org/person/784">Theodosius of <placeName>Alexandria</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName ref="http://syriaca.org/person/51">Severus</persName> to <persName ref="http://syriaca.org/person/784">Theodosius of <placeName>Alexandria</placeName></persName>
                       </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܥ̈ܣܪܝܢ ܘܬܠܬܐ. ܐܓܪܬܐ ܕܣܐܘܪܐ ܠܘܬ ܬܐܕܣܝܣ</rubric>
                     <note>See <bibl>Land, p. 301</bibl>.</note>
@@ -1362,8 +1325,7 @@
                   </msItem>
                   <msItem xml:id="d122" n="135" defective="true">
                     <locus from="181b"/>
-                    <title xml:lang="en">Of the doings of <persName>Abraham bar <foreign xml:lang="syr">ܟܝܠܝ</foreign>
-                        </persName> at <placeName ref="http://syriaca.org/place/8">Amid</placeName>
+                    <title xml:lang="en">Of the doings of <persName>Abraham bar <foreign xml:lang="syr">ܟܝܠܝ</foreign></persName> at <placeName ref="http://syriaca.org/place/8">Amid</placeName>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬ̈ܪܝܢ ܕܝܠܗ ܕܫܪܒܐ ܕܥ̈ܣܪܐ. ܥܠ ܗܠܝܢ ܕܣܥܪ ܐܒܪܗܡ [ܒܪܟܝܠܝ ܒܐܡܕ ܒܦܢܛܩܕܩܛܐ ܘܒܕܘܛܪܐ]</rubric>
                     <note>See <bibl>Land, p. 316</bibl>.</note>
@@ -1371,19 +1333,14 @@
                   </msItem>
                   <msItem xml:id="d123" n="136" defective="true">
                     <locus from="181b"/>
-                    <title xml:lang="en">Of the priest <persName>Cyrus of <placeName>
-                          <foreign xml:lang="syr">ܠܓܝܢ</foreign>
-                        </placeName>
-                        </persName>, who was burned at <placeName ref="http://syriaca.org/place/8">Amid</placeName>
+                    <title xml:lang="en">Of the priest <persName>Cyrus of <placeName><foreign xml:lang="syr">ܠܓܝܢ</foreign></placeName></persName>, who was burned at <placeName ref="http://syriaca.org/place/8">Amid</placeName>
                       </title>
                     <rubric xml:lang="syr">ܕܬܠܬܐ ܥܠ ܩܝܪܣ ܩܫܝܫܐ. ܡܢ ܠܓܝܢ ܩܪܝܬܐ. ܕܐܝܩܕ ܒܛܛܪܦܘܠܢ ܕܐܡܕ</rubric>
                     <note>This chapter is wanting.</note>
                   </msItem>
                   <msItem xml:id="d124" n="137">
                     <locus from="182a"/>
-                    <title xml:lang="en">Letter of <persName>Rabūlas of <placeName>Edessa</placeName>
-                      </persName> to <persName>Gamalinus of <placeName>Perrhe</placeName>
-                      </persName>
+                    <title xml:lang="en">Letter of <persName>Rabūlas of <placeName>Edessa</placeName></persName> to <persName>Gamalinus of <placeName>Perrhe</placeName></persName>
                       </title>
                     <rubric xml:lang="syr">. . . ܡܢ ܐܓܪܬܐ ܕܗܘܬ ܡܢ ܪܒܘܠܐ. ܠܘܬ ܓܡܠܝܢܐ ܐܦܣܩܘܦܐ ܕܦܝܪܝܢ. ܡܛܘܠ ܐܝܠܝܢ ܕܡܥܘܠܝܢ ܒܪ̈ܐܙܐ. ܘܡܬܬܪܣܝܢ ܡܢܗܘܢ ܐܝܟ ܠܚܡܐ ܫܚܝܡܐ</rubric>
                     <note>See <bibl>Land, p. 316</bibl>, and <bibl>Overbeck, S. Ephraemi Syri etc. Opera Selecta, p. 231</bibl>.</note>
@@ -1391,8 +1348,7 @@
                   <msItem xml:id="d125" n="138" defective="true">
                     <locus from="185a"/>
                     <title xml:lang="en">Of the Dedication of <placeName>the Church at <placeName>Antioch</placeName>
-                      </placeName>, celebrated by <persName>Ephraim</persName>, and of the synod of <persName>bishops of <placeName>the diocese</placeName>
-                      </persName>
+                      </placeName>, celebrated by <persName>Ephraim</persName>, and of the synod of <persName>bishops of <placeName>the diocese</placeName></persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܡܫܐ ܥܠ ܐܢܩܢܝܐ ܕܥܒܕ ܐܦܪܝܡ ܕܐܢܛܝܘܟ ܕܥܕܬܐ ܘܣܘܢܗܕܘܣ ܕܐܦܣܩܦܐ ܕܫܘܠܛܢܗ</rubric>
                     <note>See <bibl>Land, p. 322</bibl>.</note>
@@ -1402,8 +1358,7 @@
                       <author ref="http://syriaca.org/person/42">
                         <persName xml:lang="en">Jacob of Batnae</persName>
                       </author>
-                      <title xml:lang="en">The beginning of a metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName>
-                        </persName> on the Transfiguration</title>
+                      <title xml:lang="en">The beginning of a metrical discourse of <persName ref="http://syriaca.org/person/42">Jacob of <placeName>Batnae</placeName></persName> on the Transfiguration</title>
                       <incipit xml:lang="syr">ܡܐܡܪܐ ܕܥܠ ܡܪܢ ܘܡܘܫܐ ܘܐܠܝܐ ܟܕ ܡܡܠܠܝܢ ܥܡܗ ܒܥܢܢܐ ܕܣܝܡ ܠܡܪܝ ܝܥܩܘܒ ܡܠܦܢܐ ܘܦܝܣܦܐ <foreign xml:lang="en">(sic)</foreign> ܕܒܛܢܢ.</incipit>
                       <note>See <bibl>Assemani, Bibl. Or., t. i., p. 328, no. 187</bibl>.</note>
                       <note>See <ref>additions</ref>.</note>
@@ -1437,9 +1392,7 @@
                   </msItem>
                   <msItem xml:id="d128" n="145">
                     <locus from="187a"/>
-                    <title xml:lang="en">Of the priest <persName>Basiliscus of <placeName>Antioch</placeName>
-                      </persName> who came with <persName>the dux <foreign xml:lang="syr">ܐܘܕܢܐ</foreign>
-                      </persName> to <placeName ref="http://syriaca.org/place/8">Amid</placeName>
+                    <title xml:lang="en">Of the priest <persName>Basiliscus of <placeName>Antioch</placeName></persName> who came with <persName>the dux <foreign xml:lang="syr">ܐܘܕܢܐ</foreign></persName> to <placeName ref="http://syriaca.org/place/8">Amid</placeName>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܐܫܬܐ ܕܝܠܗ ܕܫܪܒܐ ܕܬܪ̈ܥܣܪ ܥܠ ܒܣܝܠܝܣܩܘܣ ܩܫܝܫܐ ܕܐܢܛܝܘܟ ܕܐܬܡܢܥ ܥܡ ܐܘܕܢܐ ܕܘܟܣ ܠܐܡܕ</rubric>
                     <note>See <bibl>Land, p. 325</bibl>.</note>

--- a/data/tei/864.xml
+++ b/data/tei/864.xml
@@ -184,8 +184,7 @@
                   <msItem xml:id="d3" n="6">
                     <locus from="3b"/>
                     <title xml:lang="en">A letter, asking an explanation of the chronological
-                  differences between the Greek and Syriac texts in the genealogies of <ref>the book of
-                  Genesis</ref>
+                  differences between the Greek and Syriac texts in the genealogies of <ref>the book of Genesis</ref>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬ̈ܪܝ̣ܢ. ܦܝܣܐ ܡܛܠ ܡܢܝܢܐ ܕܣܦܪ ܬܘ̈ܠܕܬܐ</rubric>
                     <note>See <bibl>Land, p. 6</bibl>.</note>
@@ -200,8 +199,7 @@
                   </msItem>
                   <msItem xml:id="d5" n="8">
                     <locus from="8a"/>
-                    <title xml:lang="en">A letter addressed to <persName ref="http://syriaca.org/person/64">Moses of Agel</persName> regarding <ref>the book of <persName>Joseph</persName> and <persName>Asiyath (Ase-nath)</persName>
-                      </ref>
+                    <title xml:lang="en">A letter addressed to <persName ref="http://syriaca.org/person/64">Moses of Agel</persName> regarding <ref>the book of <persName>Joseph</persName> and <persName>Asiyath (Ase-nath)</persName></ref>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܐܪ̈ܒܥܐ. ܦܝܣܐ ܕܥܠ ܬܫܥܝܬܐ ܕܐܣܝܬ ܘܕܝܘܣܦ. ܐܓܪܬܐ ܡܛܠ ܗܕܐ ܠܘܬ ܡܘܫܐ ܐܓܠܝܐ</rubric>
                     <note>On  <persName ref="http://syriaca.org/person/64">Moses of Agel</persName>, see <bibl>Assemani, Bibl. Or., t. ii., p. 82</bibl>.</note>
@@ -242,11 +240,7 @@
                   <msItem xml:id="d9" n="12">
                     <locus from="43a"/>
                     <title xml:lang="en">The revelation of <placeName>the repository of the bones of <persName ref="http://syriaca.org/person/1711">S. Stephen the protomartyr</persName>, <persName>Nicodemus</persName>,
-                  <persName ref="http://syriaca.org/person/1245">Gamaliel</persName>, and his son <persName ref="http://syriaca.org/person/3019">Ḥabib</persName></placeName>, from <ref>the
-                  letters of <persName>Lucian, the priest, of
-                    <placeName>Kĕphar-Gamlā</placeName>
-                        </persName>
-                      </ref>
+                  <persName ref="http://syriaca.org/person/1245">Gamaliel</persName>, and his son <persName ref="http://syriaca.org/person/3019">Ḥabib</persName></placeName>, from <ref>the letters of <persName>Lucian, the priest, of <placeName>Kĕphar-Gamlā</placeName></persName></ref>
                     </title>
                     <rubric xml:lang="syr">ܬܘܒ ܪܝܫܐ ܕܬܡܢܝܐ. ܓܠܝܢܐ ܕܣܝܡܬ ܓܪ̈ܡܐ ܕܐܣܛܦܢܘܣ. ܪܝܫܐ.  ܕܣܗ̈ܕܐ
                   ܕܒܡܫܝܚܐ. ܘܕܢܝܩܕܡܣ. ܘܕܓܡܠܝܐܝܠ. ܘܕܚܒܝܒ ܒܪܗ. ܕܒܝ̈ܘܡܝ ܬܐܕܣܝܣ ܡ̇ܠܟܐ. ܡܢ ܐܓܪ̈ܬܐ ܕܠܘܩܝܢܘܣ
@@ -576,9 +570,7 @@
                     <locus from="80b"/>
                     <title xml:lang="en">The <foreign xml:lang="grc">Δέησις</foreign>, or Petition, of
                         <persName>Timotheus</persName> to the emperor, setting forth his confession
-                      of faith, and arguing against <ref>the letter of <persName ref="http://syriaca.org/person/2299">Leo of
-                      Rome</persName>
-                      </ref>
+                      of faith, and arguing against <ref>the letter of <persName ref="http://syriaca.org/person/2299">Leo of Rome</persName></ref>
                       </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܫܬܐ ܕܡܘܕܥ ܒܕܝܣܝܣ ܕܛܝܡܬܐ ܗܝܡܢܘܬܗ ܘܥ̈ܘܕܠܐ ܕܥܒܕ ܥܠ ܐܓܪܬܗ ܕܠܐܘܢ</rubric>
                     <note>See <bibl>Land, p. 139</bibl>.</note>
@@ -753,8 +745,7 @@
                   <msItem xml:id="d51" n="58">
                     <locus from="97a"/>
                     <title xml:lang="en">What happened at <placeName ref="http://syriaca.org/place/586">Constantinople</placeName>
-                    and <placeName ref="http://syriaca.org/place/623">Ephesus</placeName> after the publication of <ref>the encyclical
-                    letter</ref>
+                    and <placeName ref="http://syriaca.org/place/623">Ephesus</placeName> after the publication of <ref>the encyclical letter</ref>
                     </title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܐܪ̈ܒܥܐ ܕܝܠܗ ܟܕ ܕܝܠܗ ܕܡܐܡܪܐ ܕܚܡܫܐ̣. ܡܫܘܕܥ ܐܝܠܝܢ ܕܒܬܪ
                     ܐܢܩܘܩܠܝܐ ܓܕܫ ܒܩܘܣܛܢܛܝܢܦܘܠܝܣ ܘܒܐܦܣܘܣ</rubric>

--- a/data/tei/864.xml
+++ b/data/tei/864.xml
@@ -117,8 +117,7 @@
                 <persName xml:lang="en">Zacharias Rhetor, bishop of
                 Mitylene</persName>
               </author>
-              <title xml:lang="en">The Ecclesiastical History of <persName ref="http://syriaca.org/person/58">Zacharias
-                Rhetor</persName>, bishop of <placeName ref="http://syriaca.org/place/1478">Mitylene</placeName>, in twelve
+              <title xml:lang="en">The Ecclesiastical History of <persName ref="http://syriaca.org/person/58">Zacharias Rhetor</persName>, bishop of <placeName ref="http://syriaca.org/place/1478">Mitylene</placeName>, in twelve
                 books</title>
               <title xml:lang="en">A volume of narratives of events which have happened in the world</title>
               <rubric xml:lang="syr">
@@ -346,8 +345,7 @@
                     <author ref="http://syriaca.org/person/688">
                       <persName xml:lang="en">Proclus</persName>
                     </author>
-                    <title xml:lang="en">The letter of <persName ref="http://syriaca.org/person/688">Proclus</persName> to <persName>the
-                  Armenians</persName>
+                    <title xml:lang="en">The letter of <persName ref="http://syriaca.org/person/688">Proclus</persName> to <persName>the Armenians</persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚܡܫܐ ܕܐܝܬ ܒܗ ܐܓܪܬܐ ܕܦܪܩܠܘܣ ܪܝܫ ܟܗ̈ܢܐ ܕܝܠܗ̇
                   ܕܩܘܣܛܢܛܝܢܦܘܠܝܣ. ܕܠܘܬ ܐܪ̈ܡܢܝܐ. ܛܒ ܡܝܬܪܐ ܘܡܘܕܥܐ ܗܝܡܢܘܬܗ ܕܓܒܪܐ. ܘܠܥܘܗܕܢܐ ܕܬܢܢ
@@ -402,8 +400,7 @@
                   </msItem>
                   <msItem xml:id="d21" n="26">
                     <locus from="71b"/>
-                    <title xml:lang="en">Of the exile of <persName ref="http://syriaca.org/person/2432">Dioscorus of
-                      <placeName>Alexandria</placeName>
+                    <title xml:lang="en">Of the exile of <persName ref="http://syriaca.org/person/2432">Dioscorus of <placeName>Alexandria</placeName>
                       </persName>, and the ordination of <persName ref="http://syriaca.org/person/2471">Proterius</persName>
                       in his stead</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬ̈ܪܝܢ ܡܘܕܥ ܥܠ ܐܟܣܘܪܝܐ ܕܕܝܣܩܪܣ ܘܟܪܛܘܢܝܐ ܕܦܪܛܘܪܝܣ
@@ -452,8 +449,7 @@
                   </msItem>
                   <msItem xml:id="d26" n="31">
                     <locus from="74a"/>
-                    <title xml:lang="en">Of the appearance of <persName>our Lord</persName> to <persName ref="http://syriaca.org/person/680">Peter the
-                        Iberian</persName>, bidding him leave <placeName>Gaza</placeName> along with
+                    <title xml:lang="en">Of the appearance of <persName>our Lord</persName> to <persName ref="http://syriaca.org/person/680">Peter the Iberian</persName>, bidding him leave <placeName>Gaza</placeName> along with
                       <persName>the persecuted</persName>
                     </title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܫ̈ܒܥܐ ܥܠ ܕܐܬܚܙܝ ܡܪܢ ܠܦܛܪܐ ܝܒܝܪܝܐ ܕܓܙܐ ܘܐܡܪ ܠܗ ܕܢܫܢܐ ܥܡ ܪ̈ܕܝܦܐ</rubric>
@@ -538,8 +534,7 @@
                   </msItem>
                   <msItem xml:id="d34" n="40">
                     <locus from="77b"/>
-                    <title xml:lang="en">Of the ordination of <persName>Timotheus
-                        "the Weasel"</persName> (<foreign xml:lang="grc">Αἴλουρος</foreign>, <foreign xml:lang="syr">ܐܠܘܪܘܣ</foreign>, translated by
+                    <title xml:lang="en">Of the ordination of <persName>Timotheus "the Weasel"</persName> (<foreign xml:lang="grc">Αἴλουρος</foreign>, <foreign xml:lang="syr">ܐܠܘܪܘܣ</foreign>, translated by
                       <foreign xml:lang="syr">ܩܘܙܐ</foreign>) as bishop of
                       <placeName ref="http://syriaca.org/place/2620">Alexandria</placeName>
                       </title>
@@ -558,8 +553,7 @@
                   </msItem>
                   <msItem xml:id="d36" n="42">
                     <locus from="79a"/>
-                    <title xml:lang="en">How many of <persName>the clergy, who had taken the side of
-                      <persName ref="http://syriaca.org/person/2471">Proterius</persName>
+                    <title xml:lang="en">How many of <persName>the clergy, who had taken the side of <persName ref="http://syriaca.org/person/2471">Proterius</persName>
                       </persName>, wished to be reconciled to
                         <persName>Timotheus</persName>, but were hindered by <persName>the common people</persName> and
                       <persName>the more bigoted priests</persName>
@@ -599,8 +593,7 @@
                   </msItem>
                   <msItem xml:id="d40" n="46">
                     <locus from="82a"/>
-                    <title xml:lang="en">How <persName>the bishops who had been at
-                      <placeName ref="http://syriaca.org/place/622">Chalcedon</placeName>
+                    <title xml:lang="en">How <persName>the bishops who had been at <placeName ref="http://syriaca.org/place/622">Chalcedon</placeName>
                       </persName>, with the exception of
                         <persName>Amphilochius of <placeName>Side</placeName>
                       </persName>, wrote to the emperor
@@ -634,8 +627,7 @@
                     <locus from="83b"/>
                     <title xml:lang="en">Of the other <persName>Timotheus</persName>,
                         surnamed <foreign xml:lang="syr">ܡܬܪܘܛ ܦܩܝܠܐ</foreign> (or <foreign xml:lang="syr">ܪܥܘܠܦܩܝܠܐ</foreign>, or
-                        <persName>Salofaciolus</persName>), whom the <persName>partizans of
-                        <persName>Proterius</persName>
+                        <persName>Salofaciolus</persName>), whom the <persName>partizans of <persName>Proterius</persName>
                       </persName> elected bishop</title>
                     <rubric xml:lang="syr">ܪܝܫܐ ܕܥ̈ܣܪܐ ܥܠ ܛܝܡܬܐܣ ܐܚܪܝܢܐ ܡܚܘܐ̣. ܗ̣ܘ ܕܗܘܐ ܐܦܣܩܘܦܐ ܡܢ
                       ܒ̈ܢܝ ܓܒܗ ܕܦܪܛܘܪܝܣ ܕܡܬܩܪܐ ܗܘܐ ܡܬܪܘܛ ܦܩܝܠܐ</rubric>
@@ -645,8 +637,7 @@
                     <locus from="84b"/>
                     <title xml:lang="en">How <persName>Timotheus Ælurus</persName> was
                       conveyed from <placeName ref="http://syriaca.org/place/624">Gangra</placeName> to <placeName>Cherson</placeName>
-                        (<foreign xml:lang="grc">Χερσών</foreign>), through the machinations of <persName>Gennadius of
-                        <placeName>Constantinople</placeName>
+                        (<foreign xml:lang="grc">Χερσών</foreign>), through the machinations of <persName>Gennadius of <placeName>Constantinople</placeName>
                       </persName> and his party</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܚ̈ܕܥܣܪ݂. ܕܐܝܟܢ ܡܢ ܓܢܓܪܐ ܠܟܪܣܘܢܐ ܐܬ݂ܕܒܪ ܛܝܡܬܐܘܣ.
                       ܒܣܢܐܬܐ ܕܥܠܘܗܝ ܕܟܠܩܝܕܘܢܐ</rubric>
@@ -654,12 +645,10 @@
                   </msItem>
                   <msItem xml:id="d45" n="51">
                     <locus from="85a"/>
-                    <title xml:lang="en">Of <persName>Isaiah, bishop of
-                        <placeName>Hermopolis</placeName>
+                    <title xml:lang="en">Of <persName>Isaiah, bishop of <placeName>Hermopolis</placeName>
                       </persName>, and the priest
                         <persName>Theophilus of <placeName ref="http://syriaca.org/place/572">Alexandria</placeName>
-                      </persName>, <persName>the
-                      Eutychianists</persName>, and how <persName>Timotheus</persName> wrote against them and
+                      </persName>, <persName>the Eutychianists</persName>, and how <persName>Timotheus</persName> wrote against them and
                       excommunicated them</title>
                     <rubric xml:lang="syr">ܪܫܐ ܕܬܪ̈ܥܣܪ܆ ܥܠ ܐܫܥܝܐ ܐܦܣܩܘܦܐ ܕܗܪܡܦܘܠܝܣ. ܘܥܠ ܬܐܦܝܠܐ
                       ܩܫܝܫܐ ܕܐܠܟܣܢܕܪܝܐ ܐܘܛܟܝܢܣܛܐ. ܘܐܓܪܬܐ ܕܥܒ̣ܕ ܡܛܠܬܗܘܢ ܛܝܡܬܐܣ ܘܦܪܣܝ ܐܢܘܢ</rubric>
@@ -758,8 +747,7 @@
                   </msItem>
                   <msItem xml:id="d49" n="56">
                     <locus from="95b"/>
-                    <title xml:lang="en">The encyclical letter of <persName>Basiliscus
-                    </persName> and <persName>Marcus</persName>
+                    <title xml:lang="en">The encyclical letter of <persName>Basiliscus </persName> and <persName>Marcus</persName>
                     </title>
                     <rubric xml:lang="syr"> ܪܝܫܐ ܕܬ̈ܪܝܢ ܡܘܕܥ ܥܠ ܐܢܩܘܩܠܝܐ ܕܒܣܝܠܝܣܩܘܣ ܘܕܡܪܩܘܣ̣. ܕܐܝܬ
                     ܐܢܘܢ̣ ܗܟܘܬܝ <foreign xml:lang="en">(sic)</foreign>

--- a/data/tei/865.xml
+++ b/data/tei/865.xml
@@ -103,8 +103,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="7"/>
-              <title xml:lang="en">Fragments of a life of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                </persName>, written by the author,
+              <title xml:lang="en">Fragments of a life of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>, written by the author,
                         whose name is not mentioned in the portions extant, at the request of one
                            <persName>Domitius</persName>.</title>
             </msItem>

--- a/data/tei/865.xml
+++ b/data/tei/865.xml
@@ -103,8 +103,7 @@
             <textLang mainLang="syr">Syriac</textLang>
             <msItem xml:id="a1" n="1" defective="true">
               <locus from="7"/>
-              <title xml:lang="en">Fragments of a life of <persName ref="http://syriaca.org/person/51">Severus, patriarch
-                        of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+              <title xml:lang="en">Fragments of a life of <persName ref="http://syriaca.org/person/51">Severus, patriarch of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                 </persName>, written by the author,
                         whose name is not mentioned in the portions extant, at the request of one
                            <persName>Domitius</persName>.</title>

--- a/data/tei/868.xml
+++ b/data/tei/868.xml
@@ -186,8 +186,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                    </persName>.</title>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕ܏ܩܕ ܦܝܠܠܟܣܐܢܘܣ ܕܡܒܘܓ ܕܥܠ ܗܝܡܢܘܬܐ</rubric>
               </msItem>
               <msItem xml:id="p1a4" n="6">
@@ -249,8 +248,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">A paraenetic discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">A paraenetic discourse of <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܡܪܬܝܢܘܬܐ ܏ܕܩܕ ܡܪܝ ܐܟܣܢܝܐ</rubric>
                 <incipit xml:lang="syr">ܐܠܘ ܦܓ̈ܥܘܗܝ ܕܥܠܡܐ ܒܝܫܐ ܠܐ ܡܕܘܕܝܢ ܠܝ̣. ܦܫܝܩ ܗܘܐ ܠܝ ܐܣܬܟܠ
                       ܐܝܠܝܢ ܕܥܕܪ̈ܢ ܠܝ. ܏ܘܫ.</incipit>

--- a/data/tei/868.xml
+++ b/data/tei/868.xml
@@ -151,8 +151,7 @@
                 <author ref="http://syriaca.org/person/573">
                   <persName xml:lang="en">John Chrysostom</persName>
                 </author>
-                <title xml:lang="en">An exposition of <title>Ps. vi.</title> by <persName>John
-                      Chrysostom</persName>.</title>
+                <title xml:lang="en">An exposition of <title>Ps. vi.</title> by <persName>John Chrysostom</persName>.</title>
                 <note>See <bibl>Opera, t. v., p. 664</bibl>.</note>
               </msItem>
               <msItem xml:id="p1a2" n="2">
@@ -187,8 +186,7 @@
                 <author ref="http://syriaca.org/person/44">
                   <persName xml:lang="en">Philoxenus of Mabūg</persName>
                 </author>
-                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of
-                      <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
+                <title xml:lang="en">An extract from <persName ref="http://syriaca.org/person/44">Philoxenus of <placeName ref="http://syriaca.org/place/122">Mabūg</placeName>
                     </persName>.</title>
                 <rubric xml:lang="syr">ܕ܏ܩܕ ܦܝܠܠܟܣܐܢܘܣ ܕܡܒܘܓ ܕܥܠ ܗܝܡܢܘܬܐ</rubric>
               </msItem>

--- a/data/tei/869.xml
+++ b/data/tei/869.xml
@@ -197,8 +197,7 @@
                   <persName xml:lang="en">Theophilus of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/10">Alexandria</placeName>
-                  </persName> on the Separation of the
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/10">Alexandria</placeName></persName> on the Separation of the
                            Soul from the Body.</title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܩܕܝܫܐ ܬܐܘܦܝܠܘܣ܆ ܥܠ ܦܘܪܫܢܐ ܕܢܦܫܐ ܡܢ
                            ܦܓܪܐ</rubric>

--- a/data/tei/869.xml
+++ b/data/tei/869.xml
@@ -149,9 +149,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of
-                           Batnae</persName> on the Nativity of <persName ref="http://syriaca.org/person/2245">our
-                           Lord</persName>.</title>
+                <title xml:lang="en">Prose homily of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the Nativity of <persName ref="http://syriaca.org/person/2245">our Lord</persName>.</title>
                 <rubric xml:lang="syr">ܬܘܒ ܬܘܪܓܡܐ ܕܩܕܝܫܐ ܡܪܝ ܝܥܩܘܒ̣ ܕܥܠ ܒܝܬ ܝܠܕܗ ܕܡܪܢ
                            ܒܒܣܪ</rubric>
                 <note>See <bibl>Assemani, Bibl. Or., t. i., p. 304, no. 8</bibl>, and
@@ -199,8 +197,7 @@
                   <persName xml:lang="en">Theophilus of Alexandria
                 </persName>
                 </author>
-                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of
-                           <placeName ref="http://syriaca.org/place/10">Alexandria</placeName>
+                <title xml:lang="en">Discourse of <persName ref="http://syriaca.org/person/2507">Theophilus of <placeName ref="http://syriaca.org/place/10">Alexandria</placeName>
                   </persName> on the Separation of the
                            Soul from the Body.</title>
                 <rubric xml:lang="syr">ܬܘܒ ܡܐܡܪܐ ܕܩܕܝܫܐ ܬܐܘܦܝܠܘܣ܆ ܥܠ ܦܘܪܫܢܐ ܕܢܦܫܐ ܡܢ

--- a/data/tei/870.xml
+++ b/data/tei/870.xml
@@ -117,8 +117,7 @@
               <author ref="http://syriaca.org/person/154">
                 <persName xml:lang="en">Antonius Rhetor of Tagrit</persName>
               </author>
-              <title xml:lang="en">Works of <persName ref="http://syriaca.org/person/154">Antonius Rhetor of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
-                </persName>
+              <title xml:lang="en">Works of <persName ref="http://syriaca.org/person/154">Antonius Rhetor of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName></persName>
               </title>
               <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 345</bibl>.
               </note>
@@ -221,8 +220,7 @@
                     <persName xml:lang="en">Antonius Rhetor of Tagrit</persName>
                   </author>
                   <title xml:lang="en">Thanksgiving to God on the part of the said
-                      <persName>Euphemius</persName>, alias <persName>'Othman bar 'Anbasa, of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
-                    </persName>
+                      <persName>Euphemius</persName>, alias <persName>'Othman bar 'Anbasa, of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName></persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܕܝܬܐ ܠܐܠܗܐ ܐܝܟ ܕܡܢ ܦܪܨܘܦܗ ܕܐܘܦܝܡܝܘܣ ܗ̇ܘ ܕܡܢ ܠܥܠ̣.
                     ܒܗ̇ ܟܕ ܒܗ̇ ܒܕܝܨܬܐ</rubric>

--- a/data/tei/870.xml
+++ b/data/tei/870.xml
@@ -117,8 +117,7 @@
               <author ref="http://syriaca.org/person/154">
                 <persName xml:lang="en">Antonius Rhetor of Tagrit</persName>
               </author>
-              <title xml:lang="en">Works of <persName ref="http://syriaca.org/person/154">Antonius Rhetor of
-                <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
+              <title xml:lang="en">Works of <persName ref="http://syriaca.org/person/154">Antonius Rhetor of <placeName ref="http://syriaca.org/place/193">Tagrit</placeName>
                 </persName>
               </title>
               <note>See <bibl>Assemani, Bibl. Or., t. ii., p. 345</bibl>.
@@ -222,8 +221,7 @@
                     <persName xml:lang="en">Antonius Rhetor of Tagrit</persName>
                   </author>
                   <title xml:lang="en">Thanksgiving to God on the part of the said
-                      <persName>Euphemius</persName>, alias <persName>'Othman bar 'Anbasa, of
-                        <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
+                      <persName>Euphemius</persName>, alias <persName>'Othman bar 'Anbasa, of <placeName ref="http://syriaca.org/place/109">Callinicus</placeName>
                     </persName>
                   </title>
                   <rubric xml:lang="syr">ܬܘܕܝܬܐ ܠܐܠܗܐ ܐܝܟ ܕܡܢ ܦܪܨܘܦܗ ܕܐܘܦܝܡܝܘܣ ܗ̇ܘ ܕܡܢ ܠܥܠ̣.

--- a/data/tei/873.xml
+++ b/data/tei/873.xml
@@ -413,8 +413,7 @@
                 <author>
                   <persName xml:lang="en">Granius Licinianus</persName>
                 </author>
-                <title xml:lang="en">Annals of the Roman historian <persName>Granius
-                      Licinianus</persName>
+                <title xml:lang="en">Annals of the Roman historian <persName>Granius Licinianus</persName>
                 </title>
                 <note>These fragments were edited by <persName>Dr. Karl Pertz</persName>, under the title of <bibl>"Gai Grani Liciniani Annalium quae supersunt," Berlin, 1857</bibl>; and re-edited at <bibl>Leipzig, in 1858, under the title of "Grani Liciniani quae supersunt emendatiora edidit philologorum Bonnensium heptas."</bibl>
                 </note>

--- a/data/tei/874.xml
+++ b/data/tei/874.xml
@@ -2013,8 +2013,7 @@
                 <locus from="41a"/>
                 <title xml:lang="en">A note to the effect that the manuscript, to which it
                 belonged, was presented, with several others, to <placeName ref="http://syriaca.org/place/360">the convent of S. Mary Deipara</placeName>, by <persName>Zakhe Ya'kub</persName>,
-                the oriental, and the recluse <persName>John</persName>, of <placeName ref="http://syriaca.org/place/227">the convent of Mar
-                  Matthew</placeName>.</title>
+                the oriental, and the recluse <persName>John</persName>, of <placeName ref="http://syriaca.org/place/227">the convent of Mar Matthew</placeName>.</title>
                 <quote xml:lang="syr">ܗܕܐ ܦܢܩܝܬܐ ܥܡ ܟ̈ܬܒܐ ܐܚܪ̈ܢܐ ܫܲܟܢ ܠܗܘܢ ܙܟ̇ܐ ܝܥܩܘܒ ܡܕܢܚܝܐ. ܘܝܘܚܢܢ ܟܘܪܚܝܐ (؟) ܐܘܟܝܬ ܡܲܬܝܐ ܘܚܒܝܫܝܐ̣. ܠـ[ܕܝܪܐ] ܩܕܝܫܬܐ ܕܒܝܬ ܝܠ̣ܕܬ̇ ܐܠܗܐ ܡܪܬܝ ܡܪܝܡ ܐܝܟ ܕ[ܢܗܘܘܢ] ܠܗܘܢ ܥܠ̣ܬ ܥܘܗܕܢܐ ܠܟܠ ܦܪܘܫܐ ܕܢܩܪܐ [ܒܗ]ܘܢ ܘܢܐܡܪ ܕܐܠܗܐ ܚܲܣܐ ܘܫܒܘܩ ܚܘܒ̈ܝܗ[ܘܢ] ܕܗ̇ܢܘܢ ܕܫܲܟܢ ܠܗܘܢ ܠܕܘܟܬܐ ܗܕܐ ܩܕܝܫܬ[ܐ. ܘܠܐ] ܫܠܝܛ ܠܐܢܫ  ܡܢ  ܒܢ̈ܝܢܫܐ ܕܢܟܘܡ ܥܠܝܗܘܢ. ܏ܘܫ. ܘܫܟܢ  ܥܡ ܗܠܝܢ ܟ̈ܬܒܐ ܬܘܒ ܟܬܒܐ  ܕܦܪ . . . ܦܘܫܩܐ ܕܘܕ̈ܕܐ <foreign xml:lang="en">(sic)</foreign> ܫܦܝܪܐ ܚ̣ܕܬܐ . . . ܡܢ ܥܘܡܪܐ ܛܒܝ̣ܒܐ ܕܡܪܝ ܡܬܝ ܢܨܝـ[ـܚܐ] ܘܟܬܒ̈ܐ ܐܚܪ̈ܢܐ ܕܝܕܥ̇ ܠܗܘܢ . . . ܟܠ ܕܢ̇ܛܪ ܠܗܘܢ ܐܠܗܐ ܢܢܛܪܝܘܗ[ܝ.] ܕܫ̇ܩܠ ܠܗܘܢ ܠܢܦܫܗ ܢܫܩܘܠ ܐ[ܒܕܢܐ] ܠܚܝ̈ܘܗܝ ܐܡܝܢ ܐܡܝܢ. ܗܘܝ ܗܠܝܢ [ܒܫܢܬ] ܐܠܦ ܘܚܡ̈ܫ ܡ̈ܐܐ ܘܥܣܪ̈ܝܢ ܕܝܘ̈[ܢܝܐ.] ܒܪܟܡܪ[ܝ].</quote>
               </msItem>
             </msContents>

--- a/data/tei/874.xml
+++ b/data/tei/874.xml
@@ -1507,8 +1507,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p12a1" n="1" defective="true">
                 <locus from="19a" to="19b"/>
-                <title xml:lang="en">Part of a life of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                </persName>
+                <title xml:lang="en">Part of a life of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>
               </title>
                 <incipit xml:lang="syr">ܛܘܒܢܐ ܗܟܝܠ ܐܒܐ ܐܫܥܝܐ̣. ܒܓܢܣܗ ܐܝܬܘܗܝ ܗܘܐ ܡܨܪܝܐ. ܏ܘܫ</incipit>
               </msItem>

--- a/data/tei/874.xml
+++ b/data/tei/874.xml
@@ -556,8 +556,7 @@
                 <locus from="6a" to="7b"/>
                 <title xml:lang="en">Fragments of a discourse, in the second of which
                            <persName ref="http://syriaca.org/person/376">Basil</persName> and
-                           <persName ref="http://syriaca.org/person/511">Gregory
-                           Nazianzen</persName> are thus mentioned</title>
+                           <persName ref="http://syriaca.org/person/511">Gregory Nazianzen</persName> are thus mentioned</title>
                 <quote xml:lang="syr">ܣܪܝܩܐܝܬ ܡ̇ܢ ܡܬܩܠܣ ܒܐܣܝܠܝܘܣ. ܣܪܝܩܐܝܬ ܕܝܢ ܐܦ
                         ܓܪܝܓܘܪܝܘܣ. ܗ̇ܘ ܡ̇ܢ ܟܕ ܡ̇ܫܠܡ ܠܗ̇ ܠܗܝܡܢܘܬܐ ܒܗܠܝܢ ܕܡ̇ܡܠܠ. ܗ̇ܘ ܕܝܢ ܟܕ ܥܡܗ ܡܫܠܡ
                         ܠܗ̇ ܒܗܠܝܢ ܕܡܬܕܢܐ ܠܗ. ܏ܘܫ.
@@ -672,8 +671,7 @@
                   <persName xml:lang="en">Gregory Nyssen</persName>
                 </author>
                 <title xml:lang="en">Part of a discourse of <persName ref="http://syriaca.org/person/512">Gregory Nyssen</persName> on
-                           <persName ref="http://syriaca.org/person/1711">S. Stephen the
-                           protomartyr</persName>
+                           <persName ref="http://syriaca.org/person/1711">S. Stephen the protomartyr</persName>
               </title>
                 <note>See <bibl>Opera, t. iii., p. 354</bibl>. The text begins, on <locus from="8a">fol. 8 a</locus>, with the passage
                         corresponding to <bibl>p. 355, l. 20</bibl>, <foreign xml:lang="grc">τὸ γὰρ ἑτοίμως τοῦτον
@@ -797,8 +795,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Part of the second discourse of <persName ref="http://syriaca.org/person/42">Jacob
-                           of Batnae</persName> on the prophet <persName>Elijah</persName>, when he
+                <title xml:lang="en">Part of the second discourse of <persName ref="http://syriaca.org/person/42">Jacob of Batnae</persName> on the prophet <persName>Elijah</persName>, when he
                         fled from <persName>Jezebel</persName> (<title ref="http://syriaca.org/work/9662">1 Kings, ch. xix</title>)</title>
                 <rubric xml:lang="syr">ܡܐܡܪܐ ܕܬܪ̈ܝܢ. ܕܥܠ ܐܠܝܐ̣. ܟܕ ܥ̣ܪܩ ܡܢ ܐܝܙܒܝܠ</rubric>
                 <note>See <bibl>Add. 17,184<ptr target="https://bl.syriac.uk/ms/838"/>, no. <citedRange>1, b</citedRange>
@@ -1387,8 +1384,7 @@
                 <author ref="http://syriaca.org/person/42" role="https://syriaca.org/documentation/author-editor-roles.xml#claimed" resp="https://bl.syriac.uk/documentation/editors.xml#wwright">
                   <persName xml:lang="en" type="supplied">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Part of a sūgīthā on <persName>S. Simeon the
-                           aged</persName>, probably composed by Jacob of Batnae
+                <title xml:lang="en">Part of a sūgīthā on <persName>S. Simeon the aged</persName>, probably composed by Jacob of Batnae
               </title>
                 <incipit xml:lang="syr">܏ܣܘܓܝܬܐ ܏ܕܥܠ ܏ܫܥܡܘܢ ܏ܣܒܐ ܥܘܢܝܐ. ܒ܏ܪܝܟ ܏ܗ̣ܘ ܏ܡܫܝܚܐ
                         ܏ܕܒܚܘܒܗ. ܏ܥܠ ܏ܕܪ̈ܥܘܗܝ ܏ܛܥ̣ܢܗ ܏ܗ̣ܘܐ ܏ܫܡܥܘܢ̇. ܒܬܘܠܬܐ ܢܟܦܬ ܢܟ̈ܦܬܐ. ܙܡܢܬܢܝ ܝܘܡܢ

--- a/data/tei/894.xml
+++ b/data/tei/894.xml
@@ -124,25 +124,18 @@
                   </persName>, from
                 whose letters and homilies we find the following quotations.</p>
                 <p>Letters: <title>to <persName>the deaconess Anastasia</persName>
-                  </title>, <locus>foll. 19 a</locus>, <locus>55 a</locus>; <title>to <persName>Antonine, bishop of <placeName>Aleppo</placeName>
-                    </persName>
+                  </title>, <locus>foll. 19 a</locus>, <locus>55 a</locus>; <title>to <persName>Antonine, bishop of <placeName>Aleppo</placeName></persName>
                   </title>, <locus>fol. 36 b</locus>; <title>to <persName>the reader <foreign xml:lang="syr">ܩܪܘܝܐ</foreign> Archelaus</persName>
                   </title>, <locus>fol. 57 a</locus>; <title>to <persName>the lady Caesaria</persName>
                   </title>, <locus>foll. 4 a</locus>, <locus>59 b</locus>, <locus>88 a</locus>; <title>to <persName>Conon the silentiary</persName>
-                  </title>, <locus>fol. 93 a</locus>; <title>to <persName>Constantine, bishop of <placeName>Laodicea</placeName>
-                    </persName>
-                  </title>, <locus>fol. 15 a</locus>; <title>to <persName>John</persName>, <persName>Theodore</persName> and <persName>John</persName>, priests and abbats</title>, <quote xml:lang="syr">ܕܐܬܟܬܒܬ ܠܘܩܒܠ ܩܘܕܝܠܝܩܝܐ <foreign xml:lang="en">(sic)</foreign> ܕܐܠܟܣܢܕܪܝܐ</quote>, <locus>fol. 68 b</locus>; <title>to <persName>Julian of <placeName>Halicarnassus</placeName>
-                    </persName>
+                  </title>, <locus>fol. 93 a</locus>; <title>to <persName>Constantine, bishop of <placeName>Laodicea</placeName></persName>
+                  </title>, <locus>fol. 15 a</locus>; <title>to <persName>John</persName>, <persName>Theodore</persName> and <persName>John</persName>, priests and abbats</title>, <quote xml:lang="syr">ܕܐܬܟܬܒܬ ܠܘܩܒܠ ܩܘܕܝܠܝܩܝܐ <foreign xml:lang="en">(sic)</foreign> ܕܐܠܟܣܢܕܪܝܐ</quote>, <locus>fol. 68 b</locus>; <title>to <persName>Julian of <placeName>Halicarnassus</placeName></persName>
                   </title>, <locus>fol. 90 b</locus>; <title>to the chamberlains <persName>Phocas</persName> and <persName>Eupraxius</persName>
                   </title>, <locus>fol. 28 a</locus>; <title>to <persName>the general (<foreign xml:lang="syr">ܣܛܪܛܠܛܝܣ</foreign>) Probus</persName>
                   </title>, <locus>fol. 18 b</locus>; <title>to <persName>Scholasticus</persName>
-                  </title>, <locus>fol. 63 a</locus>; <title>to <persName>Sergius</persName>, comes and archiater</title>, <locus>foll. 53 a</locus>, <locus>63 a</locus>; <title>to <persName>Sergius, bishop of <placeName>Cyrus</placeName>
-                    </persName>
-                  </title>, <locus>fol. 29 a</locus>; <title>to <persName>Solon, bishop of <placeName>Isauria</placeName>
-                    </persName>
-                  </title>, <locus>fol. 95 a</locus>; <title>to <persName>the monks of <placeName>the convent of <persName>Mār Isaac</persName>
-                      </placeName>
-                    </persName>
+                  </title>, <locus>fol. 63 a</locus>; <title>to <persName>Sergius</persName>, comes and archiater</title>, <locus>foll. 53 a</locus>, <locus>63 a</locus>; <title>to <persName>Sergius, bishop of <placeName>Cyrus</placeName></persName>
+                  </title>, <locus>fol. 29 a</locus>; <title>to <persName>Solon, bishop of <placeName>Isauria</placeName></persName>
+                  </title>, <locus>fol. 95 a</locus>; <title>to <persName>the monks of <placeName>the convent of <persName>Mār Isaac</persName></placeName></persName>
                   </title>, <locus>fol. 30 a</locus>; <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܫܒܥ ܕܟܬܒܐ ܩܕܡܝܐ ܕܩܕܡ ܐܦܣܩܦܘܬܐ ܕܐܝܬ ܒܗ̇ ܣܝܡܐ ܕܐܟܘܬܗ ܡܬܓܒܝܢ ܕܢܥܒܕܘܢ ܗ̇ܢܘܢ ܕܒܕܡܘܬ ܒܪܢܫܐ ܐܡܪܝܢ ܕܐܝܬܘܗܝ ܐܠܗܐ</quote>, <locus>fol. 93 a</locus>; <title>imperfect extract</title>, <locus>fol. 83 a</locus>.</p>
                 <p>
                   <title>Homiliae Epithron.</title>: <title>xvi.</title>, <locus>fol. 71 b</locus>; <title>xxv.</title>, <locus>fol. 34 a</locus>; <title>xxxii.</title>, <locus>fol. 32 b</locus>; <title>xiii.</title>, <locus>fol. 32 b</locus>; <title>xiv.</title>, <locus>fol. 65 b</locus>; <title>lxiii.</title>, <locus>fol. 43 b</locus>; <title>lxxxi.</title>, <locus>fol. 33 a</locus>; <title>lxxxvii.</title>, <locus>fol. 102 b</locus>; <title>lxxxix.</title>, <locus>fol. 45 a</locus>; <title>xcv.</title>, <locus>fol. 40 a</locus>; <title>xcviii.</title>, <locus>fol. 48 a</locus>; <title>ci.</title>, <locus>fol. 31 a</locus>; <title>cvii.</title>, <locus>fol. 51 a</locus>; <title>cviii.</title>, <locus>fol. 23 b</locus>; <title>cxv.</title>, <locus>fol. 39 b</locus>; <title>cxvii.</title>, <locus>fol. 51 b</locus>.</p>
@@ -163,10 +156,7 @@
                   </title>, <locus>fol. 76 b</locus>: <quote xml:lang="syr">ܕܩܕܝܫܐ ܩܠܝܡܝܣ ܪܫܐ ܕܐܦܣܩܦܐ ܕܪܗܘܡܐ ܘܣܗܕܐ̣. ܗ̇ܘ ܕܐܦ ܫܠܝܚܐ ܦܘܠܘܣ ܟܕ ܟܬ̇ܒ ܠܘܬ ܦܝܠܝܦܝ̈ܣܝܐ ܗܟܢܐ ܐ̇ܡܪ ܡܛܠܬܗ̣. ܥܡ ܩܠܝܡܝܣ ܘܫܪܟܐ̣ ܕܡܥܢܕܪ̈ܢܝ. ܗܠܝܢ ܕܫܡ̈ܗܝܗܘܢ ܒܟܬܒܐ ܕܚ̈ܝܐ. ܐܘܣܒܝܣ ܕܝܢ ܩܣܪܝܐ ܐ̇ܡܪ ܥܠܘܗܝ ܒܡܟܬܒܢܘܬܐ ܕܬܠܬ ܕܬܫܥܝܬܐ ܥܕܬܢܝܬܐ̣. ܕܗ̣ܘ ܗܘ̣ܐ ܐܦܣܩܦܐ ܡܢ ܒܬܪ ܦܛܪܘܣ ܪܝܫܐ ܕܫ̈ܠܝܚܐ ܗܘ̣ܐ ܐܦܣܩܘܦܐ ܕܪܗܘܡܐ. ܡܢ ܐܓܪܬܐ ܕܬܪ̈ܬܝܢ ܕܠܘܬ ܩܘܪ̈ܢܬܝܐ. ܡܢ ܗ̇ܝ ܕܐܦ ܩܕܝܫܐ ܦܛܪܝܪܟܐ ܣܐܘܪܐ: ܒܣܓܝܐ̈ܬܐ ܕܡܟܬܒܢܘܬܗ ܡܝܬܐ ܬܚ̈ܘܝܬܐ. ܕܐܝܬܘܗܝ ܪܫܗ̇ ܐ̈ܚܝ ܗܟܢ ܙܕܩ ܠܢ ܕܢܬܪܥܐ ܡܛܠ ܝܫܘܥ ܡܫܝܚܐ̣. ܐܝܟ ܕܡܛܠ ܐܠܗܐ. ܐܝܟ ܕܡܛܠ ܕܝ̇ܢܐ ܕܚ̈ܝܐ ܘܕܡ̈ܝܬܐ</quote>.</p>
                 <p>
                   <persName>Cyril of <placeName>Alexandria</placeName>
-                  </persName>: <title>against <persName>Julian</persName>, hom vii.</title>, <locus>fol. 36 b</locus>; <title>hom. xi.</title>, <locus>fol. 38 a</locus>; <title>hom. xiv.</title>, <locus>fol. 65 a</locus>; <title>letter to <persName>the monks of <placeName>
-                        <foreign xml:lang="syr">ܦܘܐܐ</foreign> in <placeName>Egypt</placeName>
-                      </placeName>
-                    </persName>
+                  </persName>: <title>against <persName>Julian</persName>, hom vii.</title>, <locus>fol. 36 b</locus>; <title>hom. xi.</title>, <locus>fol. 38 a</locus>; <title>hom. xiv.</title>, <locus>fol. 65 a</locus>; <title>letter to <persName>the monks of <placeName><foreign xml:lang="syr">ܦܘܐܐ</foreign> in <placeName>Egypt</placeName></placeName></persName>
                   </title>, <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܕܝܪ̈ܝܐ ܕܐܝܬ ܒܦܘܐܐ ܩܪܝܬܐ ܕܒܡܨܪܝܢ. ܗܠܝܢ ܕܟܦܪܝܢ ܗܘܘ ܒܩܝܡܬܐ ܕܦܓܪ̈ܐ ܐܢ̈ܫܝܐ</quote>, <locus>foll. 73 b</locus>, <locus>75 a</locus>; <title>comment, on <ref>Isaiah</ref>
                   </title>, <locus>foll. 103 a</locus>, <locus>105 b</locus>; <title>on <ref>Zechariah</ref>
                   </title>, <locus>foll. 107 b</locus>, <locus>108 a</locus>.</p>
@@ -175,8 +165,7 @@
                   </persName>: <title>fifteenth catechesis</title>, <quote xml:lang="syr">ܡܢ ܡܪܬܝܢܘܬܐ ܕܚܡܫܥܣܪܐ</quote>, <locus>fol. 68 a</locus>.</p>
                 <p>
                   <persName>Dionysius of <placeName>Alexandria</placeName>
-                  </persName>: <title>letter to <persName>Stephanus of <placeName>Rome</placeName>
-                    </persName>
+                  </persName>: <title>letter to <persName>Stephanus of <placeName>Rome</placeName></persName>
                   </title>, <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܕܠܘܬ ܐܣܛܦܢܐ ܪܝܫܐ ܕܐܦܣ̈ܩܘܦܐ ܕܪܗܘܡܐ. ܡܛܠ ܥܡܕܐ. ܗ̇ܝ ܕܐܝܬܘܗܝ ܫܘܪܝܗ̣. ܗܠܝܢ ܡ̇ܢ ܕܐܣܬܥܪ ܡܢ ܩܕܝܡ ܡܪܝ ܐܚܘܢ̣ ܐܘܕܥܬܟ</quote>, <locus>fol. 73 b</locus>.</p>
                 <p>
                   <persName>Dionysius the Areopagite</persName>: <title>letter to <persName>Timothy</persName>
@@ -197,15 +186,13 @@
                 <p>
                   <persName>Hippolytus</persName>: <title>discourse addressed to <persName>the empress Mamaea</persName> on the Resurrection</title>, <locus>fol. 77 a</locus>, <quote xml:lang="syr">ܕܩܕܝܫܐ ܐܝܦܘܠܝܛܘܣ ܐܦܣܩܘܦܐ ܘܣܗܕܐ ܡܢ ܡܐܡܪܐ ܕܡܛܠ ܩܝܡܬܐ ܕܠܘܬ ܡܡܝܐ ܡܠܟܬܐ. ܒܗ̇ܘ ܕܡ̈ܠܐ ܗܠܝܢ ܕܒܬܪ̈ܬܝܗܝܢ ܐܓܪ̈ܬܐ ܕܠܘܬ ܩܘܪ̈ܢܬܝܐ ܡܛܠ ܨܒܘܬܐ ܗܕܐ ܕܣܝܡܐ ܡܒܚܢ. ܗܕܐ ܕܝܢ ܡܡܝܐ ܐܡܐ ܗܘܬ ܕܐܠܟܣܢܕܪܣ ܐܘܛܘܩܪܛܘܪ ܕܪ̈ܗܘܡܝܐ. ܗ̇ܘ ܕܡܢ ܒܬܪ ܐܢܛܘܢܝܢܘܣ ܩܒܠ ܡܠܟܘܬܐ̣. ܐܝܟ ܕܡܟܬܒ ܐܘܣܒܝܘܣ ܒܡܐܡܪܐ ܕܫܬܐ ܕܬܫܥܝܬܐ ܥܕܬܢܝܬܐ</quote>.</p>
                 <p>
-                  <persName>Ignatius</persName>: <title>letter to <persName>the people of <placeName>Tarsus</placeName>
-                    </persName>
+                  <persName>Ignatius</persName>: <title>letter to <persName>the people of <placeName>Tarsus</placeName></persName>
                   </title>, <locus>fol. 74 a</locus>, <quote xml:lang="syr">ܡܢ ܐܓܪܬܐ ܗ̇ܝ ܕܠܘܬ ܗܠܝܢ ܕܒܛܪܣܘܣ. ܗ̇ܝ ܕܐܝܬܘܗܝ ܫܘܪܝܗ̇ ܡܢ ܒܬܪ ܫܠܡܐ̣. ܡܢ ܣ̣ܘܪܝܐ ܥܕܡܐ ܠܪܗܘܡܐ ܥܡ ܚܝ̈ܘܬܐ ܡܬܟܬܫ ܐܢܐ</quote>.</p>
                 <p>
                   <persName>Irenaeus</persName>: <title>contra Haereses, lib. v.</title>, <locus>fol. 67 b</locus>.</p>
                 <p>
                   <persName>John Grammaticus (Philoponus)</persName>: <title>on <ref>Aristotle, disc, viii., chap. 2</ref>
-                  </title>, <quote xml:lang="syr">ܕܝܘܚܢܢ ܓܪܡܛܝܩܘܣ ܪܘܫܡܐ ܕܩܦܠܐܘܢ ܕܬܪ̈ܝܢ ܕܡܐܡܪܐ ܕܬܡܢܝܐ ܕܠܘܩܒܠ ܐܪܣܛܛܠܝܣ</quote>, <locus>fol. 73 a</locus>; <title>on the Hexaemeron, disc, i., chap. 16</title>, <locus>fol. 73 a</locus>; <title>against <persName>Andreas <foreign xml:lang="syr">ܐܪܝܘܡܢܝܛܐ</foreign>
-                    </persName>, disc, iv., chap. 11</title>, <quote xml:lang="syr">ܕܝܠܗ ܡܢ ܩܦܠܐܘܢ ܕܚܕܥܣܪ ܕܡܐܡܪܐ ܕܐܪ̈ܒܥܐ ܕܠܘܩܒܠ ܐܢܕܕܐܘܣ ܐܪܝܘܡܢܝܛܐ</quote>, <locus>fol. 73</locus>.</p>
+                  </title>, <quote xml:lang="syr">ܕܝܘܚܢܢ ܓܪܡܛܝܩܘܣ ܪܘܫܡܐ ܕܩܦܠܐܘܢ ܕܬܪ̈ܝܢ ܕܡܐܡܪܐ ܕܬܡܢܝܐ ܕܠܘܩܒܠ ܐܪܣܛܛܠܝܣ</quote>, <locus>fol. 73 a</locus>; <title>on the Hexaemeron, disc, i., chap. 16</title>, <locus>fol. 73 a</locus>; <title>against <persName>Andreas <foreign xml:lang="syr">ܐܪܝܘܡܢܝܛܐ</foreign></persName>, disc, iv., chap. 11</title>, <quote xml:lang="syr">ܕܝܠܗ ܡܢ ܩܦܠܐܘܢ ܕܚܕܥܣܪ ܕܡܐܡܪܐ ܕܐܪ̈ܒܥܐ ܕܠܘܩܒܠ ܐܢܕܕܐܘܣ ܐܪܝܘܡܢܝܛܐ</quote>, <locus>fol. 73</locus>.</p>
                 <p>
                   <persName>Julius of <placeName>Rome</placeName>
                   </persName>: <title>letter to <persName>Prosdocius (<foreign xml:lang="syr">ܦܪܘܣܕܘܩܝܘܣ</foreign>)</persName>

--- a/data/tei/929.xml
+++ b/data/tei/929.xml
@@ -589,8 +589,7 @@
                 <author ref="http://syriaca.org/person/113">
                   <persName xml:lang="en">Jacob of Edessa</persName>
                 </author>
-                <title xml:lang="en">Portions of the <foreign xml:lang="syr">ܬܘܪܨ ܡܡܠܠܐ</foreign>, or Syriac Grammar, of <persName ref="http://syriaca.org/person/113">Jacob of
-                Edessa</persName>, in which he explained and applied his new system of vowel-pointing to the
+                <title xml:lang="en">Portions of the <foreign xml:lang="syr">ܬܘܪܨ ܡܡܠܠܐ</foreign>, or Syriac Grammar, of <persName ref="http://syriaca.org/person/113">Jacob of Edessa</persName>, in which he explained and applied his new system of vowel-pointing to the
                 Syriac language.</title>
                 <note type="footnote">On <persName ref="http://syriaca.org/person/113">Jacob of Edessa</persName>, as grammarian, see, in particular <bibl>"Jacques d'Édesse et les
                   Voyelles Syriennes," by M. l'Abbé Martin, in the Journal Asiatique for Mai-Juin

--- a/data/tei/956.xml
+++ b/data/tei/956.xml
@@ -1681,8 +1681,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical Discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/48">Batnae</placeName>
-                </persName>
+                <title xml:lang="en">Metrical Discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/48">Batnae</placeName></persName>
               </title>
                 <msItem xml:id="p15b1" n="2">
                   <locus from="59a"/>

--- a/data/tei/956.xml
+++ b/data/tei/956.xml
@@ -467,15 +467,13 @@
                 </msItem>
                 <msItem xml:id="p3b2" n="3">
                   <locus from="26a"/>
-                  <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>
+                  <title xml:lang="en">The Commemoration of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>
                 </title>
                   <rubric xml:lang="syr">ܩܪ̈ܝܢܐ ܕܕܘܟܪܢܐ ܕܝܠܕܬ ܐܠܗܐ</rubric>
                 </msItem>
                 <msItem xml:id="p3b3" n="4">
                   <locus from="31b"/>
-                  <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the
-                    Baptist</persName>
+                  <title xml:lang="en">The Commemoration of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                   <rubric xml:lang="syr">ܩܪ̈ܝܢܐ ܒܕܘܟܪܢܐ ܕܝܘܚܢܢ ܡܥܡܕܢܐ</rubric>
                 </msItem>
@@ -1683,8 +1681,7 @@
                 <author ref="http://syriaca.org/person/42">
                   <persName xml:lang="en">Jacob of Batnae</persName>
                 </author>
-                <title xml:lang="en">Metrical Discourses of <persName ref="http://syriaca.org/person/42">Jacob of
-                <placeName ref="http://syriaca.org/place/48">Batnae</placeName>
+                <title xml:lang="en">Metrical Discourses of <persName ref="http://syriaca.org/person/42">Jacob of <placeName ref="http://syriaca.org/place/48">Batnae</placeName>
                 </persName>
               </title>
                 <msItem xml:id="p15b1" n="2">

--- a/data/tei/956.xml
+++ b/data/tei/956.xml
@@ -2610,8 +2610,7 @@
               <textLang mainLang="syr">Syriac</textLang>
               <msItem xml:id="p23a1" n="1">
                 <locus from="97a"/>
-                <title xml:lang="en">A partially erased note, which states that this copy of <title xml:lang="en" ref="http://syriaca.org/work/9645">the four
-                    Gospels</title>, or of <title xml:lang="en" ref="http://syriaca.org/work/9587">the whole New Testament</title>, belonged to <placeName ref="http://syriaca.org/place/360">the convent of S. Mary Deipara</placeName>
+                <title xml:lang="en">A partially erased note, which states that this copy of <title xml:lang="en" ref="http://syriaca.org/work/9645">the four Gospels</title>, or of <title xml:lang="en" ref="http://syriaca.org/work/9587">the whole New Testament</title>, belonged to <placeName ref="http://syriaca.org/place/360">the convent of S. Mary Deipara</placeName>
                 </title>
                 <note>See additions.</note>
               </msItem>

--- a/data/tei/980.xml
+++ b/data/tei/980.xml
@@ -300,8 +300,7 @@
                   <persName xml:lang="en">John of the convent of
                            Narses.</persName>
                 </author>
-                <title xml:lang="en">For the nocturn of Friday, by <persName>John of
-                              the <placeName>convent of Narses</placeName>
+                <title xml:lang="en">For the nocturn of Friday, by <persName>John of the <placeName>convent of Narses</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ ܠܡܪܝ ܝܘܚܢܢ ܕܒܝܬ ܡܪܝ ܢܪܣܝ </rubric>
                 <incipit xml:lang="syr">ܫܘܒܚܐ ܠܛܒܐ ܕܒܝܕ ܚܘܒܗ ܓܠ̣ܐ ܬܫܒܘܚܬܗ ܠܒܢܝ̈ܢܫܐ. </incipit>
@@ -329,8 +328,7 @@
                 <author ref="http://syriaca.org/person/359">
                   <persName xml:lang="en">Bābai the Great</persName>
                 </author>
-                <title xml:lang="en">At compline on Sundays, by <persName ref="http://syriaca.org/person/359">Bābai the
-                              Great</persName>.</title>
+                <title xml:lang="en">At compline on Sundays, by <persName ref="http://syriaca.org/person/359">Bābai the Great</persName>.</title>
                 <rubric xml:lang="syr"> ܕܣܘ̈ܒܥܐ ܕܚܕ ܒܫܒܐ܀ ܠܡܪܝ ܒܒܝ ܪܒܐ</rubric>
                 <incipit xml:lang="syr">ܐܒܘܢ ܕܒܫܡܝܐ ܩܕܝܫ ܒܲܟܝܵܢܗ. ܐܫܘܐ ܠܣܓܘܕ̈ܝܟ ܕܢܩܕܫܘܢ
                            ܠܫܡܟ.</incipit>
@@ -353,8 +351,7 @@
                 <author ref="http://syriaca.org/person/360">
                   <persName xml:lang="en">Bābai bar Něsībnāyē</persName>
                 </author>
-                <title xml:lang="en">Rogationary hymn, by <persName>Bābai bar
-                              Něsībnāyē</persName>.</title>
+                <title xml:lang="en">Rogationary hymn, by <persName>Bābai bar Něsībnāyē</persName>.</title>
                 <rubric xml:lang="syr">ܕܒܥܘܬܐ܀ ܕܥܒܝܕܐ ܠܡܪܝ ܒܒܝ ܒܪ ܢܨܝܒܢܝܵܐ </rubric>
                 <note>See <bibl>Add. 14,675<ptr target="https://bl.syriac.uk/ms/529"/>, no. 2, k, γ</bibl>.</note>
               </msItem>
@@ -364,8 +361,7 @@
                   <persName xml:lang="en">Bar-saumā, bishop of Nisibis
                 </persName>
                 </author>
-                <title xml:lang="en">Rogationary bymn, by <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop
-                              of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
+                <title xml:lang="en">Rogationary bymn, by <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
                   </persName>.</title>
                 <rubric xml:lang="syr">ܕܒܥܘܬܐ. ܠܡܪܝ ܒܪܨܘܡܐ ܐܦܣܩܘܦܐ ܕܢܨܝܒܝܢ </rubric>
                 <note>See <bibl>Add. 14,675<ptr target="https://bl.syriac.uk/ms/529"/>, no. 2, k, β</bibl>.</note>
@@ -383,8 +379,7 @@
                 <author ref="http://syriaca.org/person/306">
                   <persName xml:lang="en">Abbā the Catholicus</persName>
                 </author>
-                <title xml:lang="en">At compline, by <persName>Abbā the
-                              Catholicus</persName>.</title>
+                <title xml:lang="en">At compline, by <persName>Abbā the Catholicus</persName>.</title>
                 <rubric xml:lang="syr">ܕܣܘܒܥܐ܀ ܠܡܪܝ ܐܒܐ ܩܬܘ܏ܠܝ. </rubric>
                 <incipit xml:lang="syr">ܫܘܒܚܠܟ (sic) ܡܪܝ ܡܐ ܛܒ ܐܢܬ. ܏ܘܫ.</incipit>
                 <note>See <bibl>Assemani, Bibl. Or., t. iii., pars 1, p. 75</bibl>.</note>

--- a/data/tei/980.xml
+++ b/data/tei/980.xml
@@ -175,8 +175,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">Morning hymn ("the Song of Light") by
-                              <persName>Theodore of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName>
-                  </persName>.</title>
+                              <persName>Theodore of <placeName ref="http://syriaca.org/place/138">Mopsuestia</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܨܦܪܐ ܕܥܒܝܕܐ ܠܛܘܒܢܐ ܬܐܕܘܪܘܣ ܡܦܫܩܢܐ </rubric>
                 <incipit xml:lang="syr">ܢܘܗܪܐ ܕܢܚ̣ ܠܙܕܝ̤̈ܩܐ</incipit>
               </msItem>
@@ -268,8 +267,7 @@
                 </persName>
                 </author>
                 <title xml:lang="en">For the nocturn of Tuesday, by
-                           <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                  </persName>.</title>
+                           <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܬܠܬ ܒܫܒܐ܀ ܕܥܒܝܕܐ ܠܡܪܝ ܒܪܨܘܡܐ ܏ܐܦܣܩ
                            ܕܢܨܝܒܝܢ</rubric>
                 <incipit xml:lang="syr">ܠܐ ܣܦ̇ܩܝܢ ܪܘܡܐ ܘܥܘܡܩܐ ܘܟܠ ܕܒܗܘܢ ܕܢܘܕܘܢ ܠܐܝܬܘܬܟ ܐܝܬܝܐ
@@ -300,8 +298,7 @@
                   <persName xml:lang="en">John of the convent of
                            Narses.</persName>
                 </author>
-                <title xml:lang="en">For the nocturn of Friday, by <persName>John of the <placeName>convent of Narses</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">For the nocturn of Friday, by <persName>John of the <placeName>convent of Narses</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܠܠܝܐ ܕܥܪܘܒܬܐ ܠܡܪܝ ܝܘܚܢܢ ܕܒܝܬ ܡܪܝ ܢܪܣܝ </rubric>
                 <incipit xml:lang="syr">ܫܘܒܚܐ ܠܛܒܐ ܕܒܝܕ ܚܘܒܗ ܓܠ̣ܐ ܬܫܒܘܚܬܗ ܠܒܢܝ̈ܢܫܐ. </incipit>
                 <note>Generally called <persName>John of Beth-Rabban</persName>. See
@@ -361,8 +358,7 @@
                   <persName xml:lang="en">Bar-saumā, bishop of Nisibis
                 </persName>
                 </author>
-                <title xml:lang="en">Rogationary bymn, by <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName>
-                  </persName>.</title>
+                <title xml:lang="en">Rogationary bymn, by <persName ref="http://syriaca.org/person/1162">Bar-saumā, bishop of <placeName ref="http://syriaca.org/place/142">Nisibis</placeName></persName>.</title>
                 <rubric xml:lang="syr">ܕܒܥܘܬܐ. ܠܡܪܝ ܒܪܨܘܡܐ ܐܦܣܩܘܦܐ ܕܢܨܝܒܝܢ </rubric>
                 <note>See <bibl>Add. 14,675<ptr target="https://bl.syriac.uk/ms/529"/>, no. 2, k, β</bibl>.</note>
               </msItem>

--- a/data/tei/981.xml
+++ b/data/tei/981.xml
@@ -269,8 +269,7 @@
               </msItem>
               <msItem xml:id="p2a3" n="6">
                 <locus from="186b"/>
-                <title xml:lang="en">The song of the <persName ref="http://syriaca.org/person/624">blessed
-                     Virgin</persName>
+                <title xml:lang="en">The song of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>
                 </title>
                 <rubric xml:lang="syr">[ܬܫܒܘܚܬܐ] ܕܝܠܕܬ݀ ܐܠܗܐ ܡܪܝܡ</rubric>
                 <note>See <ref>additions</ref>.</note>

--- a/data/tei/982.xml
+++ b/data/tei/982.xml
@@ -120,8 +120,7 @@
                 </msItem>
                 <msItem xml:id="c2" n="4">
                   <locus from="2b"/>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
-                    </persName>.</title>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܐܚܪܬܐ ܕܡܪܝ ܣܐܘܪܝܘܣ</rubric>
                 </msItem>
                 <msItem xml:id="c3" n="5">
@@ -176,8 +175,7 @@
                 <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܬܫ̈ܥ ܫ̈ܥܝܢ </rubric>
                 <msItem xml:id="c10" n="15">
                   <locus from="84b"/>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
-                    </persName>.</title>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName></persName>.</title>
                   <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܐܒܐ ܐܫܥܝܐ ܠܘܩܒܠ ܟܠ ܢܣܝ̈ܘܢܺܝܢ</rubric>
                 </msItem>
                 <msItem xml:id="c11" n="16">

--- a/data/tei/982.xml
+++ b/data/tei/982.xml
@@ -115,14 +115,12 @@
                 <rubric xml:lang="syr">ܬܫܡ̣ܫܬܐ ܕܨ̇ܦܪܐ</rubric>
                 <msItem xml:id="c1" n="3">
                   <locus from="1b" to="2">Foll. 1b-2</locus>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/1808">S. John the
-                                 Baptist</persName>.</title>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>.</title>
                   <rubric xml:lang="syr">ܨܠ̇ܘܬܐ ܕܡܪܝ ܝܘܚܢܢ ܡܲܥܡܕܢܐ</rubric>
                 </msItem>
                 <msItem xml:id="c2" n="4">
                   <locus from="2b"/>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/51">Severus of
-                              <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/51">Severus of <placeName ref="http://syriaca.org/place/10">Antioch</placeName>
                     </persName>.</title>
                   <rubric xml:lang="syr">ܐܚܪܬܐ ܕܡܪܝ ܣܐܘܪܝܘܣ</rubric>
                 </msItem>
@@ -138,8 +136,7 @@
                 <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܬܠܵܬ ܫ̈ܥܝܢ </rubric>
                 <msItem xml:id="c4" n="7">
                   <locus from="29a" to="52">Foll. 29a-52</locus>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/511">Gregory
-                                 (Theologus)</persName>.</title>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/511">Gregory (Theologus)</persName>.</title>
                   <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܩܕܝܫܐ ܓܪܝܓܘܪܝܘܣ</rubric>
                 </msItem>
                 <msItem xml:id="c5" n="8">
@@ -160,8 +157,7 @@
                 <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܦܠܓܗ ܕܝܘܡܐ</rubric>
                 <msItem xml:id="c7" n="11">
                   <locus from="55a"/>
-                  <title xml:lang="en">Prayer of <persName>Abraham
-                                 Kīdūnāyā</persName>.</title>
+                  <title xml:lang="en">Prayer of <persName>Abraham Kīdūnāyā</persName>.</title>
                   <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܩܕܝܫܐ ܡܪܝ ܐܒܪܗܡ ܩܝܕܘܢܝܐ</rubric>
                 </msItem>
                 <msItem xml:id="c8" n="12">
@@ -180,8 +176,7 @@
                 <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܬܫ̈ܥ ܫ̈ܥܝܢ </rubric>
                 <msItem xml:id="c10" n="15">
                   <locus from="84b"/>
-                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/548">Isaiah of
-                              <placeName ref="http://syriaca.org/place/289">Scete</placeName>
+                  <title xml:lang="en">Prayer of <persName ref="http://syriaca.org/person/548">Isaiah of <placeName ref="http://syriaca.org/place/289">Scete</placeName>
                     </persName>.</title>
                   <rubric xml:lang="syr">ܨܠܘܼܬܐ ܕܐܒܐ ܐܫܥܝܐ ܠܘܩܒܠ ܟܠ ܢܣܝ̈ܘܢܺܝܢ</rubric>
                 </msItem>

--- a/data/tei/985.xml
+++ b/data/tei/985.xml
@@ -471,8 +471,7 @@
                 </msItem>
                 <msItem xml:id="p3b3" n="4">
                   <locus from="20a"/>
-                  <title xml:lang="en">The Annunciation of the <persName ref="http://syriaca.org/person/624">blessed
-                    Virgin</persName>
+                  <title xml:lang="en">The Annunciation of the <persName ref="http://syriaca.org/person/624">blessed Virgin</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܣܘܒܪܗ̇ ܕܝ̇ܠܕܬ ܐܠܗܐ</rubric>
                 </msItem>
@@ -485,8 +484,7 @@
                 </msItem>
                 <msItem xml:id="p3b5" n="6" defective="true">
                   <locus from="21b"/>
-                  <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the
-                  Baptist</persName>
+                  <title xml:lang="en">The Nativity of <persName ref="http://syriaca.org/person/1808">S. John the Baptist</persName>
                 </title>
                   <rubric xml:lang="syr">ܕܡܘܠܕܗ ܕܝܘܚܢܢ</rubric>
                 </msItem>


### PR DESCRIPTION
This merges in changes to whitespace in title that will make it easier to remove unwanted child elements of title. No rich data has been lost.